### PR TITLE
Update helm and kube config maps to follow new format, update versions.

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -12,21 +12,21 @@ If you are wanting to use Helm and kubernetes rbac use the following install ste
 
 #### Bootstrap Local Kubernetes-Helm Dev
 
-- Install [Helm](helm.sh) **Client Version 2.8.2**
+- Install [Helm](helm.sh) **Client Version 2.9.1**
     ```
     brew install kubernetes-helm
     ```
 
-- Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) **client server 1.9.4, client version 1.9.4**
+- Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) **client server 1.13.4, client version 1.13.4**
     ```
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.9.4/bin/darwin/amd64/kubectl
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.13.4/bin/darwin/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
     ```
 
-- Install [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) **version 0.25.0**
+- Install [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) **version 0.35.0**
     ```
-    curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.2/minikube-darwin-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+    curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.23.2/minikube-darwin-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
     ```
-    
+
 - Start minikube and enable RBAC `make start-minikube` or manually with `--extra-config=apiserver.Authorization.Mode=RBAC --kubernetes-version=v1.8.0`.
 - Install Tiller `make bootstrap-peripherals`
 - Wait until Tiller is running `kubectl get po --namespace trickster -w`
@@ -55,7 +55,7 @@ For pure kubernetes deployment use the `deploy/kube` directory.
     ```
     brew cask install https://raw.githubusercontent.com/caskroom/homebrew-cask/903f1507e1aeea7fc826c6520a8403b4076ed6f4/Casks/minikube.rb
     ```
-    
+
 - Start minikube `make start-minikube` or manually with `minikube start`.
 - Deploy all K8 artifacts `make bootstrap-trickster-dev`
 

--- a/deploy/helm/Makefile
+++ b/deploy/helm/Makefile
@@ -1,14 +1,14 @@
 
 KUBE_DIR ?= kube-artifacts
 
-install-tiller-dev: 
+install-tiller-dev:
 	kubectl config use-context minikube
 	-kubectl create ns trickster
 	kubectl config set-context minikube --namespace=trickster
 	-kubectl --namespace trickster create -f tiller/templates/serviceaccount.yaml
 	-kubectl --namespace trickster create -f tiller/templates/role.yaml
-	-helm init --service-account tiller --tiller-image gcr.io/kubernetes-helm/tiller:v2.8.2 --tiller-namespace trickster
-	
+	-helm init --service-account tiller --tiller-image gcr.io/kubernetes-helm/tiller:v2.9.1 --tiller-namespace trickster
+
 bootstrap-peripherals: install-tiller-dev
 	kubectl config use-context minikube
 	-kubectl create -f $(KUBE_DIR)/compute-quota.yaml -n trickster
@@ -19,7 +19,7 @@ bootstrap-trickster-dev:
 		--install \
 		--namespace=trickster \
 		--tiller-namespace=trickster
-	
+
 update-dev-chart: update-trickster
 	kubectl config use-context minikube
 	helm upgrade dev trickster --namespace=trickster --tiller-namespace=trickster --reuse-values
@@ -27,11 +27,9 @@ update-dev-chart: update-trickster
 start-minikube:
 	minikube start \
 		--memory 2048 \
-		--cpus 2 \
-		--extra-config=apiserver.Authorization.Mode=RBAC \
-		--kubernetes-version=v1.9.4
+		--cpus 2
 	-kubectl config set-context minikube --namespace=trickster
-	
+
 delete:
 	kubectl config use-context minikube
 	helm delete --purge dev --tiller-namespace=trickster

--- a/deploy/helm/trickster/Chart.yaml
+++ b/deploy/helm/trickster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
-appVersion: 0.0.12
+appVersion: 1.0.0
 description: Trickster is a reverse proxy cache for the Prometheus HTTP API that dramatically accelerates chart rendering times for any series queried from Prometheus.
 name: trickster
-version: 1.1.2
+version: 1.2.0
 home: https://github.com/comcast/trickster
 icon: ""

--- a/deploy/helm/trickster/templates/configmap.yaml
+++ b/deploy/helm/trickster/templates/configmap.yaml
@@ -10,105 +10,191 @@ metadata:
 data:
   trickster.conf: |-
     [main]
