### PR TITLE
PromSim parameter fix

### DIFF
--- a/pkg/promsim/http_server.go
+++ b/pkg/promsim/http_server.go
@@ -97,10 +97,14 @@ func queryHandler(w http.ResponseWriter, r *http.Request) {
 	t := params.Get("time")
 
 	if q != "" {
-		tm, err := parseTime(t)
-		if err != nil {
-			writeError(http.StatusBadRequest, []byte("unable to parse time parameter"), w)
-			return
+		tm := time.Now()
+		if t != "" {
+			var err error
+			tm, err = parseTime(t)
+			if err != nil {
+				writeError(http.StatusBadRequest, []byte("unable to parse time parameter"), w)
+				return
+			}
 		}
 
 		json, code, _ := GetInstantData(q, tm)


### PR DESCRIPTION
on requests to /query, the time parameter is optional and should default time to Now() instead of returning an error if missing