### PR TITLE
Use built-in HTTP Status Code Constants

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -161,7 +161,7 @@ func writeable(path string) bool {
 func makeDirectory(path string) error {
 	err := os.MkdirAll(path, 0755)
 	if err != nil || !writeable(path) {
-		return fmt.Errorf(`[%s] directory is not writeable by the trickster: %s`, path, err.Error())
+		return fmt.Errorf("[%s] directory is not writeable by the trickster: %v", path, err)
 	}
 
 	return nil


### PR DESCRIPTION
Great project! I noticed that the handler references the 200 HTTP status-code in numerous places. It's less error-prone to instead use the status-code constants provided in the `http` package.

Also, use the `%v` formatting verb when formatting an `error` variable rather than invoking `err.Error()`. This was actually a bug: invoking `err.Error()` when  `!writeable(path)` is `true` refers to a nil `err` variable.