-
-        # instance_id allows you to run multiple trickster processes on the same host and log to separate files
-        # Useful for baremetal, not so much for elastic deployments, so only uncomment if you really need it
-        #instance_id = 1
+    # instance_id allows you to run multiple trickster processes on the same host and log to separate files
+    # Useful for baremetal, not so much for elastic deployments, so only uncomment if you really need it
+    #instance_id = 1
 
     # Configuration options for the Proxy Server
     [proxy_server]
+    # listen_port defines the port on which Trickster's Proxy server listens.
+    # The default proxy is for Prometheus, so we use 9090 by default, just like Prometheus does
+    # listen_port = 9090
+    listen_port = {{ .Values.service.port }}
+    # listen_address defines the ip on which Trickster's Proxy server listens.
+    # empty by default, listening on all interfaces
+    # listen_address =
+    {{ if .Values.service.metricsAddress }}
+    listen_address = {{ .Values.service.address }}
+    {{ end }}
 
-        # listen_port defines the port on which Trickster's Proxy server listens.
-        # since this is a proxy for Prometheus, we use 9090 by default, just like Prometheus does
-        listen_port = {{ .Values.service.port }}
 
-    [cache]
+    [caches]
+
+        # [caches.default]
         # cache_type defines what kind of cache Trickster uses
-        # options are 'boltdb', 'filesystem', 'memory', and 'redis'.  'memory' is the default
-        cache_type = {{ .Values.cache.type | quote }}
+        # options are 'bbolt', 'filesystem', 'memory', and 'redis'.
+        # The default is 'memory'.
+        # type = 'memory'
 
-        # record_ttl_secs defines the relative expiration of cached queries. default is 6 hours (21600 seconds)
-        record_ttl_secs = {{ .Values.recordTTLSecs }}
+        # record_ttl_secs defines the relative expiration of cached timeseries. default is 6 hours (21600 seconds)
+        # record_ttl_secs = 21600
 
-            {{- if eq .Values.cache.type "redis" }}
-            # Configuration options when using a Redis Cache
-            [cache.redis]
+        # reap_interval_ms defines how long the cache reaper waits between reap cycles. Default is 1000 (1s)
+        # reap_interval_ms = 1000
 
+        # compression determines whether the cache should be compressed. default is true
+        # changing the compression setting will leave orphans in your cache for the duration of record_ttl_secs
+        # compression = true
+
+            ### Configuration options when using a Redis Cache
+            # [cache.redis]
             # protocol defines the protocol for connecting to redis ('unix' or 'tcp') 'tcp' is default
-            protocol = {{ .Values.cache.redis.protocol | quote }}
-
+            # protocol = 'tcp'
             # endpoint defines the fqdn+port or path to a unix socket file for connecting to redis
             # default is 'redis:6379'
-            endpoint = {{ .Values.cache.redis.endpoint | quote }}
+            # endpoint = 'redis:6379'
+            # password provides the redis password
+            # default is empty
+            # password = ''
 
-            {{- else if eq .Values.cache.type "filesystem" }}
-            # Configuration options when using a Filesystem Cache
-            [cache.filesystem]
-
+            ### Configuration options when using a Filesystem Cache
+            # [cache.filesystem]
             # cache_path defines the directory location under which the Trickster cache will be maintained
             # default is '/tmp/trickster'
-            cache_path = {{ .Values.cache.filesystem.path | quote }}
+            # cache_path = '/tmp/trickster'
 
-            {{- else if eq .Values.cache.type "boltdb" }}
-            # Configuration options when using a BoltDb Cache
-            [cache.boltdb]
+            # Configuration options when using a bbolt Cache
+            #[cache.bbolt]
+
             # filename defines the file where the Trickster cache will be maintained
             # default is 'trickster.db'
-            filename = {{ .Values.cache.boltdb.file | quote }}
+            # filename = 'trickster.db'
 
             # bucket defines the name of the BotlDb bucket (similar to a namespace) under which our key value store lives
             # default is 'trickster'
