### PR TITLE
Add proxy connections limit

### DIFF
--- a/cmd/trickster/conf/example.conf
+++ b/cmd/trickster/conf/example.conf
@@ -12,6 +12,10 @@ listen_port = 9090
 # listen_address defines the ip on which Trickster's Proxy server listens.
 # empty by default, listening on all interfaces
 # listen_address = ''
+# connections_limit defines the maximum number of concurrent connections
+# Trickster's Proxy server may handle at any time.
+# 0 by default, unlimited.
+# connections_limit = 0
 
 [caches]
 

--- a/cmd/trickster/main.go
+++ b/cmd/trickster/main.go
@@ -21,6 +21,7 @@ import (
 
 	cr "github.com/Comcast/trickster/internal/cache/registration"
 	"github.com/Comcast/trickster/internal/config"
+	"github.com/Comcast/trickster/internal/proxy"
 	th "github.com/Comcast/trickster/internal/proxy/handlers"
 	"github.com/Comcast/trickster/internal/routing"
 	rr "github.com/Comcast/trickster/internal/routing/registration"
@@ -66,9 +67,12 @@ func main() {
 		log.Fatal(1, err.Error(), log.Pairs{})
 	}
 
-	log.Info("proxy http endpoint starting", log.Pairs{"address": config.ProxyServer.ListenAddress, "port": config.ProxyServer.ListenPort})
-
 	// Start the Server
-	err = http.ListenAndServe(fmt.Sprintf("%s:%d", config.ProxyServer.ListenAddress, config.ProxyServer.ListenPort), handlers.CompressHandler(routing.Router))
+	l, err := proxy.NewListener(config.ProxyServer.ListenAddress, config.ProxyServer.ListenPort,
+		config.ProxyServer.ConnectionsLimit)
+
+	if err == nil {
+		err = http.Serve(l, handlers.CompressHandler(routing.Router))
+	}
 	log.Error("exiting", log.Pairs{"err": err})
 }

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/tinylib/msgp v1.1.0
 	github.com/yuin/gopher-lua v0.0.0-20190206043414-8bfc7677f583 // indirect
 	go.etcd.io/bbolt v1.3.2 // indirect
+	golang.org/x/net v0.0.0-20181201002055-351d144fa1fc
 	golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -212,6 +212,8 @@ type ProxyServerConfig struct {
 	ListenAddress string `toml:"listen_address"`
 	// ListenPort is TCP Port for the main http listener for the application
 	ListenPort int `toml:"listen_port"`
+	// ConnectionsLimit indicates how many concurrent front end connections trickster will handle at any time
+	ConnectionsLimit int `toml:"connections_limit"`
 }
 
 // LoggingConfig is a collection of Logging configurations

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Comcast/trickster/internal/util/metrics"
 )
 
