### PR TITLE
Panic when attempting to configure invalid cache

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -13,6 +13,10 @@
 
 package main
 
+import (
+	"fmt"
+)
+
 const (
 	// Cache interface types
 	ctMemory     = "memory"
@@ -39,7 +43,9 @@ func getCache(t *TricksterHandler) Cache {
 		return &BoltDBCache{Config: t.Config.Caching.BoltDB, T: t}
 	case ctRedis:
 		return &RedisCache{Config: t.Config.Caching.Redis, T: t}
-	default:
+	case ctMemory:
 		return &MemoryCache{T: t}
+	default:
+		panic(fmt.Errorf("Invalid cache type: %q", t.Config.Caching.CacheType))
 	}
 }


### PR DESCRIPTION
Instead of defaulting to cache type memory when misconfigured, panic.

Signed-off-by: Ben Kochie <superq@gmail.com>

Looks like this:
```console
$ trickster -conf invalid.conf
time=2018-10-25T12:19:25.109494354Z app=trickster caller=trickster/main.go:63 level=info event="application startup" version=0.1.1
time=2018-10-25T12:19:25.109628973Z app=trickster caller=trickster/metrics.go:47 level=info event="metrics http endpoint starting" address= port=8082
panic: Invalid cache type: "boom"

goroutine 1 [running]:
main.getCache(0xc000032580, 0xc00000e0d0, 0xc00000e0d8)
	/home/ben/go/src/github.com/comcast/trickster/cache.go:49 +0x3c5
main.main()
	/home/ben/go/src/github.com/comcast/trickster/main.go:68 +0x32a
```