-            bucket = {{ .Values.cache.boltdb.bucket | quote }}
+            # bucket = 'trickster'
+
+      {{- range .Values.caches }}
+        {{ printf "[caches.%s]" .name }}
+        type = {{ .type | quote }}
+        record_ttl_secs = {{ .recordTTLSecs }}
+        {{ if .reapIntervalMs }}
+        reap_interval_ms = {{ .reapIntervalMs }}
+        {{ end }}
+        compression = {{ .compression }}
+
+            {{- if eq .type "redis" }}
+            [cache.redis]
+            protocol = {{ .redis.protocol | quote }}
+            endpoint = {{ .redis.endpoint | quote }}
+            password = {{ .redis.password | quote }}
+
+            {{- else if eq .type "filesystem" }}
+            [cache.filesystem]
+            cache_path = {{ .filesystem.path | quote }}
+
+            {{- else if eq .type "bbolt" }}
+            [cache.bbolt]
+            filename = {{ .bbolt.file | quote }}
+            bucket = {{ .boltdb.bucket | quote }}
             {{- end }}
+      {{- end }}
+
 
     # Configuration options for mapping Origin(s)
     [origins]
 
-        # The default origin
-        [origins.default]
+        ### The default origin
+        # [origins.default]
 
-            # origin_url defines the URL of the origin. Default is http://prometheus:9090
-            origin_url = {{ .Values.originURL | quote }}
+        # type identifies the origin type. Valid options are 'prometheus', 'influxdb'
+        # default is prometheus.
+        # type = 'prometheus'
 
-            # api path defines the path of the Prometheus API (usually '/api/v1')
-            api_path = '/api/v1'
+        # cache_name identifies the name of the cache (configured above) that you want to use with this origin proxy.
+        # cache_name = 'default'
 
-            # default_step defines the step (in seconds) of a query_range request if one is
-            # not provided by the client. This helps to correct improperly formed client requests.
-            default_step = {{ .Values.defaultStep }}
+        # scheme identifies the scheme
+        # default is http
+        # scheme = 'http'
 
-            # ignore_no_cache_header disables a client's ability to send a no-cache to refresh a cached query. Default is false
-            #ignore_no_cache_header = false
+        # host identifies the upstream origin by fqdn/IP and port
+        # default is prometheus:9090
+        # host = 'prometheus:9090'
 
-            # max_value_age_secs defines the maximum age of specific datapoints in seconds. Default is 86400 (24 hours)
-            max_value_age_secs = {{ .Values.maxValueAgeSecs }}
+        # path_prefix provides any path that is prefixed onto the front of the client's requested path
+        # default is empty
+        # path_prefix = ''
 
-            # fast_forward_disable, when set to true, will turn off the 'fast forward' feature for any requests proxied to this origin
-            fast_forward_disable = {{ .Values.fastForwardDisable }}
+        # timeout_secs defines how many seconds Trickster will wait before aborting and upstream http request. Default: 180s
+        # timeout_secs = 180
 
-        # For multi-origin support, origins are named, and the name is the second word of the configuration section name.
-        # In this example, an origin is named "foo". Clients can indicate this origin in their path (http://trickster.example.com:9090/foo/query_range?.....)
-        # there are other ways for clients to indicate which origin to use in a multi-origin setup. See the documentation for more information
-        #[origins.foo]
-            #origin_url = 'http://prometheus-foo:9090'
-            #api_path = '/api/v1'
-            #default_step = 300
-            #ignore_no_cache_header = false
-            #max_value_age_secs = 86400
+        # api_path defines the path of the Upstream Origin's API (usually '/api/v1')
+        # api_path = '/api/v1'
+
+        # ignore_no_cache_header disables a client's ability to send a no-cache to refresh a cached query. Default is false
+        # ignore_no_cache_header = false
+
+        # max_value_age_secs defines the maximum age of data in the cached timeseries. Default is 86400 (24 hours)
+        # max_value_age_secs = 86400
+
+        # fast_forward_disable, when set to true, will turn off the 'fast forward' feature for any requests proxied to this origin
+        # fast_forward_disable = false
+
+    {{- range .Values.origins }}
+        {{ printf "[origins.%s]" .name }}
+        type = {{ .type | quote }}
+        cache_name = {{ .name }}
+        scheme = {{ .scheme | quote }}
+        host = {{ .host | quote }}
+        path_prefix = {{ .pathPrefix | quote }}
+        api_path = {{ .apiPath | quote }}
+        ignore_no_cache_header = {{ .ignoreNoCacheHeader }}
+        max_value_age_secs = {{ .maxValueAgeSecs }}
+        timeout_secs = {{ .timeoutSecs }}
+        backfill_tolerance_secs = {{ .backfillToleranceSecs }}
+        fast_forward_disable = {{ .fastForwardDisable }}
+    {{- end }}
+
+        # [origins.foo]
+        # type = 'influxdb'
+        # cache_name = default
+        # scheme = 'http'
+        # host = 'influx-origin:8086'
+        # path_prefix = ''
+        # api_path = ''
+        # ignore_no_cache_header = false
+        # max_value_age_secs = 86400
+        # timeout_secs = 180
+        # backfill_tolerance_secs = 180
+        # fast_forward_disable = false
 
     # Configuration Options for Metrics Instrumentation
     [metrics]
