### PR TITLE
Support Multi-Origin in the Helm Chart

### DIFF
--- a/deploy/helm/trickster/README.md
+++ b/deploy/helm/trickster/README.md
@@ -46,6 +46,7 @@ Parameter | Description | Default
 `persistentVolume.size` | trickster data Persistent Volume size | `15Gi`
 `persistentVolume.storageClass` | trickster data Persistent Volume Storage Class | `unset`
 `podAnnotations` | annotations to be added to trickster pods | `{}`
+`rawOrigins` | manual origin TOML segment to provide the trickster configmap | `""`
 `replicaCount` | desired number of trickster pods | `1`
 `statefulSet.enabled` | If true, use a statefulset instead of a deployment for pod management | `false`
 `priorityClassName` | trickster priorityClassName | `nil`

--- a/deploy/helm/trickster/templates/configmap.yaml
+++ b/deploy/helm/trickster/templates/configmap.yaml
@@ -57,7 +57,7 @@ data:
             # default is 'trickster'
             bucket = {{ .Values.config.cache.boltdb.bucket | quote }}
             {{- end }}
-		{{- if not .Values.rawOrigins }}
+    {{- if not .Values.rawOrigins }}
     # Configuration options for mapping Origin(s)
     [origins]
 

--- a/deploy/helm/trickster/templates/configmap.yaml
+++ b/deploy/helm/trickster/templates/configmap.yaml
@@ -57,7 +57,7 @@ data:
             # default is 'trickster'
             bucket = {{ .Values.config.cache.boltdb.bucket | quote }}
             {{- end }}
-
+		{{- if not .Values.rawOrigins }}
     # Configuration options for mapping Origin(s)
     [origins]
 
@@ -92,6 +92,9 @@ data:
             #default_step = 300
             #ignore_no_cache_header = false
             #max_value_age_secs = 86400
+      {{- else }}
+      {{ .Values.rawOrigins | nindent 2 }}
+      {{- end }}
 
     # Configuration Options for Metrics Instrumentation
     [metrics]
@@ -109,3 +112,4 @@ data:
         # log_file defines the file location to store logs. These will be auto-rolled and maintained for you.
         # not specifying a log_file (this is the default behavior) will print logs to STDOUT
         #log_file = '/some/path/to/trickster.log'
+

--- a/deploy/helm/trickster/values.yaml
+++ b/deploy/helm/trickster/values.yaml
@@ -37,32 +37,12 @@ config:
   fastForwardDisable: false
   logLevel: info
 
-## rawConfig - Provide a trickster config via values.yaml to pass
-## through to the pod.
-rawOrigins: |
-      [origins]
-        # default origin
-        [origins.default]
-            origin_url = 'http://preview-prometheus-server.management-api-preview.svc.cluster.local'
-            api_path = '/api/v1'
-            default_step = 300
-            ignore_no_cache_header = false
-            max_value_age_secs = 86400
-        # "preview" origin
-        [origins.preview]
-            origin_url = 'http://preview-prometheus-server.management-api-preview.svc.cluster.local'
-            api_path = '/api/v1'
-            default_step = 300
-            ignore_no_cache_header = false
-            max_value_age_secs = 86400
-        # "dev" origin
-        [origins.dev]
-            origin_url = 'http://dev-prometheus-server.management-api-dev.svc.cluster.local'
-            api_path = '/api/v1'
-            default_step = 300
-            ignore_no_cache_header = false
-            max_value_age_secs = 86400
-
+## rawConfig - Provide a trickster origins config segment via values.yaml to pass
+## through to the pod. see the code example here:
+## https://github.com/Comcast/trickster/blob/master/docs/multi-origin.md#path-and-url-param-configurations
+## Note, the entire origins block must be provided, in perpetuity, when using
+## this configuration option.
+rawOrigins: ""
 
 ## trickster priorityClassName
 ##

--- a/deploy/helm/trickster/values.yaml
+++ b/deploy/helm/trickster/values.yaml
@@ -37,6 +37,33 @@ config:
   fastForwardDisable: false
   logLevel: info
 
+## rawConfig - Provide a trickster config via values.yaml to pass
+## through to the pod.
+rawOrigins: |
+      [origins]
+        # default origin
+        [origins.default]
+            origin_url = 'http://preview-prometheus-server.management-api-preview.svc.cluster.local'
+            api_path = '/api/v1'
+            default_step = 300
+            ignore_no_cache_header = false
+            max_value_age_secs = 86400
+        # "preview" origin
+        [origins.preview]
+            origin_url = 'http://preview-prometheus-server.management-api-preview.svc.cluster.local'
+            api_path = '/api/v1'
+            default_step = 300
+            ignore_no_cache_header = false
+            max_value_age_secs = 86400
+        # "dev" origin
+        [origins.dev]
+            origin_url = 'http://dev-prometheus-server.management-api-dev.svc.cluster.local'
+            api_path = '/api/v1'
+            default_step = 300
+            ignore_no_cache_header = false
+            max_value_age_secs = 86400
+
+
 ## trickster priorityClassName
 ##
 priorityClassName: ""


### PR DESCRIPTION
I'm not positive of the consequences of how i've implemented this. We're going
to be using a trickster multi-origin deployment, and the chart was the fastest
way to get this up and running in our use-case. However the chart doesn't seem
to support multi-origin out of the box.

I had the idea to just provide an override configmap name, to eschew any
unintended side-effects of the template hacking i've done, but decided it might
be best as a first iteration to shop a "pass-through" config and see how it would
be received, as it's then all provided by the helm chart and not a one-off manifest
that an operator would have to deal with. But i can see negatives to both approaches.


with what i'm proposing, to configure multi-origin would look similar to the following:

```
rawOrigins: |                                                                   
 [origins]                                                                      
    [origins.default]                                                           
        origin_url = 'http://preview-prometheus-server.management-api-preview.svc.cluster.local'
        api_path = '/api/v1'                                                    
        default_step = 300                                                      
        ignore_no_cache_header = false                                          
        max_value_age_secs = 86400                                              
    [origins.preview]                                                           
        origin_url = 'http://preview-prometheus-server.management-api-preview.svc.cluster.local'
        api_path = '/api/v1'                                                    
        default_step = 300                                                      
        ignore_no_cache_header = false                                          
        max_value_age_secs = 86400                                              
    [origins.dev]                                                               
        origin_url = 'http://dev-prometheus-server.management-api-dev.svc.cluster.local'
        api_path = '/api/v1'                                                    
        default_step = 300                                                      
        ignore_no_cache_header = false                                          
        max_value_age_secs = 86400   
```

I'm happy to refactor with guidance on what's a desireable outcome.
