### PR TITLE
Update the Healthcheck and auto-roll on configmap update

### DIFF
--- a/deploy/helm/trickster/templates/deployment.yaml
+++ b/deploy/helm/trickster/templates/deployment.yaml
@@ -22,6 +22,8 @@ spec:
       labels:
         app: {{ template "trickster.name" . }}
         release: {{ .Release.Name }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       containers:
         - name: trickster
@@ -43,7 +45,7 @@ spec:
               port: http
           readinessProbe:
             httpGet:
-              path: /health
+              path: /trickster/ping
               port: http
           resources:
 {{ toYaml .Values.resources | indent 12 }}


### PR DESCRIPTION
I isolated these changes as they ship with some behavior changes from what exists today:

- Adds the magic shebang to trigger a rollout on configmap update. Uses
  the helm sha256 sum crc as an annotation.

- A potential controversial update to the healthcheck. I noticed in
  multi-origin deployments that trickster would fail to pass its
  readiness check. This is due to how trickster itself passes the /health check
  to the "default origin" in all cases. if the default is down, or
  otherwise misconfigured (or missing!) the healthcheck will fail and
  trickster will never enter a ready state. This caused a lot of confusion and some healthy debugging.

I discovered the second point quite by accident as rolling from a single origin to multi-origin broke in very interesting ways with the state of the chart in the next branch. I've carried these patches locally in our tracking fork - so i hope these are useful additions. Combined with #264 for how vapor.io is using trickster to monitor autonomous colocation facilities. Scraping somewhere around 6000 data-points of metrics a second per site and cached with trickster to keep the visuals snappy. :bowing_man: 