### PR TITLE
Release with tar.gz format instead of only gz format (support Ansible unarchive module)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ release: build release-artifacts docker docker-release
 
 .PHONY: release-artifacts
 release-artifacts:
-	GOOS=darwin GOARCH=amd64 go build -o ./OPATH/trickster-$(PROGVER).darwin-amd64 && gzip -f ./OPATH/trickster-$(PROGVER).darwin-amd64
-	GOOS=linux  GOARCH=amd64 go build -o ./OPATH/trickster-$(PROGVER).linux-amd64  && gzip -f ./OPATH/trickster-$(PROGVER).linux-amd64
+	GOOS=darwin GOARCH=amd64 go build -o ./OPATH/trickster-$(PROGVER).darwin-amd64 && tar cvfz ./OPATH/trickster-$(PROGVER).darwin-amd64.tar.gz ./OPATH/trickster-$(PROGVER).darwin-amd64
+	GOOS=linux  GOARCH=amd64 go build -o ./OPATH/trickster-$(PROGVER).linux-amd64  && tar cvfz ./OPATH/trickster-$(PROGVER).linux-amd64.tar.gz ./OPATH/trickster-$(PROGVER).linux-amd64
 
 .PHONY: helm-local
 helm-local:


### PR DESCRIPTION
I try to deploy trickster with Ansible, but Ansible doesn't support `.gz` release file. [From Ansible  unarchive docs](https://docs.ansible.com/ansible/latest/modules/unarchive_module.html):

- Can handle .zip files using unzip as well as .tar, .tar.gz, .tar.bz2 and .tar.xz files using gtar.
- Does not handle .gz files, .bz2 files or .xz files that do not contain a .tar archive.

So I recommend trickster releases with `tar.gz` format, please consider this request. Example Ansible code

![image](https://user-images.githubusercontent.com/1505720/70305336-b314b200-1836-11ea-94b8-cf22880a9a39.png)
