### PR TITLE
fix max_value_age_secs config doesn't work

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -857,7 +857,7 @@ func (t *TricksterHandler) originRangeProxyHandler(cacheKey string, originRangeR
 			}
 
 			// Prune any old points based on retention policy
-			ctx.Matrix.cropToRange(ctx.Time-ctx.Origin.MaxValueAgeSecs, 0)
+			ctx.Matrix.cropToRange(int64(ctx.Time-ctx.Origin.MaxValueAgeSecs)*1000, 0)
 
 			// If it's not a full cache hit, we want to write this back to the cache
 			if ctx.CacheLookupResult != crHit {


### PR DESCRIPTION
The max_value_age_secs config in origin doesn't work, Trickster will not drop any old points based on retention policy.

I noticed that in handlers.go:860, in the code use ctx.Matrix.cropToRange(ctx.Time-ctx.Origin.MaxValueAgeSecs, 0), the start=ctx.Time-ctx.Origin.MaxValueAgeSecs use seconds, but the timestamp in metrics from Prometheus use milliseconds, which cause the ts always >= start in cropToRange function, so old data will never be dropped.