### PR TITLE
Add IRONdb origin fetch API support

### DIFF
--- a/internal/proxy/engines/deltaproxycache.go
+++ b/internal/proxy/engines/deltaproxycache.go
@@ -205,6 +205,7 @@ func DeltaProxyCacheRequest(r *model.Request, w http.ResponseWriter, client mode
 					return
 				}
 				uncachedValueCount += nts.ValueCount()
+				nts.SetStep(trq.Step)
 				nts.SetExtents([]timeseries.Extent{*e})
 				appendLock.Lock()
 				defer appendLock.Unlock()

--- a/internal/proxy/errors/errors.go
+++ b/internal/proxy/errors/errors.go
@@ -53,3 +53,15 @@ func InvalidPath(path string) error {
 func ParseDuration(input string) (time.Duration, error) {
 	return time.Duration(0), fmt.Errorf("unable to parse duration: %s", input)
 }
+
+// ParseRequestBody returns an error indicating the request body could not
+// parsed into a valid value.
+func ParseRequestBody(err error) error {
+	return fmt.Errorf("unable to parse request body: %v", err)
+}
+
+// MissingRequestParam returns an error indicating the request is missing a
+// required parameter.
+func MissingRequestParam(param string) error {
+	return fmt.Errorf("missing request parameter: %s", param)
+}

--- a/internal/proxy/errors/errors_test.go
+++ b/internal/proxy/errors/errors_test.go
@@ -54,3 +54,31 @@ func TestParseDurationError(t *testing.T) {
 func ParseDurationError(input string) (time.Duration, error) {
 	return time.Duration(0), fmt.Errorf("unable to parse duration: %s", input)
 }
+
+func TestNotTimeRangeQuery(t *testing.T) {
+	err := NotTimeRangeQuery()
+	if err.Error() != "not a time range query" {
+		t.Errorf("ErrorParseDuration failed, got: %v", err.Error())
+	}
+}
+
+func TestInvalidPath(t *testing.T) {
+	err := InvalidPath("test")
+	if err.Error() != "invalid request path: test" {
+		t.Errorf("ErrorInvalidPath failed, got: %v", err.Error())
+	}
+}
+
+func TestParseRequestBody(t *testing.T) {
+	err := ParseRequestBody(fmt.Errorf("test"))
+	if err.Error() != "unable to parse request body: test" {
+		t.Errorf("ErrorParseDuration failed, got: %v", err.Error())
+	}
+}
+
+func TestMissingRequestParam(t *testing.T) {
+	err := MissingRequestParam("test")
+	if err.Error() != "missing request parameter: test" {
+		t.Errorf("ErrorMissingRequestParam failed, got: %v", err.Error())
+	}
+}

--- a/internal/proxy/origins/irondb/handler_fetch.go
+++ b/internal/proxy/origins/irondb/handler_fetch.go
@@ -1,0 +1,128 @@
+package irondb
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Comcast/trickster/internal/proxy/engines"
+	"github.com/Comcast/trickster/internal/proxy/errors"
+	"github.com/Comcast/trickster/internal/proxy/model"
+	"github.com/Comcast/trickster/internal/timeseries"
+	"github.com/Comcast/trickster/internal/util/md5"
+)
+
+// FetchHandler handles requests for numeric timeseries data with specified
+// spans and processes them through the delta proxy cache.
+func (c *Client) FetchHandler(w http.ResponseWriter, r *http.Request) {
+	u := c.BuildUpstreamURL(r)
+	engines.DeltaProxyCacheRequest(
+		model.NewRequest(c.name, otIRONdb, "FetchHandler",
+			r.Method, u, r.Header, c.config.Timeout, r, c.webClient),
+		w, c, c.cache, c.cache.Configuration().TimeseriesTTL)
+}
+
+// fetchHandlerSetExtent will change the upstream request query to use the
+// provided Extent.
+func (c Client) fetchHandlerSetExtent(r *model.Request,
+	extent *timeseries.Extent) {
+	trq := r.TimeRangeQuery
+	var err error
+	if trq == nil {
+		if trq, err = c.ParseTimeRangeQuery(r); err != nil {
+			return
+		}
+	}
+
+	b, err := ioutil.ReadAll(r.ClientRequest.Body)
+	if err != nil {
+		return
+	}
+
+	fetchReq := map[string]interface{}{}
+	if err = json.NewDecoder(bytes.NewBuffer(b)).Decode(&fetchReq); err != nil {
+		return
+	}
+
+	st := extent.Start.UnixNano() - (extent.Start.UnixNano() % int64(trq.Step))
+	et := extent.End.UnixNano() - (extent.End.UnixNano() % int64(trq.Step))
+	if st == et {
+		et += int64(trq.Step)
+	}
+
+	ct := (et - st) / int64(trq.Step)
+	fetchReq[rbStart] = time.Unix(0, st).Unix()
+	fetchReq[rbCount] = ct
+	newBody := &bytes.Buffer{}
+	err = json.NewEncoder(newBody).Encode(&fetchReq)
+	if err != nil {
+		return
+	}
+
+	r.ClientRequest.Body = ioutil.NopCloser(newBody)
+}
+
+// fetchHandlerParseTimeRangeQuery parses the key parts of a TimeRangeQuery
+// from the inbound HTTP Request.
+func (c *Client) fetchHandlerParseTimeRangeQuery(
+	r *model.Request) (*timeseries.TimeRangeQuery, error) {
+	trq := &timeseries.TimeRangeQuery{}
+	b, err := ioutil.ReadAll(r.ClientRequest.Body)
+	if err != nil {
+		return nil, errors.ParseRequestBody(err)
+	}
+
+	r.ClientRequest.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+	fetchReq := map[string]interface{}{}
+	if err = json.NewDecoder(bytes.NewBuffer(b)).Decode(&fetchReq); err != nil {
+		return nil, errors.ParseRequestBody(err)
+	}
+
+	i := float64(0)
+	var ok bool
+	if i, ok = fetchReq[rbStart].(float64); !ok {
+		return nil, errors.MissingRequestParam(rbStart)
+	}
+
+	trq.Extent.Start = time.Unix(int64(i), 0)
+	if i, ok = fetchReq[rbPeriod].(float64); !ok {
+		return nil, errors.MissingRequestParam(rbPeriod)
+	}
+
+	trq.Step = time.Second * time.Duration(i)
+	if i, ok = fetchReq[rbCount].(float64); !ok {
+		return nil, errors.MissingRequestParam(rbCount)
+	}
+
+	trq.Extent.End = trq.Extent.Start.Add(trq.Step * time.Duration(i))
+	return trq, nil
+}
+
+// fetchHandlerDeriveCacheKey calculates a query-specific keyname based on the
+// user request.
+func (c Client) fetchHandlerDeriveCacheKey(r *model.Request,
+	extra string) string {
+	var sb strings.Builder
+	sb.WriteString(r.URL.Path)
+	newBody := &bytes.Buffer{}
+	if b, err := ioutil.ReadAll(r.ClientRequest.Body); err == nil {
+		r.ClientRequest.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+		fetchReq := map[string]interface{}{}
+		err := json.NewDecoder(bytes.NewBuffer(b)).Decode(&fetchReq)
+		if err == nil {
+			delete(fetchReq, "start")
+			delete(fetchReq, "end")
+			delete(fetchReq, "count")
+			err = json.NewEncoder(newBody).Encode(&fetchReq)
+			if err == nil {
+				sb.Write(newBody.Bytes())
+			}
+		}
+	}
+
+	sb.WriteString(extra)
+	return md5.Checksum(sb.String())
+}

--- a/internal/proxy/origins/irondb/handler_fetch_test.go
+++ b/internal/proxy/origins/irondb/handler_fetch_test.go
@@ -10,7 +10,7 @@ import (
 	tu "github.com/Comcast/trickster/internal/util/testing"
 )
 
-func TestHistogramHandler(t *testing.T) {
+func TestFetchHandler(t *testing.T) {
 	es := tu.NewTestServer(200, "{}")
 	defer es.Close()
 	err := config.Load("trickster", "test",
@@ -29,8 +29,8 @@ func TestHistogramHandler(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET",
-		"http://0/histogram/0/900/300/00112233-4455-6677-8899-aabbccddeeff/"+
-			"metric", nil)
+		"http://0/rollup/00112233-4455-6677-8899-aabbccddeeff/metric"+
+			"?start_ts=0&end_ts=900&rollup_span=300s&type=average", nil)
 	client := &Client{
 		name:      "default",
 		config:    config.Origins["default"],
@@ -38,7 +38,7 @@ func TestHistogramHandler(t *testing.T) {
 		webClient: tu.NewTestWebClient(),
 	}
 
-	client.HistogramHandler(w, r)
+	client.FetchHandler(w, r)
 	resp := w.Result()
 
 	// it should return 200 OK
@@ -47,28 +47,6 @@ func TestHistogramHandler(t *testing.T) {
 	}
 
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if string(bodyBytes) != "{}" {
-		t.Errorf("expected '{}' got %s.", bodyBytes)
-	}
-
-	w = httptest.NewRecorder()
-	r = httptest.NewRequest("GET",
-		"http://0/irondb/histogram/0/900/300/"+
-			"00112233-4455-6677-8899-aabbccddeeff/"+
-			"metric", nil)
-	client.HistogramHandler(w, r)
-	resp = w.Result()
-
-	// it should return 200 OK
-	if resp.StatusCode != 200 {
-		t.Errorf("expected 200 got %d.", resp.StatusCode)
-	}
-
-	bodyBytes, err = ioutil.ReadAll(resp.Body)
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/proxy/origins/irondb/handler_rollup.go
+++ b/internal/proxy/origins/irondb/handler_rollup.go
@@ -37,6 +37,10 @@ func (c Client) rollupHandlerSetExtent(r *model.Request,
 
 	st := extent.Start.UnixNano() - (extent.Start.UnixNano() % int64(trq.Step))
 	et := extent.End.UnixNano() - (extent.End.UnixNano() % int64(trq.Step))
+	if st == et {
+		et += int64(trq.Step)
+	}
+
 	q := r.URL.Query()
 	q.Set(upStart, formatTimestamp(time.Unix(0, st), true))
 	q.Set(upEnd, formatTimestamp(time.Unix(0, et), true))

--- a/internal/proxy/origins/irondb/irondb.go
+++ b/internal/proxy/origins/irondb/irondb.go
@@ -20,6 +20,7 @@ const (
 	mnHealth    = "health"
 	mnRaw       = "raw"
 	mnRollup    = "rollup"
+	mnFetch     = "fetch"
 	mnRead      = "read"
 	mnHistogram = "histogram"
 	mnFind      = "find"
@@ -39,9 +40,17 @@ const (
 	upType       = "type"
 	upActStart   = "activity_start_seconds"
 	upActEnd     = "activity_end_seconds"
+	upCAQLQuery  = "q"
 	upCAQLStart  = "start"
 	upCAQLEnd    = "end"
 	upCAQLPeriod = "period"
+)
+
+// IRONdb request body field names.
+const (
+	rbStart  = "start"
+	rbCount  = "count"
+	rbPeriod = "period"
 )
 
 // Client values provide access to IRONdb and implement the Trickster proxy

--- a/internal/proxy/origins/irondb/key.go
+++ b/internal/proxy/origins/irondb/key.go
@@ -18,6 +18,8 @@ func (c Client) DeriveCacheKey(r *model.Request, extra string) string {
 		return c.rawHandlerDeriveCacheKey(r, extra)
 	case "RollupHandler":
 		return c.rollupHandlerDeriveCacheKey(r, extra)
+	case "FetchHandler":
+		return c.fetchHandlerDeriveCacheKey(r, extra)
 	case "TextHandler":
 		return c.textHandlerDeriveCacheKey(r, extra)
 	default:

--- a/internal/proxy/origins/irondb/model.go
+++ b/internal/proxy/origins/irondb/model.go
@@ -322,7 +322,7 @@ func (c *Client) MarshalTimeseries(ts timeseries.Timeseries) ([]byte, error) {
 // UnmarshalTimeseries converts a JSON blob into a Timeseries value.
 func (c *Client) UnmarshalTimeseries(data []byte) (timeseries.Timeseries,
 	error) {
-	if strings.Contains(strings.ReplaceAll(string(data), " ", ""),
+	if strings.Contains(strings.Replace(string(data), " ", "", -1),
 		`"version":"DF4"`) {
 		se := &DF4SeriesEnvelope{}
 		err := json.Unmarshal(data, &se)

--- a/internal/proxy/origins/irondb/model_df4.go
+++ b/internal/proxy/origins/irondb/model_df4.go
@@ -237,7 +237,7 @@ func (se *DF4SeriesEnvelope) CropToRange(e timeseries.Extent) {
 	newData := [][]interface{}{}
 	newMeta := []map[string]interface{}{}
 	newHead := DF4Info{
-		Count:  (e.End.Unix()-e.Start.Unix())/se.Head.Period + 1,
+		Count:  (e.End.Unix() - e.Start.Unix()) / se.Head.Period,
 		Start:  e.Start.Unix(),
 		Period: se.Head.Period,
 	}
@@ -266,7 +266,7 @@ func (se *DF4SeriesEnvelope) CropToRange(e timeseries.Extent) {
 // during crop.
 func (se *DF4SeriesEnvelope) CropToSize(sz int, t time.Time,
 	lur timeseries.Extent) {
-	// The Series has no extents, so no need to do anything
+	// The Series has no extents, so no need to do anything.
 	if len(se.ExtentList) < 1 {
 		se.Data = [][]interface{}{}
 		se.Meta = []map[string]interface{}{}

--- a/internal/proxy/origins/irondb/model_df4_test.go
+++ b/internal/proxy/origins/irondb/model_df4_test.go
@@ -76,16 +76,7 @@ const testDF4Response2 = `{
 `
 
 func TestDF4SeriesEnvelopeSetStep(t *testing.T) {
-	se := SeriesEnvelope{}
-	const step = time.Duration(300) * time.Minute
-	se.SetStep(step)
-	if se.StepDuration != step {
-		t.Errorf("Expected step: %v, got: %v", step, se.StepDuration)
-	}
-}
-
-func TestDF4SeriesEnvelopeStep(t *testing.T) {
-	se := SeriesEnvelope{}
+	se := DF4SeriesEnvelope{}
 	const step = time.Duration(300) * time.Minute
 	se.SetStep(step)
 	if se.Step() != step {
@@ -94,20 +85,7 @@ func TestDF4SeriesEnvelopeStep(t *testing.T) {
 }
 
 func TestDF4SeriesEnvelopeSetExtents(t *testing.T) {
-	se := &SeriesEnvelope{}
-	ex := timeseries.ExtentList{timeseries.Extent{
-		Start: time.Time{},
-		End:   time.Time{},
-	}}
-
-	se.SetExtents(ex)
-	if len(se.ExtentList) != 1 {
-		t.Errorf("Expected length: 1, got: %d", len(se.ExtentList))
-	}
-}
-
-func TestDF4SeriesEnvelopeExtents(t *testing.T) {
-	se := &SeriesEnvelope{}
+	se := &DF4SeriesEnvelope{}
 	ex := timeseries.ExtentList{timeseries.Extent{
 		Start: time.Time{},
 		End:   time.Time{},
@@ -249,9 +227,9 @@ func TestDF4SeriesEnvelopeCropToRange(t *testing.T) {
 		return
 	}
 
-	exp := `{"data":[[1,2]],"meta":[{"kind":"numeric","label":"test",` +
+	exp := `{"data":[[1]],"meta":[{"kind":"numeric","label":"test",` +
 		`"tags":["__check_uuid:11223344-5566-7788-9900-aabbccddeeff",` +
-		`"__name:test"]}],"version":"DF4","head":{"count":2,"start":0,` +
+		`"__name:test"]}],"version":"DF4","head":{"count":1,"start":0,` +
 		`"period":300},"extents":[{"start":"` +
 		time.Unix(0, 0).Format(time.RFC3339) +
 		`","end":"` + time.Unix(300, 0).Format(time.RFC3339) + `"}]}`
@@ -351,8 +329,8 @@ func TestMarshalDF4Timeseries(t *testing.T) {
 		return
 	}
 
-	exp := strings.ReplaceAll(strings.ReplaceAll(testDF4Response, "\n", ""),
-		" ", "")
+	exp := strings.Replace(strings.Replace(testDF4Response, "\n", "", -1),
+		" ", "", -1)
 	if string(bytes) != exp {
 		t.Errorf("Expected JSON: %s, got: %s", exp, string(bytes))
 	}

--- a/internal/proxy/origins/irondb/routes.go
+++ b/internal/proxy/origins/irondb/routes.go
@@ -23,6 +23,8 @@ func (c *Client) RegisterRoutes(originName string, o *config.OriginConfig) {
 		HandlerFunc(c.RawHandler).Methods("GET").Host(originName)
 	routing.Router.PathPrefix(prefix + mnRollup).
 		HandlerFunc(c.RollupHandler).Methods("GET").Host(originName)
+	routing.Router.PathPrefix(prefix + mnFetch).
+		HandlerFunc(c.FetchHandler).Methods("POST").Host(originName)
 	routing.Router.PathPrefix(prefix + mnRead).
 		HandlerFunc(c.TextHandler).Methods("GET").Host(originName)
 	routing.Router.PathPrefix(prefix + mnHistogram).
@@ -45,6 +47,8 @@ func (c *Client) RegisterRoutes(originName string, o *config.OriginConfig) {
 		HandlerFunc(c.RawHandler).Methods("GET")
 	routing.Router.PathPrefix("/" + originName + prefix + mnRollup).
 		HandlerFunc(c.RollupHandler).Methods("GET")
+	routing.Router.PathPrefix("/" + originName + prefix + mnFetch).
+		HandlerFunc(c.FetchHandler).Methods("POST")
 	routing.Router.PathPrefix("/" + originName + prefix + mnRead).
 		HandlerFunc(c.TextHandler).Methods("GET")
 	routing.Router.PathPrefix("/" + originName + prefix + mnHistogram).
@@ -68,8 +72,10 @@ func (c *Client) RegisterRoutes(originName string, o *config.OriginConfig) {
 			HandlerFunc(c.HealthHandler).Methods("GET")
 		routing.Router.PathPrefix(prefix + mnRaw).
 			HandlerFunc(c.RawHandler).Methods("GET")
-		routing.Router.PathPrefix(prefix + mnRollup + "/").
+		routing.Router.PathPrefix(prefix + mnRollup).
 			HandlerFunc(c.RollupHandler).Methods("GET")
+		routing.Router.PathPrefix(prefix + mnFetch).
+			HandlerFunc(c.FetchHandler).Methods("POST")
 		routing.Router.PathPrefix(prefix + mnRead).
 			HandlerFunc(c.TextHandler).Methods("GET")
 		routing.Router.PathPrefix(prefix + mnHistogram).

--- a/internal/proxy/origins/irondb/url.go
+++ b/internal/proxy/origins/irondb/url.go
@@ -47,6 +47,8 @@ func (c Client) SetExtent(r *model.Request, extent *timeseries.Extent) {
 		c.rawHandlerSetExtent(r, extent)
 	case "RollupHandler":
 		c.rollupHandlerSetExtent(r, extent)
+	case "FetchHandler":
+		c.fetchHandlerSetExtent(r, extent)
 	case "TextHandler":
 		c.textHandlerSetExtent(r, extent)
 	case "HistogramHandler":
@@ -110,6 +112,10 @@ func parseTimestamp(s string) (time.Time, error) {
 // parseDuration attempts to parse an IRONdb API duration string into a valid
 // duration value.
 func parseDuration(s string) (time.Duration, error) {
+	if !strings.HasSuffix(s, "s") {
+		s += "s"
+	}
+
 	d, err := time.ParseDuration(s)
 	if err != nil {
 		return 0, fmt.Errorf("unable to parse duration %s: %s",
@@ -128,6 +134,8 @@ func (c *Client) ParseTimeRangeQuery(
 		return c.rawHandlerParseTimeRangeQuery(r)
 	case "RollupHandler":
 		return c.rollupHandlerParseTimeRangeQuery(r)
+	case "FetchHandler":
+		return c.fetchHandlerParseTimeRangeQuery(r)
 	case "TextHandler":
 		return c.textHandlerParseTimeRangeQuery(r)
 	case "HistogramHandler":


### PR DESCRIPTION
- Adds origin handler support for the IRONdb /fetch API.
- That API uses POST requests, so handling of client request body support is added.
- Fixes issues with cache key generation preventing IRONdb CAQL requests from using the delta cache properly.
- Fixes an issue with time request query parsing for IRONdb histogram requests.
- Fixes an issue preventing proper delta cache utilization for IRONdb rollup requests involving requests for time ranges with the same start and end times.