### PR TITLE
fix wrong timeunit in trickster_proxy_duration_seconds

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -246,7 +246,7 @@ func (t *TricksterHandler) getURL(method string, uri string, params url.Values, 
 		return []byte{}, resp, 0
 	}
 
-	duration := int64(time.Now().Sub(startTime).Nanoseconds() / 1000000)
+	duration := int64(time.Now().Sub(startTime).Nanoseconds() / 1000000000)
 
 	return body, resp, duration
 }


### PR DESCRIPTION
The duration was measured in milliseconds, but the metric is for seconds.

closes https://github.com/Comcast/trickster/issues/37