### PR TITLE
Observe frontend requests

### DIFF
--- a/internal/proxy/origins/prometheus/routes.go
+++ b/internal/proxy/origins/prometheus/routes.go
@@ -14,61 +14,68 @@
 package prometheus
 
 import (
+	"net/http"
+
 	"github.com/Comcast/trickster/internal/config"
 	"github.com/Comcast/trickster/internal/routing"
 	"github.com/Comcast/trickster/internal/util/log"
+	"github.com/Comcast/trickster/internal/util/middleware"
 )
 
 // RegisterRoutes registers the routes for the Client into the proxy's HTTP multiplexer
 func (c *Client) RegisterRoutes(originName string, o *config.OriginConfig) {
 
+	decorate := func(path string, f func(http.ResponseWriter, *http.Request)) func(http.ResponseWriter, *http.Request) {
+		return middleware.Decorate(originName, otPrometheus, path, f)
+	}
+
 	// Host Header-based routing
 	log.Debug("Registering Origin Handlers", log.Pairs{"originType": o.Type, "originName": originName})
-	routing.Router.HandleFunc("/"+mnHealth, c.HealthHandler).Methods("GET").Host(originName)
-	routing.Router.HandleFunc(APIPath+mnQueryRange, c.QueryRangeHandler).Methods("GET", "POST").Host(originName)
-	routing.Router.HandleFunc(APIPath+mnQuery, c.QueryHandler).Methods("GET", "POST").Host(originName)
-	routing.Router.HandleFunc(APIPath+mnSeries, c.SeriesHandler).Methods("GET", "POST").Host(originName)
-	routing.Router.HandleFunc(APIPath+mnLabels, c.ObjectProxyCacheHandler).Methods("GET", "POST").Host(originName)
-	routing.Router.HandleFunc(APIPath+mnLabel, c.ObjectProxyCacheHandler).Methods("GET").Host(originName)
-	routing.Router.HandleFunc(APIPath+mnTargets, c.ObjectProxyCacheHandler).Methods("GET").Host(originName)
-	routing.Router.HandleFunc(APIPath+mnRules, c.ObjectProxyCacheHandler).Methods("GET").Host(originName)
-	routing.Router.HandleFunc(APIPath+mnAlerts, c.ObjectProxyCacheHandler).Methods("GET").Host(originName)
-	routing.Router.HandleFunc(APIPath+mnAlertManagers, c.ObjectProxyCacheHandler).Methods("GET").Host(originName)
-	routing.Router.HandleFunc(APIPath+mnStatus, c.ObjectProxyCacheHandler).Methods("GET").Host(originName)
-	routing.Router.PathPrefix(APIPath).HandlerFunc(c.ProxyHandler).Methods("GET", "POST").Host(originName)
-	routing.Router.PathPrefix("/").HandlerFunc(c.ProxyHandler).Methods("GET", "POST").Host(originName)
+	routing.Router.HandleFunc("/"+mnHealth, decorate("health", c.HealthHandler)).Methods("GET").Host(originName)
+	routing.Router.HandleFunc(APIPath+mnQueryRange, decorate("query_range", c.QueryRangeHandler)).Methods("GET", "POST").Host(originName)
+	routing.Router.HandleFunc(APIPath+mnQuery, decorate("query", c.QueryHandler)).Methods("GET", "POST").Host(originName)
+	routing.Router.HandleFunc(APIPath+mnSeries, decorate("series", c.SeriesHandler)).Methods("GET", "POST").Host(originName)
+	routing.Router.HandleFunc(APIPath+mnLabels, decorate("labels", c.ObjectProxyCacheHandler)).Methods("GET", "POST").Host(originName)
+	routing.Router.HandleFunc(APIPath+mnLabel, decorate("label", c.ObjectProxyCacheHandler)).Methods("GET").Host(originName)
+	routing.Router.HandleFunc(APIPath+mnTargets, decorate("targets", c.ObjectProxyCacheHandler)).Methods("GET").Host(originName)
+	routing.Router.HandleFunc(APIPath+mnRules, decorate("rules", c.ObjectProxyCacheHandler)).Methods("GET").Host(originName)
+	routing.Router.HandleFunc(APIPath+mnAlerts, decorate("alerts", c.ObjectProxyCacheHandler)).Methods("GET").Host(originName)
+	routing.Router.HandleFunc(APIPath+mnAlertManagers, decorate("alert_managersj", c.ObjectProxyCacheHandler)).Methods("GET").Host(originName)
+	routing.Router.HandleFunc(APIPath+mnStatus, decorate("status", c.ObjectProxyCacheHandler)).Methods("GET").Host(originName)
+	routing.Router.PathPrefix(APIPath).HandlerFunc(decorate("api", c.ProxyHandler)).Methods("GET", "POST").Host(originName)
+	routing.Router.PathPrefix("/").HandlerFunc(decorate("proxy", c.ProxyHandler)).Methods("GET", "POST").Host(originName)
 
 	// Path based routing
-	routing.Router.HandleFunc("/"+originName+"/"+mnHealth, c.HealthHandler).Methods("GET")
-	routing.Router.HandleFunc("/"+originName+APIPath+mnQueryRange, c.QueryRangeHandler).Methods("GET", "POST")
-	routing.Router.HandleFunc("/"+originName+APIPath+mnQuery, c.QueryHandler).Methods("GET", "POST")
-	routing.Router.HandleFunc("/"+originName+APIPath+mnSeries, c.SeriesHandler).Methods("GET", "POST")
-	routing.Router.HandleFunc("/"+originName+APIPath+mnLabels, c.ObjectProxyCacheHandler).Methods("GET", "POST")
-	routing.Router.HandleFunc("/"+originName+APIPath+mnLabel, c.ObjectProxyCacheHandler).Methods("GET")
-	routing.Router.HandleFunc("/"+originName+APIPath+mnTargets, c.ObjectProxyCacheHandler).Methods("GET")
-	routing.Router.HandleFunc("/"+originName+APIPath+mnRules, c.ObjectProxyCacheHandler).Methods("GET")
-	routing.Router.HandleFunc("/"+originName+APIPath+mnAlerts, c.ObjectProxyCacheHandler).Methods("GET")
-	routing.Router.HandleFunc("/"+originName+APIPath+mnAlertManagers, c.ObjectProxyCacheHandler).Methods("GET")
-	routing.Router.HandleFunc("/"+originName+APIPath+mnStatus, c.ObjectProxyCacheHandler).Methods("GET")
-	routing.Router.PathPrefix("/"+originName+APIPath).HandlerFunc(c.ProxyHandler).Methods("GET", "POST")
-	routing.Router.PathPrefix("/"+originName+"/").HandlerFunc(c.ProxyHandler).Methods("GET", "POST")
+	routing.Router.HandleFunc("/"+originName+"/"+mnHealth, decorate("health", c.HealthHandler)).Methods("GET")
+	routing.Router.HandleFunc("/"+originName+APIPath+mnQueryRange, decorate("query_range", c.QueryRangeHandler)).Methods("GET", "POST")
+	routing.Router.HandleFunc("/"+originName+APIPath+mnQuery, decorate("query", c.QueryHandler)).Methods("GET", "POST")
+	routing.Router.HandleFunc("/"+originName+APIPath+mnSeries, decorate("series", c.SeriesHandler)).Methods("GET", "POST")
+	routing.Router.HandleFunc("/"+originName+APIPath+mnLabels, decorate("labels", c.ObjectProxyCacheHandler)).Methods("GET", "POST")
+	routing.Router.HandleFunc("/"+originName+APIPath+mnLabel, decorate("label", c.ObjectProxyCacheHandler)).Methods("GET")
+	routing.Router.HandleFunc("/"+originName+APIPath+mnTargets, decorate("targets", c.ObjectProxyCacheHandler)).Methods("GET")
+	routing.Router.HandleFunc("/"+originName+APIPath+mnRules, decorate("rules", c.ObjectProxyCacheHandler)).Methods("GET")
+	routing.Router.HandleFunc("/"+originName+APIPath+mnAlerts, decorate("alerts", c.ObjectProxyCacheHandler)).Methods("GET")
+	routing.Router.HandleFunc("/"+originName+APIPath+mnAlertManagers, decorate("alert_managers", c.ObjectProxyCacheHandler)).Methods("GET")
+	routing.Router.HandleFunc("/"+originName+APIPath+mnStatus, decorate("status", c.ObjectProxyCacheHandler)).Methods("GET")
+	routing.Router.PathPrefix("/"+originName+APIPath).HandlerFunc(decorate("api", c.ProxyHandler)).Methods("GET", "POST")
+	routing.Router.PathPrefix("/"+originName+"/").HandlerFunc(decorate("proxy", c.ProxyHandler)).Methods("GET", "POST")
 
 	// If default origin, set those routes too
 	if o.IsDefault {
 		log.Debug("Registering Default Origin Handlers", log.Pairs{"originType": o.Type})
-		routing.Router.HandleFunc("/"+mnHealth, c.HealthHandler).Methods("GET")
-		routing.Router.HandleFunc(APIPath+mnQueryRange, c.QueryRangeHandler).Methods("GET", "POST")
-		routing.Router.HandleFunc(APIPath+mnQuery, c.QueryHandler).Methods("GET", "POST")
-		routing.Router.HandleFunc(APIPath+mnSeries, c.SeriesHandler).Methods("GET", "POST")
-		routing.Router.HandleFunc(APIPath+mnLabels, c.ObjectProxyCacheHandler).Methods("GET", "POST")
-		routing.Router.HandleFunc(APIPath+mnLabel, c.ObjectProxyCacheHandler).Methods("GET")
-		routing.Router.HandleFunc(APIPath+mnTargets, c.ObjectProxyCacheHandler).Methods("GET")
-		routing.Router.HandleFunc(APIPath+mnRules, c.ObjectProxyCacheHandler).Methods("GET")
-		routing.Router.HandleFunc(APIPath+mnAlerts, c.ObjectProxyCacheHandler).Methods("GET")
-		routing.Router.HandleFunc(APIPath+mnAlertManagers, c.ObjectProxyCacheHandler).Methods("GET")
-		routing.Router.HandleFunc(APIPath+mnStatus, c.ObjectProxyCacheHandler).Methods("GET")
-		routing.Router.PathPrefix(APIPath).HandlerFunc(c.ProxyHandler).Methods("GET", "POST")
-		routing.Router.PathPrefix("/").HandlerFunc(c.ProxyHandler).Methods("GET", "POST")
+		routing.Router.HandleFunc("/"+mnHealth, decorate("health", c.HealthHandler)).Methods("GET")
+		routing.Router.HandleFunc(APIPath+mnQueryRange, decorate("query_range", c.QueryRangeHandler)).Methods("GET", "POST")
+		routing.Router.HandleFunc(APIPath+mnQuery, decorate("query", c.QueryHandler)).Methods("GET", "POST")
+		routing.Router.HandleFunc(APIPath+mnSeries, decorate("series", c.SeriesHandler)).Methods("GET", "POST")
+		routing.Router.HandleFunc(APIPath+mnLabels, decorate("labels", c.ObjectProxyCacheHandler)).Methods("GET", "POST")
+		routing.Router.HandleFunc(APIPath+mnLabel, decorate("label", c.ObjectProxyCacheHandler)).Methods("GET")
+		routing.Router.HandleFunc(APIPath+mnTargets, decorate("targets", c.ObjectProxyCacheHandler)).Methods("GET")
+		routing.Router.HandleFunc(APIPath+mnRules, decorate("rules", c.ObjectProxyCacheHandler)).Methods("GET")
+		routing.Router.HandleFunc(APIPath+mnAlerts, decorate("alerts", c.ObjectProxyCacheHandler)).Methods("GET")
+		routing.Router.HandleFunc(APIPath+mnAlertManagers, decorate("alert_managers", c.ObjectProxyCacheHandler)).Methods("GET")
+		routing.Router.HandleFunc(APIPath+mnStatus, decorate("status", c.ObjectProxyCacheHandler)).Methods("GET")
+		routing.Router.PathPrefix(APIPath).HandlerFunc(decorate("api", c.ProxyHandler)).Methods("GET", "POST")
+		routing.Router.PathPrefix("/").HandlerFunc(decorate("proxy", c.ProxyHandler)).Methods("GET", "POST")
 	}
 
 }

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -43,6 +43,9 @@ var FrontendRequestStatus *prometheus.CounterVec
 // FrontendRequestDuration is a histogram that tracks the time it takes to process a request
 var FrontendRequestDuration *prometheus.HistogramVec
 
