### PR TITLE
added build time and commit ID to the binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ FIRST_GOPATH   := $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))
 TRICKSTER_MAIN := cmd/trickster
 TRICKSTER      := $(FIRST_GOPATH)/bin/trickster
 PROGVER        := $(shell grep 'applicationVersion = ' $(TRICKSTER_MAIN)/main.go | awk '{print $$3}' | sed -e 's/\"//g')
+BUILD_TIME     := $(shell date -u +%FT%T%z)
+GIT_LATEST_COMMIT_ID     := $(shell git rev-parse HEAD)
+LDFLAGS=-ldflags "-s -X main.applicationBuildTime=$(BUILD_TIME) -X main.applicationGitCommitID=$(GIT_LATEST_COMMIT_ID)"
 GO111MODULE    ?= on
 export GO111MODULE
 
@@ -35,7 +38,7 @@ test-go-mod: go-mod-vendor
 
 .PHONY: build
 build:
-	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=$(CGO_ENABLED) $(GO) build -o trickster -a -v $(TRICKSTER_MAIN)/main.go
+	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o trickster -a -v $(TRICKSTER_MAIN)/main.go 
 
 rpm: build
 	mkdir -p ./OPATH/SOURCES

--- a/cmd/trickster/main.go
+++ b/cmd/trickster/main.go
@@ -30,10 +30,12 @@ import (
 
 	"github.com/gorilla/handlers"
 )
+
 var (
-    applicationGitCommitID string
-    applicationBuildTime string
+	applicationGitCommitID string
+	applicationBuildTime   string
 )
+
 const (
 	applicationName    = "trickster"
 	applicationVersion = "1.0.9"

--- a/cmd/trickster/main.go
+++ b/cmd/trickster/main.go
@@ -30,7 +30,10 @@ import (
 
 	"github.com/gorilla/handlers"
 )
-
+var (
+    applicationGitCommitID string
+    applicationBuildTime string
+)
 const (
 	applicationName    = "trickster"
 	applicationVersion = "1.0.9"


### PR DESCRIPTION
I have added the build time using `date -u %FT%T%z` which gives sample timestamp 2019-10-11T07:46:1707:46:17+0000 which seems to be the standard according to [here](https://stackoverflow.com/questions/11354518/application-auto-build-versioning) and [here](https://github.com/commissure/go-git-build-vars/blob/master/Makefile). I made 2 global variables in `cmd/trickster/main.go` applicationBuildTime and applicationGitCommitID which are set during build time from the Makefile using `-ldflags` option.
@jranson please let me know if any changes are required/recommended.