### PR TITLE
Fix if condition in configmap template when using redis as cache type

### DIFF
--- a/deploy/helm/trickster/templates/configmap.yaml
+++ b/deploy/helm/trickster/templates/configmap.yaml
@@ -41,7 +41,7 @@ data:
             protocol = {{ .redis.protocol | quote }}
             password = {{ .redis.password | quote }}
 
-            {{- else if eq .redis.clientType "standard" }}
+            {{- if eq .redis.clientType "standard" }}
             endpoint = {{ .redis.endpoint | quote }}
 
             {{- else if or (eq .clientType "cluster") (eq .clientType "sentinel") }}
@@ -88,6 +88,7 @@ data:
             {{- end }}
             {{- if .redis.idleCheckFrequencyMs }}
             idle_check_frequency_ms = {{ .redis.idleCheckFrequencyMs }}
+            {{- end }}
             {{- end }}
             
             {{- else if eq .type "filesystem" }}


### PR DESCRIPTION
If  redis is used as a cache type (`{{- if eq .type "redis" }}`), the template skips all the settings, independently of if you use standard, cluster or sentinel, as the following else if statement follows the mentioned one: `{{- else if eq .redis.clientType "standard" }}`. This pull request suggests changing the following block:

```
{{- if eq .type "redis" }}
....
{{- else if eq .redis.clientType "standard" }}
...
{{- else if or (eq .clientType "cluster") (eq .clientType "sentinel") }}
...
{{- if eq .clientType "sentinel" }} 
...
{{- end }}
{{- end }}
```

To:
```
{{- if eq .type "redis" }}
....
{{- if eq .redis.clientType "standard" }}
...
{{- else if or (eq .clientType "cluster") (eq .clientType "sentinel") }}
...
{{- if eq .clientType "sentinel" }} 
...
{{- end }}
{{- end }}
{{- end }}
```
Otherwise the template will never populate parameters in the clientType blocks for a redis cache type.