### PR TITLE
Add option to authenticate with redis servers

### DIFF
--- a/config.go
+++ b/config.go
@@ -63,6 +63,8 @@ type RedisCacheConfig struct {
 	Protocol string `toml:"protocol"`
 	// Endpoint represents FQDN:port or IPAddress:Port of the Redis server
 	Endpoint string `toml:"endpoint"`
+	// Password can be set when using password protected redis instance.
+	Password string `toml:"password"`
 }
 
 // BoltDBCacheConfig is a collection of Configurations for storing cached data on the Filesystem

--- a/redis.go
+++ b/redis.go
@@ -36,6 +36,9 @@ func (r *RedisCache) Connect() error {
 		Network: r.Config.Protocol,
 		Addr:    r.Config.Endpoint,
 	})
+	if r.Config.Password != "" {
+		r.client.Options().Password = r.Config.Password
+	}
 	return r.client.Ping().Err()
 }
 


### PR DESCRIPTION
We have all of our redis instances setup with authentication which makes using them as a backend impossible.

This change just adds AUTH support to the redis client, based on the presence of password in the configuration file.