-// NewListener create a new network listener wich obeys to the configuration max
+// NewListener create a new network listener which obeys to the configuration max
 // connection limit, and also monitors connections with prometheus metrics.
 //
 // The way this works is by creating a listener and wrapping it with a

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1,0 +1,85 @@
+package proxy
+
+import (
+	"fmt"
+	"net"
+
+	"golang.org/x/net/netutil"
+
+	"github.com/Comcast/trickster/internal/util/log"
+	"github.com/Comcast/trickster/internal/util/metrics"
+)
+
+// NewListener create a new network listener wich obeys to the configuration max
+// connection limit, and also monitors connections with prometheus metrics.
+//
+// The way this works is by creating a listener and wrapping it with a
+// netutil.LimitListener to set a limit.
+//
+// This limiter will simply block waiting for resources to become available
+// whenever clients go above the limit.
+//
+// To simplify settings limits the listener is wrapped with yet another object
+// which observes the connections to set a gauge with the current number of
+// connections (with operates with sampling through scrapes), and a set of
+// counter metrics for connections accepted, rejected and closed.
+func NewListener(listenAddress string, listenPort, connectionsLimit int) (net.Listener, error) {
+	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", listenAddress, listenPort))
+	if err != nil {
+		// so we can exit one level above, this usually means that the port is in use
+		return nil, err
+	}
+
+	log.Debug("starting http proxy listener", log.Pairs{
+		"connectionsLimit": connectionsLimit,
+		"address":          listenAddress,
+		"port":             listenPort,
+	})
+
+	if connectionsLimit > 0 {
+		listener = netutil.LimitListener(listener, connectionsLimit)
+		metrics.ProxyMaxConnections.Set(float64(connectionsLimit))
+	}
+
+	return &connectionsLimitObProxy{
+		listener,
+	}, nil
+}
+
+type connectionsLimitObProxy struct {
+	net.Listener
+}
+
+// Accept implements Listener.Accept
+func (l *connectionsLimitObProxy) Accept() (net.Conn, error) {
+
+	metrics.ProxyConnectionRequested.Inc()
+
+	c, err := l.Listener.Accept()
+	if err != nil {
+		// This generally happens when a connection gives up waiting for resources and
+		// just goes away on timeout, thus it's more of a client side error, which
+		// gets reflected on the server.
+		log.Debug("failed to accept client connection", log.Pairs{"reason": err})
+		metrics.ProxyConnectionFailed.Inc()
+		return c, err
+	}
+
+	metrics.ProxyActiveConnections.Inc()
+	metrics.ProxyConnectionAccepted.Inc()
+
+	return observedConnection{c}, nil
+}
+
+type observedConnection struct {
+	net.Conn
+}
+
+func (o observedConnection) Close() error {
+	err := o.Conn.Close()
+
+	metrics.ProxyActiveConnections.Dec()
+	metrics.ProxyConnectionClosed.Inc()
+
+	return err
+}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1,0 +1,98 @@
+package proxy_test
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Comcast/trickster/internal/config"
+	"github.com/Comcast/trickster/internal/proxy"
+	"github.com/Comcast/trickster/internal/routing"
+	"github.com/Comcast/trickster/internal/util/metrics"
+)
+
+func TestListenerConnectionLimitWorks(t *testing.T) {
+	metrics.Init() // For some reason I need to call it specifically
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		fmt.Fprint(w, "hello!")
+	}
+	es := httptest.NewServer(http.HandlerFunc(handler))
+	defer es.Close()
+
+	err := config.Load("trickster", "test", []string{"-origin", es.URL, "-origin-type", "prometheus"})
+	if err != nil {
+		t.Errorf("Could not load configuration: %s", err.Error())
+	}
+
+	tt := []struct {
+		Name             string
+		ListenPort       int
+		ConnectionsLimit int
+		Clients          int
+		expectedErr      string
+	}{
+		{
+			"Without connection limit",
+			34001,
+			0,
+			1,
+			"",
+		},
+		{
+			"With connection limit of 10",
+			34002,
+			10,
+			10,
+			"",
+		},
+		{
+			"With connection limit of 1, but with 10 clients",
+			34003,
+			1,
+			10,
+			"Get http://localhost:34003/: net/http: request canceled (Client.Timeout exceeded while awaiting headers)",
+		},
+	}
+
+	http.DefaultClient.Timeout = 100 * time.Millisecond
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			l, err := proxy.NewListener("", tc.ListenPort, tc.ConnectionsLimit)
+			defer l.Close()
+
+			go func() {
+				http.Serve(l, routing.Router)
+			}()
+
+			if err != nil {
+				t.Fatalf("failed to create listener: %s", err)
+			}
+
+			for i := 0; i < tc.Clients; i++ {
+				r, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:%d/", tc.ListenPort), nil)
+				if err != nil {
+					t.Fatalf("failed to create request: %s", err)
+				}
+				res, err := http.DefaultClient.Do(r)
+				if err != nil {
+					if fmt.Sprintf("%s", err) != tc.expectedErr {
+						t.Fatalf("unexpected error when executing request: %s", err)
+					}
+					continue
+				}
+				defer func() {
+					io.Copy(ioutil.Discard, res.Body)
+					res.Body.Close()
+				}()
+			}
+
+		})
+	}
+}

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -61,6 +61,24 @@ var CacheMaxObjects *prometheus.GaugeVec
 // CacheMaxBytes is a Gauge representing the Trickster cache's Max Object Threshold for triggering an eviction exercise
 var CacheMaxBytes *prometheus.GaugeVec
 
