### PR TITLE
Patch waitgroup leak on multiple return

### DIFF
--- a/internal/proxy/engines/progressive_collapse_forwarder.go
+++ b/internal/proxy/engines/progressive_collapse_forwarder.go
@@ -90,7 +90,6 @@ func NewPCF(resp *http.Response, contentLength int64) ProgressiveCollapseForward
 // This client will read all the cached data and read from the live edge if caught up.
 func (pfc *progressiveCollapseForwarder) AddClient(w io.Writer) error {
 	pfc.clientWaitgroup.Add(1)
-	defer pfc.clientWaitgroup.Done()
 	var readIndex uint64
 	var err error
 	remaining := 0
@@ -119,11 +118,13 @@ func (pfc *progressiveCollapseForwarder) AddClient(w io.Writer) error {
 		}
 		if err != nil {
 			if err != io.EOF {
+				pfc.clientWaitgroup.Done()
 				return err
 			}
 			break
 		}
 	}
+	pfc.clientWaitgroup.Done()
 	return io.EOF
 }
 

--- a/internal/proxy/engines/progressive_collapse_forwarder.go
+++ b/internal/proxy/engines/progressive_collapse_forwarder.go
@@ -90,6 +90,7 @@ func NewPCF(resp *http.Response, contentLength int64) ProgressiveCollapseForward
 // This client will read all the cached data and read from the live edge if caught up.
 func (pfc *progressiveCollapseForwarder) AddClient(w io.Writer) error {
 	pfc.clientWaitgroup.Add(1)
+	defer pfc.clientWaitgroup.Done()
 	var readIndex uint64
 	var err error
 	remaining := 0
@@ -123,7 +124,6 @@ func (pfc *progressiveCollapseForwarder) AddClient(w io.Writer) error {
 			break
 		}
 	}
-	pfc.clientWaitgroup.Done()
 	return io.EOF
 }
 


### PR DESCRIPTION
The return on line 121 would cause the waitgroup to never finish. Use defer instead.