+    # listen_port defines the port that Trickster's metrics server listens on at /metrics
+    listen_port =  {{ .Values.service.metricsPort }}
+    # listen_address defines the ip that Trickster's metrics server listens on at /metrics
+    # empty by default, listening on all interfaces
+    # listen_address =
+    {{ if .Values.service.metricsAddress }}
+    listen_address = {{ .Values.service.metricsAddress }}
+    {{ end }}
 
-        # listen_port defines the port that Trickster's metrics server listens on at /metrics
-        listen_port =  {{ .Values.service.metricsPort }}
+    # Configruation Options for Profiler
+    [profiler]
+    # enabled indicates whether to start the profiler server when Trickster starts up. Default: false
+    # enabled = false
+    enabled = {{ .Values.profiler.enabled }}
+    # listen_port defines the port that Trickster's profiler server listens on at /debug/pprof. Default: 6060
+    # listen_port = 6060
+    listen_port = {{ .Values.profiler.port }}
 
     # Configuration Options for Logging Instrumentation
     [logging]
+    # log_level defines the verbosity of the logger. Possible values are 'debug', 'info', 'warn', 'error'
+    # default is info
+    log_level = {{ .Values.logLevel | quote }}
 
-        # log_level defines the verbosity of the logger. Possible values are 'debug', 'info', 'warn', 'error'
-        # default is info
-        log_level = {{ .Values.logLevel | quote }}
-
-        # log_file defines the file location to store logs. These will be auto-rolled and maintained for you.
-        # not specifying a log_file (this is the default behavior) will print logs to STDOUT
-        #log_file = '/some/path/to/trickster.log'
+    # log_file defines the file location to store logs. These will be auto-rolled and maintained for you.
+    # not specifying a log_file (this is the default behavior) will print logs to STDOUT
+    # log_file = '/some/path/to/trickster.log'

--- a/deploy/helm/trickster/templates/configmap.yaml
+++ b/deploy/helm/trickster/templates/configmap.yaml
@@ -23,9 +23,6 @@ data:
     # listen_address defines the ip on which Trickster's Proxy server listens.
     # empty by default, listening on all interfaces
     # listen_address =
-    {{ if .Values.service.metricsAddress }}
-    listen_address = {{ .Values.service.address }}
-    {{ end }}
 
 
     [caches]
@@ -77,7 +74,7 @@ data:
       {{- range .Values.caches }}
         {{ printf "[caches.%s]" .name }}
         type = {{ .type | quote }}
-        record_ttl_secs = {{ .recordTTLSecs }}
+        record_ttl_secs = {{ .recordTTLSecs | default(21600) }}
         {{ if .reapIntervalMs }}
         reap_interval_ms = {{ .reapIntervalMs }}
         {{ end }}
@@ -176,9 +173,6 @@ data:
     # listen_address defines the ip that Trickster's metrics server listens on at /metrics
     # empty by default, listening on all interfaces
     # listen_address =
-    {{ if .Values.service.metricsAddress }}
-    listen_address = {{ .Values.service.metricsAddress }}
-    {{ end }}
 
     # Configruation Options for Profiler
     [profiler]

--- a/deploy/helm/trickster/values.yaml
+++ b/deploy/helm/trickster/values.yaml
@@ -77,13 +77,13 @@ ingress:
 
 # Resource limits & requests
 # Ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
-resources:
-  limits:
-   cpu: 100m
-   memory: 128Mi
-  requests:
-   cpu: 100m
-   memory: 128Mi
+resources: {}
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
 
 # Node labels for pod assignment
 # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector

