### PR TITLE
Get test coverage to 100 on pcf

### DIFF
--- a/internal/proxy/engines/progressive_collapse_forwarder_test.go
+++ b/internal/proxy/engines/progressive_collapse_forwarder_test.go
@@ -15,7 +15,6 @@ package engines
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"net/http"
 	"reflect"
@@ -158,7 +157,6 @@ func TestPCFWaits(t *testing.T) {
 
 	go func() {
 		pcf.WaitServerComplete()
-		fmt.Println("HDFHFD")
 		atomic.StoreUint64(&serverComplete, 1)
 	}()
 


### PR DESCRIPTION
- Minor changes in the PCF code itself to better use sync.Cond as described [in the docs](https://golang.org/pkg/sync/#Cond.Wait).

- Added tests to wait server and wait all.

- Removed manual set N for benchmarks.