### PR TITLE
Enforce strict error handling and early aborts

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -92,11 +92,9 @@ const (
 
 // Log Fields
 const (
-	lfEvent      = "event"
-	lfDetail     = "detail"
-	lfParamName  = "paramName"
-	lfParamValue = "paramValue"
-	lfCacheKey   = "cacheKey"
+	lfEvent    = "event"
+	lfDetail   = "detail"
+	lfCacheKey = "cacheKey"
 )
 
 // http methods

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -13,7 +13,11 @@
 
 package main
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
 
 func TestParseTime(t *testing.T) {
 	fixtures := []struct {
@@ -35,5 +39,80 @@ func TestParseTime(t *testing.T) {
 		if outStr != f.output {
 			t.Errorf("Expected %s, got %s for input %s", f.output, outStr, f.input)
 		}
+	}
+}
+
+func newTestTricksterHandler(t *testing.T) (tr *TricksterHandler, close func(t *testing.T)) {
+	conf := NewConfig()
+	conf.Origins["default"] = PrometheusOriginConfig{
+		OriginURL:           "http://nonexistent-origin:54321/",
+		APIPath:             "/api/v1/",
+		DefaultStep:         300,
+		IgnoreNoCacheHeader: true,
+		MaxValueAgeSecs:     86400,
+	}
+	logger := newLogger(conf.Logging, "")
+	tr = &TricksterHandler{
+		ResponseChannels: make(map[string]chan *ClientRequestContext),
+		Config:           conf,
+		Logger:           logger,
+		Metrics:          NewApplicationMetrics(conf, logger),
+	}
+
+	tr.Cacher = getCache(tr)
+	if err := tr.Cacher.Connect(); err != nil {
+		t.Fatal("Unable to connect to cache:", err)
+	}
+
+	return tr, func(t *testing.T) {
+		if err := tr.Cacher.Close(); err != nil {
+			t.Fatal("Error closing cacher:", err)
+		}
+	}
+}
+
+func TestUnreachableOriginReturnsStatusBadGateway(t *testing.T) {
+	tests := []struct {
+		handler func(*TricksterHandler, http.ResponseWriter, *http.Request)
+		path    string
+	}{
+		{
+			handler: (*TricksterHandler).promHealthCheckHandler,
+		},
+		{
+			handler: (*TricksterHandler).promFullProxyHandler,
+		},
+		{
+			handler: (*TricksterHandler).promAPIProxyHandler,
+		},
+		{
+			handler: (*TricksterHandler).promQueryHandler,
+		},
+		{
+			handler: (*TricksterHandler).promQueryRangeHandler,
+			path:    "/api/v1/query_range?start=0&end=100000000&query=up",
+		},
+	}
+
+	tr, closeFn := newTestTricksterHandler(t)
+	defer closeFn(t)
+
+	for _, test := range tests {
+		rr := httptest.NewRecorder()
+		test.handler(tr, rr, httptest.NewRequest("GET", "http://trickster"+test.path, nil))
+		if rr.Result().StatusCode != http.StatusBadGateway {
+			t.Errorf("unexpected status code; want %d, got %d", http.StatusBadGateway, rr.Result().StatusCode)
+		}
+	}
+}
+
+func TestMissingRangeQueryParametersResultInStatusBadRequest(t *testing.T) {
+	tr, closeFn := newTestTricksterHandler(t)
+	defer closeFn(t)
+
+	rr := httptest.NewRecorder()
+	tr.promQueryRangeHandler(rr, httptest.NewRequest("GET", "http://trickster/api/v1/query_range", nil))
+	if rr.Result().StatusCode != http.StatusBadRequest {
+		t.Errorf("unexpected status code; want %d, got %d", http.StatusBadRequest, rr.Result().StatusCode)
 	}
 }


### PR DESCRIPTION
This fixes a number of crashes that currently happen when either the
origin Prometheus cannot be reached or when a user request is faulty.

It also explicitly hard-errors to the user whenever a partial error
happens somewhere in Trickster (due to unreachable origin, faulty JSON
marshaling, or else). There were many cases where an error was logged,
but not handled, causing undefined/crashy behavior. These errors are now
handled and cause the entire request to fail. This seems better than
returning wrong results or crashing.

I also added tests for the obvious crash cases and check whether they
are now returning a user-exposed HTTP error status code instead.

A TODO for the future would be to clean up the metrics handling, since
it currently happens before or after an error return, and errors aren't
properly tracked in the metrics.

Fixes https://github.com/Comcast/trickster/issues/49