+// FrontendRequestWrittenBytes is a Counter of bytes written for front end requests
+var FrontendRequestWrittenBytes *prometheus.CounterVec
+
 // ProxyRequestStatus is a Counter of downstream client requests handled by Trickster
 var ProxyRequestStatus *prometheus.CounterVec
 
@@ -96,6 +99,15 @@ func Init() {
 		},
 		[]string{"origin_name", "origin_type", "method", "path", "http_status"},
 	)
+
+	FrontendRequestWrittenBytes = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: frontendSubsystem,
+			Name:      "written_bytes_total",
+			Help:      "Count of bytes written in front end requests handled by Trickster",
+		},
+		[]string{"origin_name", "origin_type", "method", "path", "http_status"})
 
 	ProxyRequestStatus = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -201,6 +213,7 @@ func Init() {
 	// Register Metrics
 	prometheus.MustRegister(FrontendRequestStatus)
 	prometheus.MustRegister(FrontendRequestDuration)
+	prometheus.MustRegister(FrontendRequestWrittenBytes)
 	prometheus.MustRegister(ProxyRequestStatus)
 	prometheus.MustRegister(ProxyRequestElements)
 	prometheus.MustRegister(ProxyRequestDuration)

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -83,7 +83,7 @@ func Init() {
 			Name:      "requests_total",
 			Help:      "Count of front end requests handled by Trickster",
 		},
-		[]string{"origin_name", "origin_type", "http_status"},
+		[]string{"origin_name", "origin_type", "method", "path", "http_status"},
 	)
 
 	FrontendRequestDuration = prometheus.NewHistogramVec(
@@ -94,7 +94,7 @@ func Init() {
 			Help:      "Histogram of front end request durations handled by Trickster",
 			Buckets:   defaultBuckets,
 		},
-		[]string{"origin_name", "origin_type", "origin", "http_status"},
+		[]string{"origin_name", "origin_type", "method", "path", "http_status"},
 	)
 
 	ProxyRequestStatus = prometheus.NewCounterVec(

--- a/internal/util/middleware/observer.go
+++ b/internal/util/middleware/observer.go
@@ -1,0 +1,61 @@
+/**
+* Copyright 2018 Comcast Cable Communications Management, LLC
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package middleware
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/Comcast/trickster/internal/util/metrics"
+)
+
+// RequestObserver is a middleware that decorates a function in such a way that
+// it captures both the returned status and the time used to execute a request
+// from the front end perspective
+func RequestObserver(originName, originType string, f func(http.ResponseWriter, *http.Request)) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		statusObserver := writerStatusObserver{
+			w,
+			"unknown",
+		}
+
+		n := time.Now()
+		f(statusObserver, r)
+
+		metrics.FrontendRequestDuration.WithLabelValues(originName, originType, statusObserver.status).Observe(time.Now().Sub(n).Seconds())
+		metrics.FrontendRequestStatus.WithLabelValues(originName, originType, statusObserver.status).Inc()
+	}
+}
+
+type writerStatusObserver struct {
+	http.ResponseWriter
+
+	status string
+}
+
+func (w *writerStatusObserver) WriterHeader(statusCode int) {
+	w.ResponseWriter.WriteHeader(statusCode)
+	switch {
+	case statusCode >= 100 && statusCode < 199:
+		w.status = "1xx"
+	case statusCode >= 200 && statusCode < 299:
+		w.status = "2xx"
+	case statusCode >= 300 && statusCode < 399:
+		w.status = "3xx"
+	case statusCode >= 400 && statusCode < 499:
+		w.status = "4xx"
+	case statusCode >= 500 && statusCode < 599:
+		w.status = "5xx"
+	}
+}


### PR DESCRIPTION
This PR provides a set of metrics for return codes and durations from the front end perspective of the cache.

These metrics are:
1. trickster_frontend_requests_total *counter*
2. trickster_frontend_requests_duration_seconds *histogram*
3. trickster_frontend_written_bytes_total *counter*

All metrics have the following labels:
1. http_status which follows the haproxy style of status code grouping them by hundreds (2xx, 3xx, etc)
2. method - GET/POST
3. origin_name
4. origin_type
5. path which only provides the general handler, for example: proxy, query, query_range, status, etc.

Still pending implement the same for other backends besides prometheus.