### PR TITLE
Release request context data after handling

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -882,6 +882,9 @@ func (t *TricksterHandler) originRangeProxyHandler(cacheKey string, originRangeR
 			writeResponse(r.Writer, body, resp)
 			r.WaitGroup.Done()
 		}
+		// Explicitly release the request context so that the underlying memory can be
+		// freed before the next request is received via the channel, which overwrites "r".
+		r = nil
 	}
 }
 


### PR DESCRIPTION
Every range query handler goroutine (one for each cache key, of which
there can be hundreds or thousands) currently holds on to a reference to
the last request context that it handled. This is since the channel
range loop variable (which holds the request context) is only
overwritten once a subsequent request is received from the channel. This
change explicitly sets the finished request context to nil so that Go
can release the associated memory.

In GitLab, this has fixed OOM problems in Trickster, and memory usage is
now significantly lower.

Signed-off-by: Julius Volz <julius.volz@gmail.com>