### PR TITLE
fix MaxValueAgeSecs filter

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -862,6 +862,10 @@ func (t *TricksterHandler) originRangeProxyHandler(cacheKey string, originRangeR
 			// If it's not a full cache hit, we want to write this back to the cache
 			if ctx.CacheLookupResult != crHit {
 				cacheMatrix := ctx.Matrix.copy()
+
+				// Prune any old points based on retention policy
+				cacheMatrix.cropToRange(int64(ctx.Time-ctx.Origin.MaxValueAgeSecs)*1000, 0)
+
 				if ctx.Origin.NoCacheLastDataSecs != 0 {
 					cacheMatrix.cropToRange(0, int64(ctx.Time-ctx.Origin.NoCacheLastDataSecs)*1000)
 				}


### PR DESCRIPTION
Sorry for code conflict in pull request #120 and #121, this code is based on the latest master code, and the function is same in #120, fix the MaxValueAgeSecs use seconds problem, thanks.