### PR TITLE
gzip down to the client

### DIFF
--- a/cmd/trickster/main.go
+++ b/cmd/trickster/main.go
@@ -25,6 +25,8 @@ import (
 	"github.com/Comcast/trickster/internal/routing/registration"
 	"github.com/Comcast/trickster/internal/util/log"
 	"github.com/Comcast/trickster/internal/util/metrics"
+
+	"github.com/gorilla/handlers"
 )
 
 const (
@@ -57,7 +59,7 @@ func main() {
 	log.Info("proxy http endpoint starting", log.Pairs{"address": config.ProxyServer.ListenAddress, "port": config.ProxyServer.ListenPort})
 
 	// Start the Server
-	err = http.ListenAndServe(fmt.Sprintf("%s:%d", config.ProxyServer.ListenAddress, config.ProxyServer.ListenPort), routing.Router)
+	err = http.ListenAndServe(fmt.Sprintf("%s:%d", config.ProxyServer.ListenAddress, config.ProxyServer.ListenPort), handlers.CompressHandler(routing.Router))
 	log.Error("exiting", log.Pairs{"err": err})
 
 }

--- a/go.mod
+++ b/go.mod
@@ -1,28 +1,28 @@
 module github.com/Comcast/trickster
 
 require (
-	github.com/BurntSushi/toml v0.3.1
+	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 // indirect
-	github.com/alicebob/miniredis v0.0.0-20181205055656-cfad8aca71cc
+	github.com/alicebob/miniredis v0.0.0-20181205055656-cfad8aca71cc // indirect
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 // indirect
-	github.com/coreos/bbolt v1.3.0
-	github.com/go-kit/kit v0.8.0
+	github.com/coreos/bbolt v1.3.0 // indirect
+	github.com/go-kit/kit v0.8.0 // indirect
 	github.com/go-logfmt/logfmt v0.4.0 // indirect
-	github.com/go-redis/redis v6.14.2+incompatible
-	github.com/go-stack/stack v1.8.0
+	github.com/go-redis/redis v6.14.2+incompatible // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/golang/protobuf v1.2.0 // indirect
-	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db
+	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
 	github.com/gomodule/redigo v2.0.0+incompatible // indirect
 	github.com/gorilla/context v1.1.1 // indirect
-	github.com/gorilla/handlers v1.4.0
-	github.com/gorilla/mux v1.6.2
+	github.com/gorilla/handlers v1.4.0 // indirect
+	github.com/gorilla/mux v1.6.2 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/pkg/errors v0.8.0
-	github.com/prometheus/client_golang v0.9.1
+	github.com/pkg/errors v0.8.0 // indirect
+	github.com/prometheus/client_golang v0.9.1 // indirect
 	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 // indirect
-	github.com/prometheus/common v0.0.0-20181126121408-4724e9255275
+	github.com/prometheus/common v0.0.0-20181126121408-4724e9255275 // indirect
 	github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a // indirect
 	github.com/yuin/gopher-lua v0.0.0-20181109042959-a0dfe84f6227 // indirect
-	golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a
-	gopkg.in/natefinch/lumberjack.v2 v2.0.0-20170531160350-a96e63847dc3
+	golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0-20170531160350-a96e63847dc3 // indirect
 )

--- a/internal/proxy/headers.go
+++ b/internal/proxy/headers.go
@@ -35,6 +35,7 @@ const (
 	hnXAccelerator    = "X-Accelerator"
 	hnXForwardedBy    = "X-Forwarded-By"
 	hnXForwardedFor   = "X-Forwarded-For"
+	hnAcceptEncoding  = "Accept-Encoding"
 )
 
 func addProxyHeaders(remoteAddr string, headers http.Header) {
@@ -52,4 +53,10 @@ func extractHeader(headers http.Header, header string) (string, bool) {
 		return strings.Join(hv, "; "), true
 	}
 	return "", false
+}
+
+func removeClientHeaders(headers http.Header) {
+
+	headers.Del(hnAcceptEncoding)
+
 }


### PR DESCRIPTION
This ensures that Trickster egresses Prom data down to clients as gzip compressed when the client advertises the proper content-encoding header. Fixes #138 