### PR TITLE
Fix empty response

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -722,7 +722,7 @@ func (t *TricksterHandler) originRangeProxyHandler(cacheKey string, originRangeR
 					}
 
 					m.Lock()
-					if r == (&http.Response{}) || r.StatusCode != 200 {
+					if resp.StatusCode == 0 || r.StatusCode != 200 {
 						if r.StatusCode != 200 {
 							errorBody = b
 						}
@@ -761,7 +761,7 @@ func (t *TricksterHandler) originRangeProxyHandler(cacheKey string, originRangeR
 					}
 
 					m.Lock()
-					if r == (&http.Response{}) || r.StatusCode != 200 {
+					if resp.StatusCode == 0 || r.StatusCode != 200 {
 						if r.StatusCode != 200 {
 							errorBody = b
 						}
@@ -799,7 +799,7 @@ func (t *TricksterHandler) originRangeProxyHandler(cacheKey string, originRangeR
 					}
 
 					m.Lock()
-					if r == (&http.Response{}) || r.StatusCode != 200 {
+					if resp.StatusCode == 0 || r.StatusCode != 200 {
 						if r.StatusCode != 200 {
 							errorBody = b
 						}


### PR DESCRIPTION
When comparing to another empty struct this should just be checking if
the pointers match, which they don't. In the past this wasn't an issue
since it had no real bearing on the result-- as the body was parsed out
separately. Now that we are actually using this, we need to check
properly. Instead of using a nil I'm checking that the statuscode is
non-zero.