### PR TITLE
Adds support to de-couple cache from origins

### DIFF
--- a/deploy/helm/trickster/templates/configmap.yaml
+++ b/deploy/helm/trickster/templates/configmap.yaml
@@ -229,7 +229,14 @@ data:
     {{- range .Values.origins }}
         {{ printf "[origins.%s]" .name }}
         type = {{ .type | quote }}
+        {{- if .isDefault }}
+        is_default = {{ .isDefault }}
+        {{- end }}
+        {{- if .cacheName }}
+        cache_name = {{ .cacheName | quote }}
+        {{- else }}
         cache_name = {{ .name | quote }}
+        {{- end }}
         scheme = {{ .scheme | quote }}
         host = {{ .host | quote }}
         path_prefix = {{ .pathPrefix | quote }}

--- a/deploy/helm/trickster/values.yaml
+++ b/deploy/helm/trickster/values.yaml
@@ -37,6 +37,8 @@ caches:
 
 origins:
   - name: default
+    isDefault: true
+    cacheName: 'default'
     type: prometheus
     scheme: http
     host: 'prometheus:9090'


### PR DESCRIPTION
- Adds an 'is_default' parameter during the template generator. the if
  guards prevent the key from being rendered on non-declared origins.
- Adds a cacheName parameter during generation to remove the tightly
  coupled cache/origin assumption in the chart. Defaults to the existing
  behavior of desiring a cacheName that matches the origin monicker.

Note: Still needs a README update, but it didn't look like all the
origin values are documented yet. The values are optional, but i declared them in the base values.yaml to illustrate their usage. I'm happy to circle back and document the origin datapoints in the table or as a blurb. Just advise on what would be a more useful contribution.