### PR TITLE
Use base units for metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -15,7 +15,7 @@ The following metrics are available for polling:
     * `status` - 'hit', 'phit', (partial hit) 'kmiss', (key miss) 'rmiss' (range miss)
 
 
-* `trickster_proxy_duration_ms` (Histogram) - Time required to proxy a given Prometheus query.
+* `trickster_proxy_duration_seconds` (Histogram) - Time required to proxy a given Prometheus query.
   * labels:
     * `method` - 'query' or 'query_range'
     * `status` - 'hit', 'phit', (partial hit) 'kmiss', (key miss) 'rmiss' (range miss)

--- a/metrics.go
+++ b/metrics.go
@@ -44,9 +44,9 @@ func NewApplicationMetrics(config *Config, logger log.Logger) *ApplicationMetric
 		),
 		ProxyRequestDuration: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name:    "trickster_proxy_duration_ms",
-				Help:    "Time required (ms) to proxy a given Prometheus query.",
-				Buckets: []float64{50, 100, 500, 1000, 5000, 10000, 20000},
+				Name:    "trickster_proxy_duration_seconds",
+				Help:    "Time required in seconds to proxy a given Prometheus query.",
+				Buckets: []float64{0.05, 0.1, 0.5, 1, 5, 10, 20},
 			},
 			[]string{"origin", "origin_type", "method", "status", "http_status"},
 		),


### PR DESCRIPTION
Prometheus best practices recommend that base units be used for metrics,
e.g. seconds rather than milliseconds:
https://prometheus.io/docs/practices/naming/#metric-names

/cc @jranson