+// ProxyMaxConnections is a Gauge representing the max number of active concurrent connections in the server
+var ProxyMaxConnections prometheus.Gauge
+
+// ProxyActiveConnections is a Gauge representing the number of active connections in the server
+var ProxyActiveConnections prometheus.Gauge
+
+// ProxyConnectionRequested is a counter representing the total number of connections requested by clients to the Proxy
+var ProxyConnectionRequested prometheus.Counter
+
+// ProxyConnectionAccepted is a counter representing the total number of connections accepted by the Proxy
+var ProxyConnectionAccepted prometheus.Counter
+
+// ProxyConnectionClosed is a counter representing the total number of connections closed by the Proxy
+var ProxyConnectionClosed prometheus.Counter
+
+// ProxyConnectionFailed is a counter representing the total number of connections failed to connect for whatever reason
+var ProxyConnectionFailed prometheus.Counter
+
 // Init initializes the instrumented metrics and starts the listener endpoint
 func Init() {
 
@@ -93,6 +111,59 @@ func Init() {
 			Buckets:   []float64{0.05, 0.1, 0.5, 1, 5, 10, 20},
 		},
 		[]string{"origin_name", "origin_type", "method", "status", "http_status", "path"},
+	)
+
+	ProxyMaxConnections = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Subsystem: proxySubsystem,
+			Name:      "max_connections",
+			Help:      "Trickster max numer of active connections.",
+		},
+	)
+
+	ProxyActiveConnections = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Subsystem: proxySubsystem,
+			Name:      "active_connections",
+			Help:      "Trickster numer of active connections.",
+		},
+	)
+
+	ProxyConnectionRequested = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: proxySubsystem,
+			Name:      "requested_connections_total",
+			Help:      "Trickster total numer of connections requested by clients.",
+		},
+	)
+	ProxyConnectionAccepted = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: proxySubsystem,
+			Name:      "accepted_connections_total",
+			Help:      "Trickster total numer of accepted connections.",
+		},
+	)
+
+	ProxyConnectionClosed = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: proxySubsystem,
+			Name:      "closed_connections_total",
+			Help:      "Trickster total numer of closed connections.",
+		},
+	)
+
+	ProxyConnectionFailed = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: proxySubsystem,
+			Name:      "failed_connections_total",
+			Help:      "Trickster total numer of failed connections.",
+		},
 	)
 
 	CacheObjectOperations = prometheus.NewCounterVec(
@@ -169,6 +240,12 @@ func Init() {
 	prometheus.MustRegister(ProxyRequestStatus)
 	prometheus.MustRegister(ProxyRequestElements)
 	prometheus.MustRegister(ProxyRequestDuration)
+	prometheus.MustRegister(ProxyMaxConnections)
+	prometheus.MustRegister(ProxyActiveConnections)
+	prometheus.MustRegister(ProxyConnectionRequested)
+	prometheus.MustRegister(ProxyConnectionAccepted)
+	prometheus.MustRegister(ProxyConnectionClosed)
+	prometheus.MustRegister(ProxyConnectionFailed)
 	prometheus.MustRegister(CacheObjectOperations)
 	prometheus.MustRegister(CacheByteOperations)
 	prometheus.MustRegister(CacheEvents)

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -118,7 +118,7 @@ func Init() {
 			Namespace: metricNamespace,
 			Subsystem: proxySubsystem,
 			Name:      "max_connections",
-			Help:      "Trickster max numer of active connections.",
+			Help:      "Trickster max number of active connections.",
 		},
 	)
 
@@ -127,7 +127,7 @@ func Init() {
 			Namespace: metricNamespace,
 			Subsystem: proxySubsystem,
 			Name:      "active_connections",
-			Help:      "Trickster numer of active connections.",
+			Help:      "Trickster number of active connections.",
 		},
 	)
 
@@ -136,7 +136,7 @@ func Init() {
 			Namespace: metricNamespace,
 			Subsystem: proxySubsystem,
 			Name:      "requested_connections_total",
-			Help:      "Trickster total numer of connections requested by clients.",
+			Help:      "Trickster total number of connections requested by clients.",
 		},
 	)
 	ProxyConnectionAccepted = prometheus.NewCounter(
@@ -144,7 +144,7 @@ func Init() {
 			Namespace: metricNamespace,
 			Subsystem: proxySubsystem,
 			Name:      "accepted_connections_total",
-			Help:      "Trickster total numer of accepted connections.",
+			Help:      "Trickster total number of accepted connections.",
 		},
 	)
 
@@ -153,7 +153,7 @@ func Init() {
 			Namespace: metricNamespace,
 			Subsystem: proxySubsystem,
 			Name:      "closed_connections_total",
-			Help:      "Trickster total numer of closed connections.",
+			Help:      "Trickster total number of closed connections.",
 		},
 	)
 
@@ -162,7 +162,7 @@ func Init() {
 			Namespace: metricNamespace,
 			Subsystem: proxySubsystem,
 			Name:      "failed_connections_total",
-			Help:      "Trickster total numer of failed connections.",
+			Help:      "Trickster total number of failed connections.",
 		},
 	)
 


### PR DESCRIPTION
This commit adds the ability to configure a limit of connections handled by the front end proxy. It is implemented using go's [x/net/netutil/LimitedListener][1]

Additionally, using the same technique, I am wrapping the listener to provide multiple metrics of front end connections:
1. Active connections (Gauge)
1. Requested (Counter)
1. Accepted (Counter)
1. Failed (Counter)
1. Closed (Counter)

This can be useful to determine how many connections are necessary at any point, and to identify spikes of any kind from the client side.

The way it behaves is that by default the limit is 0, which means unlimited, and all we get is metrics.

In the case of setting a limit, when a client requests a new connection and we run out of them, the request locks until there's one available (or the client gives up)

Users must be mindful that some clients will keep connections alive for a while, thus they should be accounting for it when doing capacity planning.

[1]: https://godoc.org/golang.org/x/net/netutil#LimitListener