### PR TITLE
Fix ordering assumption enforcement for mergeMatrix

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -1001,10 +1001,11 @@ func (t *TricksterHandler) mergeMatrix(pe PrometheusMatrixEnvelope, pe2 Promethe
 				// Ensure that we don't duplicate datapoints or put points out-of-order
 				// This method assumes that `pe2` is "before" `pe`, we need to actually
 				// check and enforce that assumption
-				last := pe.Data.Result[j].Values[len(pe.Data.Result[j].Values)-1]
-				for x, v := range pe2.Data.Result[i].Values {
-					if v.Timestamp > last.Timestamp {
-						pe.Data.Result[j].Values = append(pe2.Data.Result[i].Values, pe.Data.Result[j].Values[x:]...)
+				first := result1.Values[0]
+				for x := len(result2.Values) - 1; x >= 0; x-- {
+					v := result2.Values[x]
+					if v.Timestamp < first.Timestamp {
+						result1.Values = append(result2.Values[:x+1], result1.Values...)
 						break METRIC_MERGE
 					}
 				}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -484,6 +484,148 @@ func TestTricksterHandler_mergeMatrix(t *testing.T) {
 	tests := []struct {
 		a, b, merged PrometheusMatrixEnvelope
 	}{
+		// Series that adhere to rule
+		{
+			a: PrometheusMatrixEnvelope{
+				Status: rvSuccess,
+				Data: PrometheusMatrixData{
+					ResultType: "matrix",
+					Result: model.Matrix{
+						&model.SampleStream{
+							Metric: model.Metric{"__name__": "a"},
+							Values: []model.SamplePair{
+								model.SamplePair{10, 1.5},
+							},
+						},
+					},
+				},
+			},
+			b: PrometheusMatrixEnvelope{
+				Status: rvSuccess,
+				Data: PrometheusMatrixData{
+					ResultType: "matrix",
+					Result: model.Matrix{
+						&model.SampleStream{
+							Metric: model.Metric{"__name__": "a"},
+							Values: []model.SamplePair{
+								model.SamplePair{1, 1.5},
+								model.SamplePair{5, 1.5},
+							},
+						},
+					},
+				},
+			},
+			merged: PrometheusMatrixEnvelope{
+				Status: rvSuccess,
+				Data: PrometheusMatrixData{
+					ResultType: "matrix",
+					Result: model.Matrix{
+						&model.SampleStream{
+							Metric: model.Metric{"__name__": "a"},
+							Values: []model.SamplePair{
+								model.SamplePair{1, 1.5},
+								model.SamplePair{5, 1.5},
+								model.SamplePair{10, 1.5},
+							},
+						},
+					},
+				},
+			},
+		},
+		// Empty second series
+		{
+			a: PrometheusMatrixEnvelope{
+				Status: rvSuccess,
+				Data: PrometheusMatrixData{
+					ResultType: "matrix",
+					Result: model.Matrix{
+						&model.SampleStream{
+							Metric: model.Metric{"__name__": "a"},
+							Values: []model.SamplePair{
+								model.SamplePair{10, 1.5},
+							},
+						},
+					},
+				},
+			},
+			b: PrometheusMatrixEnvelope{
+				Status: rvSuccess,
+				Data: PrometheusMatrixData{
+					ResultType: "matrix",
+					Result: model.Matrix{
+						&model.SampleStream{
+							Metric: model.Metric{"__name__": "a"},
+							Values: []model.SamplePair{},
+						},
+					},
+				},
+			},
+			merged: PrometheusMatrixEnvelope{
+				Status: rvSuccess,
+				Data: PrometheusMatrixData{
+					ResultType: "matrix",
+					Result: model.Matrix{
+						&model.SampleStream{
+							Metric: model.Metric{"__name__": "a"},
+							Values: []model.SamplePair{
+								model.SamplePair{10, 1.5},
+							},
+						},
+					},
+				},
+			},
+		},
+		// Series that have too many points in the second series
+		{
+			a: PrometheusMatrixEnvelope{
+				Status: rvSuccess,
+				Data: PrometheusMatrixData{
+					ResultType: "matrix",
+					Result: model.Matrix{
+						&model.SampleStream{
+							Metric: model.Metric{"__name__": "a"},
+							Values: []model.SamplePair{
+								model.SamplePair{10, 1.5},
+							},
+						},
+					},
+				},
+			},
+			b: PrometheusMatrixEnvelope{
+				Status: rvSuccess,
+				Data: PrometheusMatrixData{
+					ResultType: "matrix",
+					Result: model.Matrix{
+						&model.SampleStream{
+							Metric: model.Metric{"__name__": "a"},
+							Values: []model.SamplePair{
+								model.SamplePair{1, 1.5},
+								model.SamplePair{5, 1.5},
+								model.SamplePair{10, 1.5},
+								model.SamplePair{15, 1.5},
+							},
+						},
+					},
+				},
+			},
+			merged: PrometheusMatrixEnvelope{
+				Status: rvSuccess,
+				Data: PrometheusMatrixData{
+					ResultType: "matrix",
+					Result: model.Matrix{
+						&model.SampleStream{
+							Metric: model.Metric{"__name__": "a"},
+							Values: []model.SamplePair{
+								model.SamplePair{1, 1.5},
+								model.SamplePair{5, 1.5},
+								model.SamplePair{10, 1.5},
+							},
+						},
+					},
+				},
+			},
+		},
+		// Series that don't adhere to rules
 		{
 			a: PrometheusMatrixEnvelope{
 				Status: rvSuccess,
@@ -507,7 +649,6 @@ func TestTricksterHandler_mergeMatrix(t *testing.T) {
 						&model.SampleStream{
 							Metric: model.Metric{"__name__": "a"},
 							Values: []model.SamplePair{
-								model.SamplePair{1, 1.5},
 								model.SamplePair{2, 1.5},
 							},
 						},
@@ -523,7 +664,6 @@ func TestTricksterHandler_mergeMatrix(t *testing.T) {
 							Metric: model.Metric{"__name__": "a"},
 							Values: []model.SamplePair{
 								model.SamplePair{1, 1.5},
-								model.SamplePair{2, 1.5},
 							},
 						},
 					},


### PR DESCRIPTION
Fix for 9c6aecb53443134537847a5b46b351a5f689b694

The original commit correctly stated that the assumption was that pe2
was before pe, but it actually enforced the exact opposite. This fixes
the enforcement and updates the tests

Fixes #116