--- a/deploy/helm/trickster/values.yaml
+++ b/deploy/helm/trickster/values.yaml
@@ -1,26 +1,44 @@
 # Default values for trickster.
 
-# Default trickster originURL, references a source Prometheus instance
-# Ref: https://github.com/Comcast/trickster/blob/master/docs/configuring.md
-originURL: http://prometheus:9090
-cache:
-  type: memory
-  redis:
-    protocol: tcp
-    endpoint: redis:6379
-  filesystem:
-    path: /tmp/trickster
-  boltdb:
-    file: trickster.db
-    bucket: trickster
 # Put ints in quotes to ensure they aren't converted to scientific notations.
 # See https://github.com/kubernetes/helm/issues/1707
-recordTTLSecs: "21600"
-defaultStep: "300"
-# 24h
-maxValueAgeSecs: "86400"
-fastForwardDisable: false
+
+origins:
+  - name: default
+    type: prometheus
+    scheme: http
+    host: 'prometheus:9090'
+    pathPrefix: ''
+    timeoutSecs: "180"
+    apiPath: /api/v1
+    ignoreNoCacheHeader: false
+    # 24h
+    maxValueAgeSecs: "86400"
+    fastForwardDisable: false
+    backfillToleranceSecs: "180"
+
+# Default trickster originURL, references a source Prometheus instance
+# Ref: https://github.com/Comcast/trickster/blob/master/docs/configuring.md
+caches:
+  - name: default
+    type: memory
+    compression: true
+    recordTTLSecs: "21600"
+    reapIntervalMs: "1000"
+    redis:
+      protocol: tcp
+      endpoint: redis:6379
+      password: ''
+    filesystem:
+      path: /tmp/trickster
+    bbolt:
+      file: trickster.db
+      bucket: trickster
+
 logLevel: info
+profiler:
+  enabled: false
+  port: 6060
 
 # Number of trickster replicas desired
 replicaCount: 1
@@ -36,7 +54,9 @@ image:
 service:
   type: ClusterIP
   port: 9090
+  #address = "localhost"
   metricsPort: 8080
+  # metricsAddress = "localhost"
   # metricsNodePort: 0
   # nodePort: 0
 
@@ -57,13 +77,13 @@ ingress:
 
 # Resource limits & requests
 # Ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
-resources: {}
-  # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
-  # requests:
-  #  cpu: 100m
-  #  memory: 128Mi
+resources:
+  limits:
+   cpu: 100m
+   memory: 128Mi
+  requests:
+   cpu: 100m
+   memory: 128Mi
 
 # Node labels for pod assignment
 # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector

--- a/deploy/helm/trickster/values.yaml
+++ b/deploy/helm/trickster/values.yaml
@@ -46,7 +46,7 @@ replicaCount: 1
 # image for trickster deplyoment
 image:
   repository: tricksterio/trickster
-  tag: 0.0.12
+  tag: 1.0.0
   pullPolicy: IfNotPresent
 
 # Service resource for trickster deplyoment

--- a/deploy/helm/trickster/values.yaml
+++ b/deploy/helm/trickster/values.yaml
@@ -54,11 +54,9 @@ image:
 service:
   type: ClusterIP
   port: 9090
-  #address = "localhost"
-  metricsPort: 8080
-  # metricsAddress = "localhost"
-  # metricsNodePort: 0
   # nodePort: 0
+  metricsPort: 8080
+  # metricsNodePort: 0
 
 # Ingress resource for trickster service
 # Ref : https://kubernetes.io/docs/concepts/services-networking/ingress/

--- a/deploy/kube/configmap.yaml
+++ b/deploy/kube/configmap.yaml
@@ -8,44 +8,56 @@ metadata:
 data:
   trickster-conf: |-
     [main]
-
-        # instance_id allows you to run multiple trickster processes on the same host and log to separate files
-        # Useful for baremetal, not so much for elastic deployments, so only uncomment if you really need it
-        #instance_id = 1
+    # instance_id allows you to run multiple trickster processes on the same host and log to separate files
+    # Useful for baremetal, not so much for elastic deployments, so only uncomment if you really need it
+    #instance_id = 1
 
     # Configuration options for the Proxy Server
     [proxy_server]
