### PR TITLE
fix fastforward time ms bug

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -800,7 +800,7 @@ func (t *TricksterHandler) originRangeProxyHandler(cacheKey string, originRangeR
 				}()
 			}
 
-			if !ctx.Origin.FastForwardDisable && !(ctx.RequestExtents.End < ctx.Time-ctx.StepMS) {
+			if !ctx.Origin.FastForwardDisable && !(ctx.RequestExtents.End < ctx.Time*1000-ctx.StepMS) {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -180,7 +180,7 @@ func TestUnreachableOriginReturnsStatusBadGateway(t *testing.T) {
 		},
 		{
 			handler: (*TricksterHandler).promQueryRangeHandler,
-			path:    prometheusAPIv1Path + "query_range?start=0&end=100000000&step=15&query=up",
+			path:    prometheusAPIv1Path + "query_range?start=100000000&end=200000000&step=15&query=up",
 		},
 	}
 


### PR DESCRIPTION
In the testing, I found in the FastForward compare, ctx.RequestExtents.End < ctx.Time-ctx.StepMS, ctx.Time use seconds and others use milliseconds, this merge request fix this bug and the corresponding unit test.