### PR TITLE
fix ineffectual assignment in irondb custom key hasher

### DIFF
--- a/internal/config/path.go
+++ b/internal/config/path.go
@@ -27,7 +27,7 @@ import (
 type PathMatchType int
 
 // KeyHasherFunc is a custom function that returns a hashed key value string for cache objects
-type KeyHasherFunc func(path string, params url.Values, headers http.Header, body io.ReadCloser, extra string) string
+type KeyHasherFunc func(path string, params url.Values, headers http.Header, body io.ReadCloser, extra string) (string, io.ReadCloser)
 
 const (
 	// PathMatchTypeExact indicates the router will map the Path by exact match against incoming requests

--- a/internal/proxy/engines/key.go
+++ b/internal/proxy/engines/key.go
@@ -57,7 +57,9 @@ func (pr *proxyRequest) DeriveCacheKey(templateURL *url.URL, extra string) strin
 	}
 
 	if pc.KeyHasher != nil && len(pc.KeyHasher) == 1 {
-		return pc.KeyHasher[0](pr.URL.Path, params, pr.Header, pr.Body, extra)
+		var k string
+		k, pr.Body = pc.KeyHasher[0](pr.URL.Path, params, pr.Header, pr.Body, extra)
+		return k
 	}
 
 	vals := make([]string, 0, (len(pc.CacheKeyParams) + len(pc.CacheKeyHeaders) + len(pc.CacheKeyFormFields)*2))

--- a/internal/proxy/engines/key_test.go
+++ b/internal/proxy/engines/key_test.go
@@ -178,8 +178,8 @@ func TestDeriveCacheKey(t *testing.T) {
 
 }
 
-func exampleKeyHasher(path string, params url.Values, headers http.Header, body io.ReadCloser, extra string) string {
-	return "test-key"
+func exampleKeyHasher(path string, params url.Values, headers http.Header, body io.ReadCloser, extra string) (string, io.ReadCloser) {
+	return "test-key", nil
 }
 
 func TestDeriveCacheKeyAuthHeader(t *testing.T) {

--- a/internal/proxy/origins/irondb/handler_fetch.go
+++ b/internal/proxy/origins/irondb/handler_fetch.go
@@ -121,7 +121,7 @@ func (c *Client) fetchHandlerParseTimeRangeQuery(
 // fetchHandlerDeriveCacheKey calculates a query-specific keyname based on the
 // user request.
 func (c Client) fetchHandlerDeriveCacheKey(path string, params url.Values,
-	headers http.Header, body io.ReadCloser, extra string) string {
+	headers http.Header, body io.ReadCloser, extra string) (string, io.ReadCloser) {
 	var sb strings.Builder
 	sb.WriteString(path)
 	newBody := &bytes.Buffer{}
@@ -141,5 +141,5 @@ func (c Client) fetchHandlerDeriveCacheKey(path string, params url.Values,
 	}
 
 	sb.WriteString(extra)
-	return md5.Checksum(sb.String())
+	return md5.Checksum(sb.String()), body
 }

--- a/internal/proxy/origins/irondb/handler_fetch_test.go
+++ b/internal/proxy/origins/irondb/handler_fetch_test.go
@@ -71,7 +71,8 @@ func TestFetchHandlerDeriveCacheKey(t *testing.T) {
 	r.Body = ioutil.NopCloser(bytes.NewReader([]byte("{}")))
 
 	const expected = "a34bbb372c505e9eea0e0589e16c0914"
-	result := client.fetchHandlerDeriveCacheKey(path, r.URL.Query(), r.Header, r.Body, "extra")
+	var result string
+	result, r.Body = client.fetchHandlerDeriveCacheKey(path, r.URL.Query(), r.Header, r.Body, "extra")
 	if result != expected {
 		t.Errorf("expected %s got %s", expected, result)
 	}

--- a/internal/proxy/origins/irondb/handler_histogram.go
+++ b/internal/proxy/origins/irondb/handler_histogram.go
@@ -111,7 +111,7 @@ func (c *Client) histogramHandlerParseTimeRangeQuery(
 // histogramHandlerDeriveCacheKey calculates a query-specific keyname based on
 // the user request.
 func (c Client) histogramHandlerDeriveCacheKey(path string, params url.Values,
-	headers http.Header, body io.ReadCloser, extra string) string {
+	headers http.Header, body io.ReadCloser, extra string) (string, io.ReadCloser) {
 	var sb strings.Builder
 	sb.WriteString(path)
 	var ps []string
@@ -129,7 +129,7 @@ func (c Client) histogramHandlerDeriveCacheKey(path string, params url.Values,
 	}
 
 	sb.WriteString(extra)
-	return md5.Checksum(sb.String())
+	return md5.Checksum(sb.String()), body
 }
 
 // histogramHandlerFastForwardURL returns the url to fetch the Fast Forward value

--- a/internal/proxy/origins/irondb/handler_histogram_test.go
+++ b/internal/proxy/origins/irondb/handler_histogram_test.go
@@ -95,14 +95,14 @@ func TestHistogramHandlerDeriveCacheKey(t *testing.T) {
 	}
 
 	expected := "11cc1b20a869f6ff0559b08b014c3ca6"
-	result := client.histogramHandlerDeriveCacheKey(path, r.URL.Query(), r.Header, r.Body, "extra")
+	result, _ := client.histogramHandlerDeriveCacheKey(path, r.URL.Query(), r.Header, r.Body, "extra")
 	if result != expected {
 		t.Errorf("expected %s got %s", expected, result)
 	}
 
 	expected = "c70681051e3af3de12f37686b6a4224f"
 	path = "/irondb/0/900/00112233-4455-6677-8899-aabbccddeeff/metric"
-	result = client.histogramHandlerDeriveCacheKey(path, r.URL.Query(), r.Header, r.Body, "extra")
+	result, _ = client.histogramHandlerDeriveCacheKey(path, r.URL.Query(), r.Header, r.Body, "extra")
 	if result != expected {
 		t.Errorf("expected %s got %s", expected, result)
 	}

--- a/internal/proxy/origins/irondb/handler_text.go
+++ b/internal/proxy/origins/irondb/handler_text.go
@@ -82,7 +82,7 @@ func (c *Client) textHandlerParseTimeRangeQuery(
 // textHandlerDeriveCacheKey calculates a query-specific keyname based on the
 // user request.
 func (c Client) textHandlerDeriveCacheKey(path string, params url.Values,
-	headers http.Header, body io.ReadCloser, extra string) string {
+	headers http.Header, body io.ReadCloser, extra string) (string, io.ReadCloser) {
 	var sb strings.Builder
 	sb.WriteString(path)
 	ps := strings.SplitN(strings.TrimPrefix(path, "/"), "/", 5)
@@ -91,5 +91,5 @@ func (c Client) textHandlerDeriveCacheKey(path string, params url.Values,
 	}
 
 	sb.WriteString(extra)
-	return md5.Checksum(sb.String())
+	return md5.Checksum(sb.String()), body
 }

--- a/internal/proxy/origins/irondb/handler_text_test.go
+++ b/internal/proxy/origins/irondb/handler_text_test.go
@@ -68,7 +68,7 @@ func TestTextHandlerDeriveCacheKey(t *testing.T) {
 	}
 
 	const expected = "a506d1700414b1d0ac15340bd619fdab"
-	result := client.textHandlerDeriveCacheKey(path, r.URL.Query(), r.Header, r.Body, "extra")
+	result, _ := client.textHandlerDeriveCacheKey(path, r.URL.Query(), r.Header, r.Body, "extra")
 	if result != expected {
 		t.Errorf("expected %s got %s", expected, result)
 	}


### PR DESCRIPTION
this patch addresses an issue where key hashers that read request body content are not able to reset set the request body to byte 0 for additional processors to read it as well (e.g, in the event of a cache miss when the request body needs to be forwarded to an origin server).