### PR TITLE
Test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,10 @@ docker-release:
 	docker tag trickster:$(PROGVER) tricksterio/trickster:$(PROGVER)
 	docker tag tricksterio/trickster:$(PROGVER) tricksterio/trickster:latest
 
+test:
+	go test
+	go test -run '' -o ${GOPATH}/bin/trickster
+
 clean:
 	rm ${GOPATH}/bin/trickster
 

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,11 @@ docker-release:
 	docker tag tricksterio/trickster:$(PROGVER) tricksterio/trickster:latest
 
 test:
-	go test
 	go test -run '' -o ${GOPATH}/bin/trickster
+
+test-cover:
+	go test -run '' -o ${GOPATH}/bin/trickster -coverprofile=cover.out
+	go tool cover -html=cover.out
 
 clean:
 	rm ${GOPATH}/bin/trickster

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -56,7 +56,7 @@ func newTestTricksterHandler(t *testing.T) (tr *TricksterHandler, close func(t *
 		ResponseChannels: make(map[string]chan *ClientRequestContext),
 		Config:           conf,
 		Logger:           logger,
-		Metrics:          NewApplicationMetrics(conf, logger),
+		Metrics:          NewApplicationMetrics(),
 	}
 
 	tr.Cacher = getCache(tr)

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -65,6 +65,7 @@ func newTestTricksterHandler(t *testing.T) (tr *TricksterHandler, close func(t *
 	}
 
 	return tr, func(t *testing.T) {
+		tr.Metrics.Unregister()
 		if err := tr.Cacher.Close(); err != nil {
 			t.Fatal("Error closing cacher:", err)
 		}

--- a/main.go
+++ b/main.go
@@ -62,7 +62,8 @@ func main() {
 
 	level.Info(t.Logger).Log("event", "application startup", "version", applicationVersion)
 
-	t.Metrics = NewApplicationMetrics(t.Config, t.Logger)
+	t.Metrics = NewApplicationMetrics()
+	t.Metrics.ListenAndServe(t.Config, t.Logger)
 
 	t.Cacher = getCache(t)
 	if err := t.Cacher.Connect(); err != nil {

--- a/metrics.go
+++ b/metrics.go
@@ -38,8 +38,24 @@ func (metrics ApplicationMetrics) Unregister() {
 	prometheus.Unregister(metrics.ProxyRequestDuration)
 }
 
+func (metrics ApplicationMetrics) ListenAndServe(config *Config, logger log.Logger) {
+	// Turn up the Metrics HTTP Server
+	if config.Metrics.ListenPort > 0 {
+		go func() {
+
+			level.Info(logger).Log("event", "metrics http endpoint starting", "address", config.Metrics.ListenAddress, "port", fmt.Sprintf("%d", config.Metrics.ListenPort))
+
+			http.Handle("/metrics", promhttp.Handler())
+			if err := http.ListenAndServe(fmt.Sprintf("%s:%d", config.Metrics.ListenAddress, config.Metrics.ListenPort), nil); err != nil {
+				level.Error(logger).Log("event", "unable to start metrics http server", "detail", err.Error())
+				os.Exit(1)
+			}
+		}()
+	}
+}
+
 // NewApplicationMetrics returns a ApplicationMetrics object and instantiates an HTTP server for polling them.
-func NewApplicationMetrics(config *Config, logger log.Logger) *ApplicationMetrics {
+func NewApplicationMetrics() *ApplicationMetrics {
 	metrics := ApplicationMetrics{
 		CacheRequestStatus: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -68,20 +84,6 @@ func NewApplicationMetrics(config *Config, logger log.Logger) *ApplicationMetric
 	prometheus.MustRegister(metrics.CacheRequestStatus)
 	prometheus.MustRegister(metrics.CacheRequestElements)
 	prometheus.MustRegister(metrics.ProxyRequestDuration)
-
-	// Turn up the Metrics HTTP Server
-	if config.Metrics.ListenPort > 0 {
-		go func() {
-
-			level.Info(logger).Log("event", "metrics http endpoint starting", "address", config.Metrics.ListenAddress, "port", fmt.Sprintf("%d", config.Metrics.ListenPort))
-
-			http.Handle("/metrics", promhttp.Handler())
-			if err := http.ListenAndServe(fmt.Sprintf("%s:%d", config.Metrics.ListenAddress, config.Metrics.ListenPort), nil); err != nil {
-				level.Error(logger).Log("event", "unable to start metrics http server", "detail", err.Error())
-				os.Exit(1)
-			}
-		}()
-	}
 
 	return &metrics
 }

--- a/metrics.go
+++ b/metrics.go
@@ -32,6 +32,12 @@ type ApplicationMetrics struct {
 	ProxyRequestDuration *prometheus.HistogramVec
 }
 
+func (metrics ApplicationMetrics) Unregister() {
+	prometheus.Unregister(metrics.CacheRequestStatus)
+	prometheus.Unregister(metrics.CacheRequestElements)
+	prometheus.Unregister(metrics.ProxyRequestDuration)
+}
+
 // NewApplicationMetrics returns a ApplicationMetrics object and instantiates an HTTP server for polling them.
 func NewApplicationMetrics(config *Config, logger log.Logger) *ApplicationMetrics {
 	metrics := ApplicationMetrics{


### PR DESCRIPTION
These changes add _test_ and _test-cover_ targets to the Makefile and fix existing tests so that they do not register duplicate metric handlers or start multiple metric listeners during test cycles.

These changes work toward addressing issue #1. The existing test coverage is 29.6%.