### PR TITLE
Fix parameter conversion errors and simplify request time parsing

### DIFF
--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,0 +1,20 @@
+package main
+
+import "testing"
+
+func TestSanitizeTime(t *testing.T) {
+	fixtures := []struct {
+		input  string
+		output string
+	}{
+		{"2015-07-01T20:10:30.781Z", "2015-07-01T20:10:30.781Z"},
+		{"1523077733", "1523077733"},
+		{"1523077733.2", "1523077733.2"},
+	}
+
+	for _, f := range fixtures {
+		if out := sanitizeTime(f.input); out != f.output {
+			t.Errorf("Expected %s, got %s for input %s", f.output, out, f.input)
+		}
+	}
+}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -2,19 +2,25 @@ package main
 
 import "testing"
 
-func TestSanitizeTime(t *testing.T) {
+func TestParseTime(t *testing.T) {
 	fixtures := []struct {
 		input  string
 		output string
 	}{
-		{"2015-07-01T20:10:30.781Z", "2015-07-01T20:10:30.781Z"},
-		{"1523077733", "1523077733"},
-		{"1523077733.2", "1523077733.2"},
+		{"2018-04-07T05:08:53.200Z", "2018-04-07 05:08:53.2 +0000 UTC"},
+		{"1523077733", "2018-04-07 05:08:53 +0000 UTC"},
+		{"1523077733.2", "2018-04-07 05:08:53.200000047 +0000 UTC"},
 	}
 
 	for _, f := range fixtures {
-		if out := sanitizeTime(f.input); out != f.output {
-			t.Errorf("Expected %s, got %s for input %s", f.output, out, f.input)
+		out, err := parseTime(f.input)
+		if err != nil {
+			t.Error(err)
+		}
+
+		outStr := out.UTC().String()
+		if outStr != f.output {
+			t.Errorf("Expected %s, got %s for input %s", f.output, outStr, f.input)
 		}
 	}
 }


### PR DESCRIPTION
Simplify the request time parsing to only accept values documented in
the Prometheus HTTP API docs:
https://prometheus.io/docs/prometheus/latest/querying/api/

...which also means removing the ability to pass relative times.

Do this to simplify the implementation and align the API more closely to
the values accepted by Prometheus' HTTP API.

Also fixes this error, which I found was occuring whenever a float value
was passed to the API:

    time=2018-04-07T11:08:39.715529214Z app=trickster caller=trickster/handlers.go:385 level=error event="request parameter parser error" paramName=start paramValue=1523097519.71 detail="strconv.ParseInt: parsing \"1523097519.71000\": invalid syntax"