### PR TITLE
Treat errors unmarshaling from cache as cache miss

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -505,8 +505,11 @@ func (t *TricksterHandler) buildRequestContext(w http.ResponseWriter, r *http.Re
 
 		// Marshall the cache payload into a PrometheusMatrixEnvelope struct
 		err = json.Unmarshal([]byte(cachedBody), &ctx.Matrix)
+		// If there is an error unmarshaling the cache we should treat it as a cache miss
+		// and re-fetch from origin
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error unmarshalling cached data for key %q with content %q", ctx.CacheKey, cachedBody))
+			ctx.CacheLookupResult = crRangeMiss
+			return ctx, nil
 		}
 
 		// Get the Extents of the data in the cache


### PR DESCRIPTION
Prior to this patch any error unmarshaling from the cache would cause
the request to fail until the item dropped out of cache. This change
simply treats a bad entry as a miss, so it will re-fetch from origin

Fixes #39