### PR TITLE
Add deletes counter metrics

### DIFF
--- a/internal/cache/badger/badger.go
+++ b/internal/cache/badger/badger.go
@@ -90,6 +90,7 @@ func (c *Cache) Remove(cacheKey string) {
 	c.dbh.Update(func(txn *badger.Txn) error {
 		return txn.Delete([]byte(cacheKey))
 	})
+	cache.ObserveCacheDel(c.Name, c.Config.Type, 0)
 }
 
 // BulkRemove removes a list of objects from the cache. noLock is not used for Badger
@@ -101,6 +102,7 @@ func (c *Cache) BulkRemove(cacheKeys []string, noLock bool) {
 			if err := txn.Delete([]byte(key)); err != nil {
 				return err
 			}
+			cache.ObserveCacheDel(c.Name, c.Config.Type, 0)
 		}
 		return nil
 	})

--- a/internal/cache/bbolt/bbolt.go
+++ b/internal/cache/bbolt/bbolt.go
@@ -152,6 +152,7 @@ func (c *Cache) remove(cacheKey string) error {
 		log.Error("bbolt cache key delete failure", log.Pairs{"cacheKey": cacheKey, "reason": err.Error()})
 		return err
 	}
+	cache.ObserveCacheDel(c.Name, c.Config.Type, 0)
 	log.Debug("bbolt cache key delete", log.Pairs{"key": cacheKey})
 	return nil
 }

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -86,6 +86,11 @@ func ObserveCacheMiss(cacheKey, cacheName, cacheType string) ([]byte, error) {
 	return nil, fmt.Errorf("value  for key [%s] not in cache", cacheKey)
 }
 
+// ObserveCacheDel records a cache deletion event
+func ObserveCacheDel(cache, cacheType string, count float64) {
+	ObserveCacheOperation(cache, cacheType, "del", "none", count)
+}
+
 // CacheError returns an empty cache object and the formatted error
 func CacheError(cacheKey, cacheName, cacheType string, msg string) ([]byte, error) {
 	ObserveCacheEvent(cacheName, cacheType, "error", msg)

--- a/internal/cache/filesystem/filesystem.go
+++ b/internal/cache/filesystem/filesystem.go
@@ -137,17 +137,13 @@ func (c *Cache) Remove(cacheKey string) {
 	if err := os.Remove(c.getFileName(cacheKey)); err == nil {
 		c.Index.RemoveObject(cacheKey, false)
 	}
+	cache.ObserveCacheDel(c.Name, c.Config.Type, 0)
 }
 
 // BulkRemove removes a list of objects from the cache
 func (c *Cache) BulkRemove(cacheKeys []string, noLock bool) {
 	for _, cacheKey := range cacheKeys {
-		locks.Acquire(lockPrefix + cacheKey)
-		defer locks.Release(lockPrefix + cacheKey)
-
-		if err := os.Remove(c.getFileName(cacheKey)); err == nil {
-			c.Index.RemoveObject(cacheKey, noLock)
-		}
+		c.Remove(cacheKey)
 	}
 }
 

--- a/internal/cache/memory/memory.go
+++ b/internal/cache/memory/memory.go
@@ -77,13 +77,13 @@ func (c *Cache) Retrieve(cacheKey string) ([]byte, error) {
 func (c *Cache) Remove(cacheKey string) {
 	c.client.Delete(cacheKey)
 	c.Index.RemoveObject(cacheKey, false)
+	cache.ObserveCacheDel(c.Name, c.Config.Type, 0)
 }
 
 // BulkRemove removes a list of objects from the cache
 func (c *Cache) BulkRemove(cacheKeys []string, noLock bool) {
 	for _, cacheKey := range cacheKeys {
-		c.client.Delete(cacheKey)
-		c.Index.RemoveObject(cacheKey, noLock)
+		c.Remove(cacheKey)
 	}
 }
 

--- a/internal/cache/redis/redis.go
+++ b/internal/cache/redis/redis.go
@@ -101,12 +101,14 @@ func (c *Cache) Retrieve(cacheKey string) ([]byte, error) {
 func (c *Cache) Remove(cacheKey string) {
 	log.Debug("redis cache remove", log.Pairs{"key": cacheKey})
 	c.removeFunc(cacheKey)
+	cache.ObserveCacheDel(c.Name, c.Config.Type, 0)
 }
 
 // BulkRemove removes a list of objects from the cache. noLock is not used for Redis
 func (c *Cache) BulkRemove(cacheKeys []string, noLock bool) {
 	log.Debug("redis cache bulk remove", log.Pairs{})
 	c.bulkRemoveFunc(cacheKeys, noLock)
+	cache.ObserveCacheDel(c.Name, c.Config.Type, float64(len(cacheKeys)))
 }
 
 // Close disconnects from the Redis Cache


### PR DESCRIPTION
While checking for bolt specific metrics I noticed that trickster is not accounting for how many cache keys are being deleted, and I think it's an interesting metric to be aware of.