### PR TITLE
Add cors support for queries like series

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -149,8 +149,7 @@ func (t *TricksterHandler) promFullProxyHandler(w http.ResponseWriter, r *http.R
 		w.Header().Set(k, strings.Join(v, ","))
 	}
 
-	w.WriteHeader(resp.StatusCode)
-	w.Write(body)
+	writeResponse(w, body, resp)
 }
 
 // promQueryHandler handles calls to /query (for instantaneous values)


### PR DESCRIPTION
Hi,

This pr fixes a problem on grafana when you want to have dashboard with parameters.
The request send by grafana for that is something like that: `https://trickster.veepeez.io/api/v1/series?match[]=probe_success&start=1554912065&end=1554913865`
but grafana can't display the result.

in the browser console I have the following message:
<img width="936" alt="Screenshot 2019-04-10 at 18 57 05" src="https://user-images.githubusercontent.com/3831949/55898243-779be800-5bc2-11e9-9192-3f0551956785.png">

@trickster-reviewers