### PR TITLE
trickster binary not in `cp` path for `make rpm`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ build:
 
 rpm: build
 	mkdir -p ./OPATH/SOURCES
-	cp -p trickster ./OPATH/SOURCES/
+	cp -p ./OPATH/trickster ./OPATH/SOURCES/
 	cp $(TRICKSTER_MAIN)/conf/trickster.service ./OPATH/SOURCES/
 	sed -e 's%^# log_file =.*$$%log_file = "/var/log/trickster/trickster.log"%' \
 		-e 's%prometheus:9090%localhost:9090%' \


### PR DESCRIPTION
Current error encountered:

> mkdir -p ./OPATH/SOURCES
> cp -p trickster ./OPATH/SOURCES/
> cp: cannot stat ‘trickster’: No such file or directory
> make: *** [rpm] Error 1

In the `next` branch, the trickster binary is placed in ./OPATH.  The Makefile needs to be updated to use this new path when building the RPM