### PR TITLE
add no_cache_last_data_secs to let trickster last recent data

### DIFF
--- a/config.go
+++ b/config.go
@@ -90,6 +90,7 @@ type PrometheusOriginConfig struct {
 	IgnoreNoCacheHeader bool   `toml:"ignore_no_cache_header"`
 	MaxValueAgeSecs     int64  `toml:"max_value_age_secs"`
 	FastForwardDisable  bool   `toml:"fast_forward_disable"`
+	NoCacheLastDataSecs int64  `toml:"no_cache_last_data_secs"`
 }
 
 // MetricsConfig is a collection of Metrics Collection configurations

--- a/handlers.go
+++ b/handlers.go
@@ -861,8 +861,13 @@ func (t *TricksterHandler) originRangeProxyHandler(cacheKey string, originRangeR
 
 			// If it's not a full cache hit, we want to write this back to the cache
 			if ctx.CacheLookupResult != crHit {
+				cacheMatrix := ctx.Matrix.copy()
+				if ctx.Origin.NoCacheLastDataSecs != 0 {
+					cacheMatrix.cropToRange(0, int64(ctx.Time-ctx.Origin.NoCacheLastDataSecs)*1000)
+				}
+
 				// Marshal the Envelope back to a json object for Cache Storage
-				cacheBody, err := json.Marshal(ctx.Matrix)
+				cacheBody, err := json.Marshal(cacheMatrix)
 				if err != nil {
 					level.Error(t.Logger).Log(lfEvent, "prometheus matrix marshaling error", lfDetail, err.Error())
 					r.Writer.WriteHeader(http.StatusInternalServerError)
@@ -1099,6 +1104,22 @@ func (pe PrometheusMatrixEnvelope) getExtents() MatrixExtents {
 	}
 
 	return MatrixExtents{Start: oldest, End: newest}
+}
+
+// copy return a deep copy of PrometheusMatrixEnvelope.
+func (pe PrometheusMatrixEnvelope) copy() PrometheusMatrixEnvelope {
+	resPe := PrometheusMatrixEnvelope{
+		Status: pe.Status,
+		Data: PrometheusMatrixData{
+			ResultType: pe.Data.ResultType,
+			Result:     make([]*model.SampleStream, len(pe.Data.Result)),
+		},
+	}
+	for index := range pe.Data.Result {
+		resSampleSteam := *pe.Data.Result[index]
+		resPe.Data.Result[index] = &resSampleSteam
+	}
+	return resPe
 }
 
 // passthroughParam passes the parameter with paramName, if present in the requestParams, on to the proxyParams collection

--- a/handlers.go
+++ b/handlers.go
@@ -866,7 +866,7 @@ func (t *TricksterHandler) originRangeProxyHandler(cacheKey string, originRangeR
 					cacheMatrix.cropToRange(0, int64(ctx.Time-ctx.Origin.NoCacheLastDataSecs)*1000)
 				}
 
-        // Marshal the Envelope back to a json object for Cache Storage
+				// Marshal the Envelope back to a json object for Cache Storage
 				cacheBody, err := json.Marshal(cacheMatrix)
 				if err != nil {
 					level.Error(t.Logger).Log(lfEvent, "prometheus matrix marshaling error", lfDetail, err.Error())


### PR DESCRIPTION
    In our use of trickster, we meet a problem. In our environment, the query flow is Grafana -> Trickster -> Prometheus_Federation -> Prometheus -> Influxdb.
Prometheus scrape each instance in a interval=10s, Prometheus_Federation collect data from Prometheus in interval=10s. In our use, we find if we query a range of time in grafana, each time after 1min we refresh the dashboard, we find a breakpoint in the dashboard. The query is max_over_time(up[15s]), if we query="up", the datapoint in the join point is not accurate.

    In my analysis, I find this is because metrics data from Prometheus to Prometheus_Federation has a latency, Prometheus_Federation collect metrics data from Prometheus in interval=10s, which means Prometheus_Federation not include all metrics data which "timestamp < now()", Prometheus_Federation may lost some datapoints which "timestamp > now() - 10s && timestamp < now()". And in this case, the query to Prometheus_Federation will return not accurate datapoint value for the last datapoint(which timestamp > now() - 10s). If we send query directly to Prometheus_Federation, the next we refresh the data, Prometheus_Federation will adjust this inaccurate value, but in the use of Trickster, Trickster will cache this inaccurate datapoint and not resend the query to Prometheus_Federation to refresh the data.
So if the query="up", because prometheus will padding the value for 5 minutes(use the last datapoint which timstamp> now() - 5min),so this datapoint value is inaccurate. If we use query="max_over_time(up[15s])", we find breakpoint in dashboard.

    Can we add this optional config parameter, let Trickster not cache the last recent data, for example: not cache last 10s data. In this case, Trickster will always refresh date in this range, so we get accurate data and also not has breakpoints in refresh the dashboard.