### PR TITLE
Move max object size to origin config

### DIFF
--- a/cmd/trickster/conf/example.conf
+++ b/cmd/trickster/conf/example.conf
@@ -40,9 +40,6 @@ listen_port = 9090
     # changing the compression setting will leave orphans in your cache for the duration of timeseries_ttl_secs
     compression = true
 
-    # max_object_size_bytes defines the largest byte size an object may be before it is uncacheable due to size. default is 524288 (512k)
-    max_object_size_bytes = 524288
-
         ### Configuration options for the Cache Index
         # The Cache Index handles key management and retention for bbolt, filesystem and memory
         # Redis and BadgerDB handle those functions natively and does not use the Trickster's Cache Index
@@ -247,6 +244,9 @@ listen_port = 9090
 
     # revalidation_factor is the multiplier for object lifetime expiration to determine cache object TTL; default is 2
     # revalidation_factor = 2
+
+    # max_object_size_bytes defines the largest byte size an object may be before it is uncacheable due to size. default is 524288 (512k)
+    max_object_size_bytes = 524288
 
     #
     # Each origin type implements their own defaults for health_check_upstream_url, health_check_verb and health_check_query,

--- a/internal/proxy/engines/objectproxycache.go
+++ b/internal/proxy/engines/objectproxycache.go
@@ -141,7 +141,7 @@ func FetchViaObjectProxyCache(r *model.Request, client model.Client, apc *config
 	}
 
 	d.CachingPolicy.NoTransform = d.CachingPolicy.NoTransform || cpReq.NoTransform
-	d.CachingPolicy.NoCache = d.CachingPolicy.NoCache || cpReq.NoCache || len(body) >= cache.Configuration().MaxObjectSizeBytes
+	d.CachingPolicy.NoCache = d.CachingPolicy.NoCache || cpReq.NoCache || len(body) >= oc.MaxObjectSizeBytes
 
 	if d.CachingPolicy.NoCache || (!d.CachingPolicy.CanRevalidate && d.CachingPolicy.FreshnessLifetime <= 0) {
 		cache.Remove(key)

--- a/testdata/test.full.conf
+++ b/testdata/test.full.conf
@@ -25,7 +25,6 @@ tls_listen_address = 'test-tls'
     cache_type = 'redis'
     compression = true
     object_ttl_secs = 39
-    max_object_size_bytes = 999
 
         [caches.test.index]
         reap_interval_secs = 4
@@ -92,6 +91,8 @@ tls_listen_address = 'test-tls'
     max_ttl_secs = 300
     fastforward_ttl_secs = 382
     require_tls = true
+    max_object_size_bytes = 999
+
 
         [origins.test.negative_cache]
         404 = 10

--- a/testdata/test.redis-cluster.conf
+++ b/testdata/test.redis-cluster.conf
@@ -19,7 +19,6 @@
     cache_type = 'redis'
     compression = true
     object_ttl_secs = 39
-    max_object_size_bytes = 999
 
         ### Configuration options when using a Redis Cache
         [caches.test.redis]
@@ -53,4 +52,6 @@ listen_address = 'test'
     origin_type = 'foo'
     cache_name = 'test'
     origin_url = 'http://1'
+    max_object_size_bytes = 999
+
 

--- a/testdata/test.redis-sentinel.conf
+++ b/testdata/test.redis-sentinel.conf
@@ -19,7 +19,6 @@
     cache_type = 'redis'
     compression = true
     object_ttl_secs = 39
-    max_object_size_bytes = 999
 
         ### Configuration options when using a Redis Cache
         [caches.test.redis]
@@ -53,4 +52,5 @@ listen_address = 'test'
     origin_type = 'foo'
     cache_name = 'test'
     origin_url = 'http://1'
+    max_object_size_bytes = 999
 

--- a/testdata/test.redis-standard.conf
+++ b/testdata/test.redis-standard.conf
@@ -19,7 +19,6 @@
     cache_type = 'redis'
     compression = true
     object_ttl_secs = 39
-    max_object_size_bytes = 999
 
         ### Configuration options when using a Redis Cache
         [caches.test.redis]
@@ -53,4 +52,5 @@ listen_address = 'test'
     origin_type = 'foo'
     cache_name = 'test'
     origin_url = 'http://1'
+    max_object_size_bytes = 999
 


### PR DESCRIPTION
# General
This allows a max cache object size on a per origin basis.

# Why
This makes the answer to "should we proxy the request or cache it?" more knowable at the time of the request. 
If we are just proxying a request and want to collapse it(see #284) we can check if the resulting memory usage would be too much - such that we can only proxy.