### PR TITLE
change default cache path to /tmp/trickster

### DIFF
--- a/config.go
+++ b/config.go
@@ -124,7 +124,7 @@ func NewConfig() *Config {
 			CacheType:     ctMemory,
 			RecordTTLSecs: 21600,
 			Redis:         RedisConfig{Protocol: "tcp", Endpoint: "redis:6379"},
-			Filesystem:    FilesystemCacheConfig{CachePath: "/tmp"},
+			Filesystem:    FilesystemCacheConfig{CachePath: "/tmp/trickster"},
 			ReapSleepMS:   1000,
 			Compression:   true,
 		},


### PR DESCRIPTION
This PR changes the default cache path  from `/tmp` to `/tmp/trickster` so it aligns with the docs and the sample config file https://github.com/Comcast/trickster/blob/master/conf/example.conf#L45

closes https://github.com/Comcast/trickster/issues/38