### PR TITLE
Update configmap.yaml

### DIFF
--- a/deploy/helm/trickster/templates/configmap.yaml
+++ b/deploy/helm/trickster/templates/configmap.yaml
@@ -41,7 +41,7 @@ data:
 
       {{ printf "[caches.%s]" .name }}
         {{- if .cacheType }}
-      cache_type = {{ .cacheType | quote }}
+      type = {{ .cacheType | quote }}
         {{- end }}
         {{- if .compression }}
       compression = {{ .compression }}
@@ -171,10 +171,10 @@ data:
 
       {{ printf "[origins.%s]" .name }}
         {{- if .originType }}
-      origin_type = {{ .originType | quote }}
+      type = {{ .originType | quote }}
         {{- end }}
         {{- if .originURL }}
-      origin_url = {{ .originURL | quote }}
+      host = {{ .originURL | quote }}
         {{- end }}
         {{- if .isDefault }}
       is_default = {{ .isDefault }}


### PR DESCRIPTION
I was confused with this configmaps, because if I deploy and check at path: `localhost:9090/trickster/config` to see the configure at runtime, it will be load with 
```
[origins]
  [origins.default]
    type = "prometheus"
    scheme = "http"
    host = "prometheus:9090"
```
and 
```
[caches]
  [caches.default]
    type = "memory"
```
So, let me check at source code, it must be 
```
[origins]
  [origins.default]
    origin_type = "prometheus"
    scheme = "http"
    origin_url = "prometheus:9090"
```
and 
```
[caches]
  [caches.default]
    cache_type = "memory"

```
Refer: https://github.com/Comcast/trickster/blob/next/internal/config/config.go#L103

But, i changed some configure at helm chart on this PR, it's work
What wrong with me?