### PR TITLE
Require "step" URL parameter in range queries

### DIFF
--- a/config.go
+++ b/config.go
@@ -75,7 +75,6 @@ type FilesystemCacheConfig struct {
 type PrometheusOriginConfig struct {
 	OriginURL           string `toml:"origin_url"`
 	APIPath             string `toml:"api_path"`
-	DefaultStep         int    `toml:"default_step"`
 	IgnoreNoCacheHeader bool   `toml:"ignore_no_cache_header"`
 	MaxValueAgeSecs     int64  `toml:"max_value_age_secs"`
 	FastForwardDisable  bool   `toml:"fast_forward_disable"`
@@ -132,7 +131,6 @@ func defaultOriginConfig() PrometheusOriginConfig {
 	return PrometheusOriginConfig{
 		OriginURL:           "http://prometheus:9090/",
 		APIPath:             prometheusAPIv1Path,
-		DefaultStep:         300,
 		IgnoreNoCacheHeader: true,
 		MaxValueAgeSecs:     86400, // Keep datapoints up to 24 hours old
 	}


### PR DESCRIPTION
Prometheus's API requires the "step" parameter to be present in range
queries, so Trickster can do the same instead of providing a default
value.

This also ensures that the step is positive, as otherwise a
divide-by-zero exception can happen further on in
buildRequestContext().