### PR TITLE
Add /debug/pprof endpoints to metrics port

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -16,6 +16,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 
 	"github.com/go-kit/kit/log"


### PR DESCRIPTION
Including "net/http/pprof/" auto-registers profiling endpoints under
/debug/pprof with the default HTTP mux. Since the metrics port HTTP
server uses the default HTTP mux, these get added to the metrics HTTP
server, which seems fitting.

These endpoints are useful in debugging CPU and memory behaviors of
Trickster, and more.

Signed-off-by: Julius Volz <julius.volz@gmail.com>