+    # listen_port defines the port on which Trickster's Proxy server listens.
+    # The default proxy is for Prometheus, so we use 9090 by default, just like Prometheus does
+    # listen_port = 9090
+    # listen_address defines the ip on which Trickster's Proxy server listens.
+    # empty by default, listening on all interfaces
+    # listen_address =
 
-        # listen_port defines the port on which Trickster's Proxy server listens.
-        # since this is a proxy for Prometheus, we use 9090 by default, just like Prometheus does
-        listen_port = 9090
+    [caches]
 
-    [cache]
+        [caches.default]
         # cache_type defines what kind of cache Trickster uses
-        # options are 'boltdb, 'filesystem', 'memory', and 'redis'.  'memory' is the default
-        cache_type = 'memory'
+        # options are 'bbolt', 'filesystem', 'memory', and 'redis'.
+        # The default is 'memory'.
+        type = 'memory'
 
-        # record_ttl_secs defines the relative expiration of cached queries. default is 6 hours (21600 seconds)
-        record_ttl_secs = 21600
+        # record_ttl_secs defines the relative expiration of cached timeseries. default is 6 hours (21600 seconds)
+        # record_ttl_secs = 21600
 
-            # Configuration options when using a Redis Cache
-            #[cache.redis]
+        # reap_interval_ms defines how long the cache reaper waits between reap cycles. Default is 1000 (1s)
+        # reap_interval_ms = 1000
 
+        # compression determines whether the cache should be compressed. default is true
+        # changing the compression setting will leave orphans in your cache for the duration of record_ttl_secs
+        # compression = true
+
+            ### Configuration options when using a Redis Cache
+            # [cache.redis]
             # protocol defines the protocol for connecting to redis ('unix' or 'tcp') 'tcp' is default
-            #protocol = 'tcp'
-
+            # protocol = 'tcp'
             # endpoint defines the fqdn+port or path to a unix socket file for connecting to redis
             # default is 'redis:6379'
-            #endpoint = 'redis:6379'
+            # endpoint = 'redis:6379'
+            # password provides the redis password
+            # default is empty
+            # password = ''
 
-            # Configuration options when using a Filesystem Cache
-            #[cache.filesystem]
-
+            ### Configuration options when using a Filesystem Cache
+            # [cache.filesystem]
             # cache_path defines the directory location under which the Trickster cache will be maintained
             # default is '/tmp/trickster'
-            #cache_path = '/tmp/trickster'
-            # Configuration options when using a BoltDb Cache
-            #[cache.boltdb]
+            # cache_path = '/tmp/trickster'
+
+            # Configuration options when using a bbolt Cache
+            #[cache.bbolt]
 
             # filename defines the file where the Trickster cache will be maintained
             # default is 'trickster.db'
@@ -55,55 +67,92 @@ data:
             # default is 'trickster'
             # bucket = 'trickster'
 
+        # [caches.bbolt]
+        # type = 'bbolt'
+
+            # [caches.bbolt.bbolt]
+            # filename = 'trickster.db'
+            # bucket = 'trickster'
+
 
     # Configuration options for mapping Origin(s)
     [origins]
-
-        # The default origin
+        ### The default origin
         [origins.default]
 
-            # origin_url defines the URL of the origin. Default is http://prometheus:9090
-            origin_url = 'http://prometheus:9090'
+        # type identifies the origin type. Valid options are 'prometheus', 'influxdb'
+        # default is prometheus.
+        type = 'prometheus'
 
-            # api path defines the path of the Prometheus API (usually '/api/v1')
-            api_path = '/api/v1'
+        # cache_name identifies the name of the cache (configured above) that you want to use with this origin proxy.
+        cache_name = 'default'
 
-            # default_step defines the step (in seconds) of a query_range request if one is
-            # not provided by the client. This helps to correct improperly formed client requests.
-            default_step = 300
+        # scheme identifies the scheme
+        # default is http
+        scheme = 'http'
 
-            # ignore_no_cache_header disables a client's ability to send a no-cache to refresh a cached query. Default is false
-            #ignore_no_cache_header = false
+        # host identifies the upstream origin by fqdn/IP and port
+        # default is prometheus:9090
+        host = 'prometheus:9090'
 
