### PR TITLE
1.0 fix prometheus annotations

### DIFF
--- a/deploy/helm/trickster/templates/service.yaml
+++ b/deploy/helm/trickster/templates/service.yaml
@@ -3,8 +3,8 @@ kind: Service
 metadata:
   {{- if .Values.prometheusScrape }}
   annotations:
-    prometheus.io/scrape: {{ .Values.prometheusScrape }}
-    prometheus.io/port: {{ .Values.service.metricsPort }}
+    prometheus.io/scrape: {{ .Values.prometheusScrape | quote }}
+    prometheus.io/port: {{ .Values.service.metricsPort | quote }}
     prometheus.io/path: /metrics
   {{- end }}
   name: {{ template "trickster.fullname" . }}

--- a/deploy/helm/trickster/values.yaml
+++ b/deploy/helm/trickster/values.yaml
@@ -192,6 +192,8 @@ profiler:
   enabled: false
   port: 6060
 
+prometheusScrape: false
+
 # Number of trickster replicas desired
 replicaCount: 1
 


### PR DESCRIPTION
Fixes a parsing error when enabling prometheus scraping annotations. The values need to be quoted so that helm is able to parse them correctly.

Also, the prometheusScrape parameter was not part of the values.yaml.