### PR TITLE
Cleanup BoltDB config

### DIFF
--- a/boltdb.go
+++ b/boltdb.go
@@ -15,7 +15,6 @@ package main
 
 import (
 	"fmt"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -33,16 +32,9 @@ type BoltDBCache struct {
 
 // Connect instantiates the BoltDBCache mutex map and starts the Expired Entry Reaper goroutine
 func (c *BoltDBCache) Connect() error {
+	level.Info(c.T.Logger).Log("event", "boltdb cache setup", "cacheFile", c.Config.Filename)
 
-	dir, _ := filepath.Split(c.Config.Filename)
-
-	level.Info(c.T.Logger).Log("event", "boltdb cache setup", "cachePath", c.Config.Filename)
-
-	err := makeDirectory(dir)
-	if err != nil {
-		return err
-	}
-
+	var err error
 	c.dbh, err = bolt.Open(c.Config.Filename, 0644, &bolt.Options{Timeout: 1 * time.Second})
 	if err != nil {
 		return err

--- a/conf/example.conf
+++ b/conf/example.conf
@@ -14,7 +14,8 @@
 
 [cache]
 # cache_type defines what kind of cache Trickster uses
-# options are 'memory', 'redis' and 'filesystem'.  'memory' is the default
+# options are 'boltdb', 'filesystem', 'memory', and 'redis'.
+# The default is 'memory'.
 cache_type = 'memory'
 
 # record_ttl_secs defines the relative expiration of cached queries. default is 6 hours (21600 seconds)
@@ -43,9 +44,9 @@ cache_type = 'memory'
     # Configuration options when using a BoltDb Cache
     #[cache.boltdb]
 
-    # filename defines the fully-qualified filename where the Trickster cache will be maintained
-    # default is '/tmp/trickster/trickster.db'
-    # filename = '/tmp/trickster/trickster.db'
+    # filename defines the file where the Trickster cache will be maintained
+    # default is 'trickster.db'
+    # filename = 'trickster.db'
 
     # bucket defines the name of the BotlDb bucket (similar to a namespace) under which our key value store lives
     # default is 'trickster'

--- a/config.go
+++ b/config.go
@@ -47,7 +47,7 @@ type ProxyServerConfig struct {
 
 // CachingConfig is a collection of defining the Trickster Caching Behavior
 type CachingConfig struct {
-	// CacheType represents the type of cache that we wish to use: "memory", "filesystem", or "redis"
+	// CacheType represents the type of cache that we wish to use: "boltdb", "memory", "filesystem", or "redis"
 	CacheType     string                `toml:"cache_type"`
 	RecordTTLSecs int64                 `toml:"record_ttl_secs"`
 	Redis         RedisCacheConfig      `toml:"redis"`
@@ -109,6 +109,7 @@ type LoggingConfig struct {
 func NewConfig() *Config {
 
 	defaultCachePath := "/tmp/trickster"
+	defaultBoltDBFile := "trickster.db"
 
 	return &Config{
 		Caching: CachingConfig{
@@ -118,7 +119,7 @@ func NewConfig() *Config {
 
 			Redis:      RedisCacheConfig{Protocol: "tcp", Endpoint: "redis:6379"},
 			Filesystem: FilesystemCacheConfig{CachePath: defaultCachePath},
-			BoltDB:     BoltDBCacheConfig{Filename: defaultCachePath + "/trickster.db", Bucket: "trickster"},
+			BoltDB:     BoltDBCacheConfig{Filename: defaultBoltDBFile, Bucket: "trickster"},
 
 			ReapSleepMS: 1000,
 			Compression: true,

--- a/deploy/helm/trickster/README.md
+++ b/deploy/helm/trickster/README.md
@@ -23,10 +23,12 @@ Parameter | Description | Default
 `ingress.tls` | TLS configuration for Trickster Ingress | `[]`
 `nodeSelector` | Node labels for pod assignment | `{}`
 `originURL` | Default trickster originURL, references a source Prometheus instance | `http://prometheus:9090`
-`cache.type` | The cache_type to use.  {memory, filesystem, redis} | `memory`
+`cache.type` | The cache_type to use.  {boltdb, filesystem, memory, redis} | `memory`
 `cache.redis.protocol` | The protocol for connecting to redis ('unix' or 'tcp') | `tcp`
 `cache.redis.endpoint` | The fqdn+port or path to a unix socket file for connecting to redis | `redis:6379`
 `cache.filesystem.path` | The directory location under which the Trickster filesystem cache will be maintained | `/tmp/trickster`
+`cache.boltdb.file` | The filename of the BoltDB database | `trickster.db`
+`cache.boltdb.bucket` | The name of the BoltDB bucket | `trickster`
 `recordTTLSecs` | The relative expiration of cached queries. default is 6 hours (21600 seconds) | `21600`
 `defaultStep` | The step (in seconds) of a query_range request if one is not provided by the client. This helps to correct improperly formed client requests. | `300`
 `maxValueAgeSecs` | The maximum age of specific datapoints in seconds. Default is 86400 (24 hours). | `86400`

--- a/deploy/helm/trickster/templates/configmap.yaml
+++ b/deploy/helm/trickster/templates/configmap.yaml
@@ -24,7 +24,7 @@ data:
 
     [cache]
         # cache_type defines what kind of cache Trickster uses
-        # options are 'memory', 'redis' and 'filesystem'.  'memory' is the default
+        # options are 'boltdb', 'filesystem', 'memory', and 'redis'.  'memory' is the default
         cache_type = {{ .Values.cache.type | quote }}
 
         # record_ttl_secs defines the relative expiration of cached queries. default is 6 hours (21600 seconds)
@@ -34,20 +34,32 @@ data:
             # Configuration options when using a Redis Cache
             [cache.redis]
 
-                # protocol defines the protocol for connecting to redis ('unix' or 'tcp') 'tcp' is default
-                protocol = {{ .Values.cache.redis.protocol | quote }}
+            # protocol defines the protocol for connecting to redis ('unix' or 'tcp') 'tcp' is default
+            protocol = {{ .Values.cache.redis.protocol | quote }}
 
-                # endpoint defines the fqdn+port or path to a unix socket file for connecting to redis
-                # default is 'redis:6379'
-                endpoint = {{ .Values.cache.redis.endpoint | quote }}
+            # endpoint defines the fqdn+port or path to a unix socket file for connecting to redis
+            # default is 'redis:6379'
+            endpoint = {{ .Values.cache.redis.endpoint | quote }}
 
             {{- else if eq .Values.cache.type "filesystem" }}
             # Configuration options when using a Filesystem Cache
             [cache.filesystem]
 
-                # cache_path defines the directory location under which the Trickster cache will be maintained
-                # default is '/tmp/trickster'
-                cache_path = {{ .Values.cache.filesystem.path | quote }}
+            # cache_path defines the directory location under which the Trickster cache will be maintained
+            # default is '/tmp/trickster'
+            cache_path = {{ .Values.cache.filesystem.path | quote }}
+            {{- end }}
+
+            {{- else if eq .Values.cache.type "boltdb" }}
+            # Configuration options when using a BoltDb Cache
+            [cache.boltdb]
+            # filename defines the file where the Trickster cache will be maintained
+            # default is 'trickster.db'
+            filename = {{ .Values.cache.boltdb.file | quote }}
+
+            # bucket defines the name of the BotlDb bucket (similar to a namespace) under which our key value store lives
+            # default is 'trickster'
+            bucket = {{ .Values.cache.boltdb.bucket | quote }}
             {{- end }}
 
     # Configuration options for mapping Origin(s)

--- a/deploy/helm/trickster/values.yaml
+++ b/deploy/helm/trickster/values.yaml
@@ -10,6 +10,9 @@ cache:
     endpoint: redis:6379
   filesystem:
     path: /tmp/trickster
+  boltdb:
+    file: trickster.db
+    bucket: trickster
 # Put ints in quotes to ensure they aren't converted to scientific notations.
 # See https://github.com/kubernetes/helm/issues/1707
 recordTTLSecs: "21600"

--- a/deploy/kube/configmap.yaml
+++ b/deploy/kube/configmap.yaml
@@ -22,7 +22,7 @@ data:
 
     [cache]
         # cache_type defines what kind of cache Trickster uses
-        # options are 'memory', 'redis' and 'filesystem'.  'memory' is the default
+        # options are 'boltdb, 'filesystem', 'memory', and 'redis'.  'memory' is the default
         cache_type = 'memory'
 
         # record_ttl_secs defines the relative expiration of cached queries. default is 6 hours (21600 seconds)
@@ -31,19 +31,30 @@ data:
             # Configuration options when using a Redis Cache
             #[cache.redis]
 
-                # protocol defines the protocol for connecting to redis ('unix' or 'tcp') 'tcp' is default
-                #protocol = 'tcp'
+            # protocol defines the protocol for connecting to redis ('unix' or 'tcp') 'tcp' is default
+            #protocol = 'tcp'
 
-                # endpoint defines the fqdn+port or path to a unix socket file for connecting to redis
-                # default is 'redis:6379'
-                #endpoint = 'redis:6379'
+            # endpoint defines the fqdn+port or path to a unix socket file for connecting to redis
+            # default is 'redis:6379'
+            #endpoint = 'redis:6379'
 
             # Configuration options when using a Filesystem Cache
             #[cache.filesystem]
 
-                # cache_path defines the directory location under which the Trickster cache will be maintained
-                # default is '/tmp/trickster'
-                #cache_path = '/tmp/trickster'
+            # cache_path defines the directory location under which the Trickster cache will be maintained
+            # default is '/tmp/trickster'
+            #cache_path = '/tmp/trickster'
+            # Configuration options when using a BoltDb Cache
+            #[cache.boltdb]
+
+            # filename defines the file where the Trickster cache will be maintained
+            # default is 'trickster.db'
+            # filename = 'trickster.db'
+
+            # bucket defines the name of the BotlDb bucket (similar to a namespace) under which our key value store lives
+            # default is 'trickster'
+            # bucket = 'trickster'
+
 
     # Configuration options for mapping Origin(s)
     [origins]

--- a/docs/caches.md
+++ b/docs/caches.md
@@ -24,7 +24,7 @@ The default Filesystem Cache path is `/tmp/trickster`. The sample configuration 
 
 ## BoltDB Cache
 
-The BoltDB Cache is a popular key/value store, created by [Ben Johnson](https://github.com/benbjohnson). [CoreOS's bbolt fork](https://github.com/coreos/bbolt) is the version implemented in Trickster. A BoltDB store is a filesystem-based solution that stores the entire database in a single file. Trickster, by default, creates the database at `/tmp/trickster/trickster.db` and uses a bucket name of 'trickster' for storing key/value data. See the example config file for details on customizing this aspect of your Trickster deployment. The same guidance about filesystem permissions described in the Filesystem Cache section above apply to a BoltDB Cache.
+The BoltDB Cache is a popular key/value store, created by [Ben Johnson](https://github.com/benbjohnson). [CoreOS's bbolt fork](https://github.com/coreos/bbolt) is the version implemented in Trickster. A BoltDB store is a filesystem-based solution that stores the entire database in a single file. Trickster, by default, creates the database at `trickster.db` and uses a bucket name of 'trickster' for storing key/value data. See the example config file for details on customizing this aspect of your Trickster deployment. The same guidance about filesystem permissions described in the Filesystem Cache section above apply to a BoltDB Cache.
 
 ## Redis Cache
 


### PR DESCRIPTION
* Cleanup docs.
* Use relative file rather than forcing path-based database file.
* Update Helm chart to support boltdb.

Signed-off-by: Ben Kochie <superq@gmail.com>