-            # max_value_age_secs defines the maximum age of specific datapoints in seconds. Default is 86400 (24 hours)
-            max_value_age_secs = 86400
+        # path_prefix provides any path that is prefixed onto the front of the client's requested path
+        # default is empty
+        path_prefix = ''
 
-            # fast_forward_disable, when set to true, will turn off the 'fast forward' feature for any requests proxied to this origin
-            #fast_forward_disable = false
+        # timeout_secs defines how many seconds Trickster will wait before aborting and upstream http request. Default: 180s
+        # timeout_secs = 180
+
+        # api_path defines the path of the Upstream Origin's API (usually '/api/v1')
+        api_path = '/api/v1'
+
+        # ignore_no_cache_header disables a client's ability to send a no-cache to refresh a cached query. Default is false
+        # ignore_no_cache_header = false
+
+        # max_value_age_secs defines the maximum age of data in the cached timeseries. Default is 86400 (24 hours)
+        max_value_age_secs = 86400
+
+        # fast_forward_disable, when set to true, will turn off the 'fast forward' feature for any requests proxied to this origin
+        # fast_forward_disable = false
 
         # For multi-origin support, origins are named, and the name is the second word of the configuration section name.
-        # In this example, an origin is named "foo". Clients can indicate this origin in their path (http://trickster.example.com:9090/foo/query_range?.....)
+        # In this example, an origin is named "foo".
+        # Clients can indicate this origin in their path (http://trickster.example.com:9090/foo/api/v1/query_range?.....)
         # there are other ways for clients to indicate which origin to use in a multi-origin setup. See the documentation for more information
-        #[origins.foo]
-            #origin_url = 'http://prometheus-foo:9090'
-            #api_path = '/api/v1'
-            #default_step = 300
-            #ignore_no_cache_header = false
-            #max_value_age_secs = 86400
+
+        # [origins.foo]
+        # type = 'influxdb'
+        # cache_name = default
+        # scheme = 'http'
+        # host = 'influx-origin:8086'
+        # path_prefix = ''
+        # api_path = ''
+        # ignore_no_cache_header = false
+        # max_value_age_secs = 86400
+        # timeout_secs = 180
+        # backfill_tolerance_secs = 180
 
     # Configuration Options for Metrics Instrumentation
     [metrics]
+    # listen_port defines the port that Trickster's metrics server listens on at /metrics
+    listen_port = 8082
+    # listen_address defines the ip that Trickster's metrics server listens on at /metrics
+    # empty by default, listening on all interfaces
+    # listen_address =
 
-        # listen_port defines the port that Trickster's metrics server listens on at /metrics
-        listen_port = 8082
+    # Configruation Options for Profiler
+    [profiler]
+    # enabled indicates whether to start the profiler server when Trickster starts up. Default: false
+    # enabled = false
+    # listen_port defines the port that Trickster's profiler server listens on at /debug/pprof. Default: 6060
+    # listen_port = 6060
 
     # Configuration Options for Logging Instrumentation
     [logging]
+    # log_level defines the verbosity of the logger. Possible values are 'debug', 'info', 'warn', 'error'
+    # default is info
+    log_level = 'info'
 
-        # log_level defines the verbosity of the logger. Possible values are 'debug', 'info', 'warn', 'error'
-        # default is info
-        log_level = 'info'
+    # log_file defines the file location to store logs. These will be auto-rolled and maintained for you.
+    # not specifying a log_file (this is the default behavior) will print logs to STDOUT
+    # log_file = '/some/path/to/trickster.log'
 
-        # log_file defines the file location to store logs. These will be auto-rolled and maintained for you.
-        # not specifying a log_file (this is the default behavior) will print logs to STDOUT
-        #log_file = '/some/path/to/trickster.log'


### PR DESCRIPTION
### Changes of note
- Helm 2.8.2 -> 2.9.1
- kubectl 1.9.4 -> 1.13.4
- Minikube 0.25.0 -> 0.35.0
- Kube and Helm config maps updated to new format.
- Helm config map is now templated to range over origins and caches in values.


A thought I had while doing this is that we could put the comments of what each thing is in [values.yaml](https://github.com/helm/charts/blob/master/stable/prometheus/values.yaml) in stead of the [configmap](https://github.com/helm/charts/blob/master/stable/prometheus/templates/server-configmap.yaml) like prometheus does in their chart. Thoughts?