### PR TITLE
Fixing a problem in helm configmap

### DIFF
--- a/deploy/helm/trickster/Chart.yaml
+++ b/deploy/helm/trickster/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: 0.0.12
 description: Trickster is a reverse proxy cache for the Prometheus HTTP API that dramatically accelerates chart rendering times for any series queried from Prometheus.
 name: trickster
-version: 1.1.1
+version: 1.1.2
 home: https://github.com/comcast/trickster
 icon: ""

--- a/deploy/helm/trickster/templates/configmap.yaml
+++ b/deploy/helm/trickster/templates/configmap.yaml
@@ -48,7 +48,6 @@ data:
             # cache_path defines the directory location under which the Trickster cache will be maintained
             # default is '/tmp/trickster'
             cache_path = {{ .Values.cache.filesystem.path | quote }}
-            {{- end }}
 
             {{- else if eq .Values.cache.type "boltdb" }}
             # Configuration options when using a BoltDb Cache


### PR DESCRIPTION
If / else chain was broken because of a {{end}} in the way.
helm lint was stating that with the following error:
```
[ERROR] templates/: parse error in "trickster/templates/configmap.yaml": template: trickster/templates/configmap.yaml:53: unexpected {{else}}
```

@LimitlessEarth