### PR TITLE
Refactor channel reap to use Bulk Get call(Issue #4)

### DIFF
--- a/redis_test.go
+++ b/redis_test.go
@@ -29,7 +29,7 @@ func setupRedisCache() (RedisCache, func()) {
 	tr := TricksterHandler{
 		Logger:           log.NewNopLogger(),
 		ResponseChannels: make(map[string]chan *ClientRequestContext),
-		Config:		  &cfg,
+		Config:           &cfg,
 	}
 	rcfg := RedisCacheConfig{Endpoint: s.Addr()}
 	close := func() {

--- a/redis_test.go
+++ b/redis_test.go
@@ -25,9 +25,11 @@ func setupRedisCache() (RedisCache, func()) {
 	if err != nil {
 		panic(err)
 	}
+	cfg := Config{Caching: CachingConfig{ReapSleepMS: 1000}}
 	tr := TricksterHandler{
 		Logger:           log.NewNopLogger(),
 		ResponseChannels: make(map[string]chan *ClientRequestContext),
+		Config:		  &cfg,
 	}
 	rcfg := RedisCacheConfig{Endpoint: s.Addr()}
 	close := func() {


### PR DESCRIPTION
The original redis cache GET call within the redis ReapOnce function has been modified to get all the keys with a single bulk call using the redis client MGET method.

Also, I noticed the reaper goroutine is **not started** within the redis.Connect function. This type of goroutine call for the reaper exists both in the memory.go file and the boltdb.go file. I have added this call to the redis.Connect function.