### PR TITLE
Helm Updates

### DIFF
--- a/deploy/helm/trickster/Chart.yaml
+++ b/deploy/helm/trickster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.0
 description: Trickster is a reverse proxy cache for the Prometheus HTTP API that dramatically accelerates chart rendering times for any series queried from Prometheus.
 name: trickster
-version: 1.4.0
+version: 1.4.1
 home: https://github.com/Comcast/trickster
 icon: https://github.com/Comcast/trickster/blob/master/docs/images/logos/trickster-horizontal-sm.png?raw=true
 sources:

--- a/deploy/helm/trickster/templates/configmap.yaml
+++ b/deploy/helm/trickster/templates/configmap.yaml
@@ -34,125 +34,130 @@ data:
     {{- if gt (len .Values.caches) 0 }}
 
     [caches]
-      {{- range .Values.caches }}
+      {{- range $key, $cache := .Values.caches }}
 
-      {{ printf "[caches.%s]" .name }}
-        {{- if .cacheType }}
-      cache_type = {{ .cacheType | quote }}
+      {{ printf "[caches.%s]" $cache.name }}
+        {{- if $cache.cacheType }}
+      cache_type = {{ $cache.cacheType | quote }}
         {{- end }}
-        {{- if and (ne .cacheType "redis") (ne .cacheType "badger") }}
-        {{- if .index }}
-        {{ printf "[caches.%s.index]" .name }}
-        {{- if .index.reapIntervalSecs }}
-        reap_interval_secs = {{ .index.reapIntervalSecs }}
+        {{- if and (ne $cache.cacheType "redis") (ne $cache.cacheType "badger") }}
+        {{- if $cache.index }}
+        {{ printf "[caches.%s.index]" $cache.name }}
+        {{- if $cache.index.reapIntervalSecs }}
+        reap_interval_secs = {{ $cache.index.reapIntervalSecs }}
         {{- end }}
-        {{- if .index.flushIntervalSecs }}
-        flush_interval_secs = {{ .index.flushIntervalSecs }}
+        {{- if $cache.index.flushIntervalSecs }}
+        flush_interval_secs = {{ $cache.index.flushIntervalSecs }}
         {{- end }}
-        {{- if .index.maxSizeBytes }}
-        max_size_bytes = {{ .index.maxSizeBytes }}
+        {{- if $cache.index.maxSizeBytes }}
+        max_size_bytes = {{ $cache.index.maxSizeBytes }}
         {{- end }}
-        {{- if .index.maxSizeBackoffBytes }}
-        max_size_backoff_bytes = {{ .index.maxSizeBackoffBytes }}
+        {{- if $cache.index.maxSizeBackoffBytes }}
+        max_size_backoff_bytes = {{ $cache.index.maxSizeBackoffBytes }}
         {{- end }}
-        {{- if .index.maxSizeObjects }}
-        max_size_objects = {{ .index.maxSizeObjects }}
+        {{- if $cache.index.maxSizeObjects }}
+        max_size_objects = {{ $cache.index.maxSizeObjects }}
         {{- end }}
-        {{- if .index.maxSizeBackoffObjects }}
-        max_size_backoff_objects = {{ .index.maxSizeBackoffObjects }}
+        {{- if $cache.index.maxSizeBackoffObjects }}
+        max_size_backoff_objects = {{ $cache.index.maxSizeBackoffObjects }}
         {{- end }}
         {{- end }}
         {{- end }}
-        {{- if and (eq .cacheType "redis") ( .redis ) }}
+        {{- if and (eq $cache.cacheType "redis") ( .redis ) }}
 
-        {{ printf "[caches.%s.redis]" .name }}
-          {{- if .redis.clientType }}
-        client_type = {{ .redis.clientType | quote }}
+        {{ printf "[caches.%s.redis]" $cache.name }}
+          {{- if $cache.redis.clientType }}
+        client_type = {{ $cache.redis.clientType | quote }}
           {{- end }}
-          {{- if .redis.protocol }}
-        protocol = {{ .redis.protocol | quote }}
+          {{- if $cache.redis.protocol }}
+        protocol = {{ $cache.redis.protocol | quote }}
           {{- end }}
-          {{- if .redis.password }}
-        password = {{ .redis.password | quote }}
+          {{- if $cache.redis.password }}
+        password = {{ $cache.redis.password | quote }}
           {{- end }}
-          {{- if or (eq .redis.clientType "cluster") (eq .redis.clientType "sentinel") }}
-            {{- if .redis.endpoints }}
-        endpoints = [ '{{- join "', '" .redis.endpoints }}' ]
+          {{- if or (eq $cache.redis.clientType "cluster") (eq $cache.redis.clientType "sentinel") }}
+            {{- if $cache.redis.endpoints }}
+        endpoints = [ '{{- join "', '" $cache.redis.endpoints }}' ]
             {{- end }}
-            {{- if eq .redis.clientType "sentinel" }}
-              {{- if .redis.sentinelMaster }}
-        sentinel_master = {{ .redis.sentinelMaster | quote }}
+            {{- if eq $cache.redis.clientType "sentinel" }}
+              {{- if $cache.redis.sentinelMaster }}
+        sentinel_master = {{ $cache.redis.sentinelMaster | quote }}
               {{- end }}
             {{- end }}
           {{- else }}
-            {{- if .redis.endpoint }}
-        endpoint = {{ .redis.endpoint | quote }}
+            {{- if $cache.redis.endpoint }}
+        endpoint = {{ $cache.redis.endpoint | quote }}
             {{- end }}
           {{- end }}
-          {{- if .redis.db }}
-        db = {{ .redis.db }}
+          {{- if $cache.redis.db }}
+        db = {{ $cache.redis.db }}
           {{- end }}
-          {{- if .redis.maxRetries }}
-        max_retries = {{ .redis.maxRetries }}
+          {{- if $cache.redis.maxRetries }}
+        max_retries = {{ $cache.redis.maxRetries }}
           {{- end }}
-          {{- if .redis.minRetryBackoffMs }}
-        min_retry_backoff_ms = {{ .redis.minRetryBackoffMs }}
+          {{- if $cache.redis.minRetryBackoffMs }}
+        min_retry_backoff_ms = {{ $cache.redis.minRetryBackoffMs }}
           {{- end }}
-          {{- if .redis.maxRetyBackoffMs }}
-        max_retry_backoff_ms = {{ .redis.maxRetyBackoffMs }}
+          {{- if $cache.redis.maxRetyBackoffMs }}
+        max_retry_backoff_ms = {{ $cache.redis.maxRetyBackoffMs }}
           {{- end }}
-          {{- if .redis.dialTimeoutMs }}
-        dial_timeout_ms = {{ .redis.dialTimeoutMs }}
+          {{- if $cache.redis.dialTimeoutMs }}
+        dial_timeout_ms = {{ $cache.redis.dialTimeoutMs }}
           {{- end }}
-          {{- if .redis.readTimeoutMs }}
-        read_timeout_ms = {{ .redis.readTimeoutMs }}
+          {{- if $cache.redis.readTimeoutMs }}
+        read_timeout_ms = {{ $cache.redis.readTimeoutMs }}
           {{- end }}
-          {{- if .redis.writeTimeoutMs }}
-        write_timeout_ms = {{ .redis.writeTimeoutMs }}
+          {{- if $cache.redis.writeTimeoutMs }}
+        write_timeout_ms = {{ $cache.redis.writeTimeoutMs }}
           {{- end }}
-          {{- if .redis.poolSize }}
-        pool_size = {{ .redis.poolSize }}
+          {{- if $cache.redis.poolSize }}
+        pool_size = {{ $cache.redis.poolSize }}
           {{- end }}
-          {{- if .redis.minIdleConns }}
-        min_idle_conns = {{ .redis.minIdleConns }}
+          {{- if $cache.redis.minIdleConns }}
+        min_idle_conns = {{ $cache.redis.minIdleConns }}
           {{- end }}
-          {{- if .redis.maxConnAgeMs }}
-        max_conn_age_ms = {{ .redis.maxConnAgeMs }}
+          {{- if $cache.redis.maxConnAgeMs }}
+        max_conn_age_ms = {{ $cache.redis.maxConnAgeMs }}
           {{- end }}
-          {{- if .redis.poolTimeoutMs }}
-        pool_timeout_ms = {{ .redis.poolTimeoutMs }}
+          {{- if $cache.redis.poolTimeoutMs }}
+        pool_timeout_ms = {{ $cache.redis.poolTimeoutMs }}
           {{- end }}
-          {{- if .redis.idleTimeoutMs }}
-        idle_timeout_ms = {{ .redis.idleTimeoutMs }}
+          {{- if $cache.redis.idleTimeoutMs }}
+        idle_timeout_ms = {{ $cache.redis.idleTimeoutMs }}
           {{- end }}
-          {{- if .redis.idleCheckFrequencyMs }}
-        idle_check_frequency_ms = {{ .redis.idleCheckFrequencyMs }}
+          {{- if $cache.redis.idleCheckFrequencyMs }}
+        idle_check_frequency_ms = {{ $cache.redis.idleCheckFrequencyMs }}
           {{- end }}
-          {{- else if and (eq .cacheType "filesystem") ( .filesystem ) }}
 
-        {{ printf "[caches.%s.filesystem]" .name }}
-          {{- if .filesystem.path }}
-        cache_path = {{ .filesystem.path | quote }}
+        {{- else if (eq $cache.cacheType "filesystem") }}
+        {{ printf "[caches.%s.filesystem]" $cache.name }}
+          {{- range $vName, $value := $.Values.volumes }}
+          {{- if eq $vName $cache.volumeName }}
+        cache_path = {{ printf "%s/%s/" $value.mountPath $cache.name }}
           {{- end }}
-        {{- else if and (eq .cacheType "bbolt") ( .bbolt ) }}
+          {{- end }}
 
-        {{ printf "[caches.%s.bbolt]" .name }}
-          {{- if .bbolt.file }}
-        filename = {{ .bbolt.file | quote }}
+        {{- else if and (eq $cache.cacheType "bbolt") ( $cache.bbolt ) }}
+        {{ printf "[caches.%s.bbolt]" $cache.name }}
+          {{- range $vName, $value := $.Values.volumes }}
+          {{- if eq $vName $cache.volumeName }}
+        filename = {{ printf "%s/%s/%s" $value.mountPath $cache.name $cache.bbolt.file }}
           {{- end }}
-          {{- if .bbolt.bucket }}
-        bucket = {{ .bbolt.bucket | quote }}
           {{- end }}
-        {{- else if and (eq .cacheType "badger") ( .badger ) }}
+          {{- if $cache.bbolt.bucket }}
+        bucket = {{ $cache.bbolt.bucket | quote }}
+          {{- end }}
 
-        {{ printf "[caches.%s.badger]" .name }}
-          {{- if .badger.directory }}
-        directory = {{ .badger.directory | quote }}
+        {{- else if and (eq $cache.cacheType "badger") ( $cache.badger ) }}
+        {{ printf "[caches.%s.badger]" $cache.name }}
+          {{- range $vName, $value := $.Values.volumes }}
+          {{- if eq $vName $cache.volumeName }}
+        directory = {{ printf "%s/%s/" $value.mountPath $cache.name }}
+        value_directory = {{ printf "%s/" $value.mountPath }}
           {{- end }}
-          {{- if .badger.valueDirectory }}
-        value_directory = {{ .badger.valueDirectory | quote }}
           {{- end }}
         {{- end }}
+
       {{- end }}
     {{- end }}
     {{- end }}

--- a/deploy/helm/trickster/templates/deployment.yaml
+++ b/deploy/helm/trickster/templates/deployment.yaml
@@ -25,8 +25,7 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     {{- end }}    
       labels:
-        app: {{ template "trickster.name" . }}
-        release: {{ .Release.Name }}
+        {{- include "trickster.labels" . | nindent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
@@ -58,6 +57,8 @@ spec:
           {{- end }}
         {{- end }}
           volumeMounts:
+            - name: cfg-volume
+              mountPath: /etc/trickster
           {{- range .Values.caches }}
           {{- if eq .cacheType "filesystem" }}
             - name: cfg-volume-{{ .name }}

--- a/deploy/helm/trickster/templates/deployment.yaml
+++ b/deploy/helm/trickster/templates/deployment.yaml
@@ -59,14 +59,13 @@ spec:
           volumeMounts:
             - name: cfg-volume
               mountPath: /etc/trickster
-          {{- range .Values.caches }}
-          {{- if eq .cacheType "filesystem" }}
-            - name: cfg-volume-{{ .name }}
-              {{- if eq .path "" }}
-              mountPath: /tmp/trickster
-              {{- else }}
-              mountPath: {{ .path }}
-              {{- end }}
+          {{- range $key, $value := .Values.volumes }}
+          {{- range $.Values.caches }}
+          {{- if eq .volumeName $key }}
+            - name: cache-volume-{{ $key }}
+              mountPath: {{ $value.mountPath }}
+              subPath: {{ .name }}
+          {{- end }}
           {{- end }}
           {{- end }}
           ports:
@@ -113,10 +112,14 @@ spec:
             items:
               - key: trickster.conf
                 path: trickster.conf
-        - name: cache-volume
-        {{- if .Values.persistentVolume.enabled }}
+      {{- range $key, $value := .Values.volumes }}
+      {{- if $value.enabled }}
+        - name: cache-volume-{{ $key }}
+        {{- if eq $value.type "persistentVolume" }}
           persistentVolumeClaim:
-            claimName: {{ if .Values.persistentVolume.existingClaim }}{{ .Values.persistentVolume.existingClaim }}{{- else }}{{ template "trickster.fullname" . }}{{- end }}
+            claimName: {{ if .existingClaim }}{{ .existingClaim }}{{- else }}{{-  printf "trickster-%s-claim" $key -}}{{- end }}
         {{- else }}
           emptyDir: {}
-        {{- end -}}
+        {{- end }}
+      {{- end }}
+      {{- end }}

--- a/deploy/helm/trickster/templates/ingress.yaml
+++ b/deploy/helm/trickster/templates/ingress.yaml
@@ -1,22 +1,23 @@
 {{- if .Values.ingress.enabled -}}
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := include "trickster.fullname" . }}
-{{- $servicePort := .Values.trickster.service.servicePort -}}
+{{- $servicePort := .Values.service.servicePort -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
+  name: trickster-ingress
 {{- if .Values.ingress.annotations }}
   annotations:
 {{ toYaml .Values.ingress.annotations | indent 4 }}
 {{- end }}
   labels:
     {{- include "trickster.labels" . | nindent 4 }}
-{{- range $key, $value := .Values.trickster.ingress.extraLabels }}
+{{- range $key, $value := .Values.ingress.extraLabels }}
     {{ $key }}: {{ $value }}
 {{- end }}
 spec:
   rules:
-  {{- range .Values.server.ingress.hosts }}
+  {{- range .Values.ingress.hosts }}
     {{- $url := splitList "/" . }}
     - host: {{ first $url }}
       http:

--- a/deploy/helm/trickster/templates/pvc.yaml
+++ b/deploy/helm/trickster/templates/pvc.yaml
@@ -1,27 +1,30 @@
-{{- if .Values.persistentVolume.enabled -}}
-{{- if not .Values.persistentVolume.existingClaim -}}
+{{- range .Values.volumes }}
+{{- if and (eq .type "persistentVolume") .enabled}}
+{{- if (eq .existingClaim "") }}
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  {{- if .Values.persistentVolume.annotations }}
+  {{- if .annotations }}
   annotations:
-{{ toYaml .Values.persistentVolume.annotations | indent 4 }}
+{{ toYaml .annotations | indent 4 }}
   {{- end }}
   labels:
-    {{- include "trickster.labels" . | nindent 4 }}
-  name: {{ template "trickster.fullname" . }}
+    {{- include "trickster.labels" $ | nindent 4 }}
+  name: {{ .volName | printf "trickster-%s-claim" }}
 spec:
   accessModes:
-{{ toYaml .Values.persistentVolume.accessModes | indent 4 }}
-{{- if .Values.persistentVolume.storageClass }}
-{{- if (eq "-" .Values.persistentVolume.storageClass) }}
+{{ toYaml .accessModes | indent 4 }}
+{{- if .storageClass }}
+{{- if (eq "-" .storageClass) }}
   storageClassName: ""
 {{- else }}
-  storageClassName: "{{ .Values.persistentVolume.storageClass }}"
+  storageClassName: "{{ .storageClass }}"
 {{- end }}
 {{- end }}
   resources:
     requests:
-      storage: "{{ .Values.persistentVolume.size }}"
+      storage: "{{ .size }}"
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/trickster/values.yaml
+++ b/deploy/helm/trickster/values.yaml
@@ -406,7 +406,7 @@ replicaCount: 1
 ##
 image:
   repository: tricksterio/trickster
-  tag: 1.0
+  tag: "1.0"
   pullPolicy: IfNotPresent
 
 # Service resource for trickster deplyoment

--- a/deploy/helm/trickster/values.yaml
+++ b/deploy/helm/trickster/values.yaml
@@ -212,6 +212,9 @@ origins:
 #     # options are 'bbolt', 'badger', 'filesystem', 'memory', and 'redis'
 #     cacheType: memory
 
+#     # if using 'bbolt', 'badger', or 'filesystem' you must link a volume as defined below
+      #volumeName: thing-volume
+
 #     ## Configuration options for the Cache Index
 #     # The Cache Index handles key management and retention for bbolt, filesystem and memory
 #     # Redis and BadgerDB handle those functions natively and does not use the Trickster's Cache Index
@@ -310,11 +313,9 @@ origins:
 #       #idleCheckFrequencyMs is the frequency of idle checks made by idle connections reaper.
 #       idleCheckFrequencyMs: "60000"
 
-#     ## Configuration options when using a Filesystem Cache
-#     filesystem:
-#       # path defines the directory location under which the Trickster cache will be maintained
-#       path: /tmp/trickster
+#     filesystem;
 
+          
 #     ## Configuration options when using a bbolt Cache
 #     bbolt:
 #       # file defines the file where the Trickster cache will be maintained
@@ -323,13 +324,7 @@ origins:
 #       # bucket defines the name of the BotlDb bucket (similar to a namespace) under which our key value store lives
 #       bucket: trickster
 
-#     ## Configuration options when using a Badger cache
-#     badger:
-#       # directory defines the directory location under which the Badger data will be maintained
-#       directory: /tmp/trickster
-
-#       # valueDirectory defines the directory location under which the Badger value log will be maintained
-#       valueDirectory: /tmp/trickster
+#      badger:
 
 # negativeCaches:
 # #  The 'default' negative cache config, mapped by all origins by default, is empty unless you populate it.
@@ -461,40 +456,59 @@ ingress:
   #   hosts:
   #     - chart-example.local
 
-persistentVolume:
-  ## If true, trickster will create/use a Persistent Volume Claim
-  ## If false, use emptyDir
-  ##
-  enabled: false
 
-  ## trickster data Persistent Volume access modes
-  ## Must match those of existing PV or dynamic provisioner
-  ## Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-  ##
-  accessModes:
-    - ReadWriteOnce
+volumes:
+  persistent:
+    ## If true, trickster will create/use a named Persistent Volume Claim
+    ##
+    type: "persistentVolume"
+    enabled: false
 
-  ## trickster data Persistent Volume Claim annotations
-  ##
-  annotations: {}
+    mountPath: "/tmp/trickster"
+  
+    ## trickster data Persistent Volume access modes
+    ## Must match those of existing PV or dynamic provisioner
+    ## Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
+    accessModes:
+      - ReadWriteOnce
+  
+    ## trickster data Persistent Volume Claim annotations
+    ##
+    annotations: {}
+  
+    ## trickster data Persistent Volume existing claim name
+    ## Requires trickster.persistentVolume.enabled: true
+    ## If defined, PVC must be created manually before volume will be bound
+    existingClaim: ""
+  
+    ## trickster data Persistent Volume size
+    ##
+    size: 15Gi
+  
+    ## trickster data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
 
-  ## trickster data Persistent Volume existing claim name
-  ## Requires trickster.persistentVolume.enabled: true
-  ## If defined, PVC must be created manually before volume will be bound
-  existingClaim: ""
+    ## Must include
+    mountPath: "/tmp/trickster"
 
-  ## trickster data Persistent Volume size
-  ##
-  size: 15Gi
+  generic:
+    ## Will create an empty dir to be used
+    ##
+    type: "generic"
+    enabled: true
 
-  ## trickster data Persistent Volume Storage Class
-  ## If defined, storageClassName: <storageClass>
-  ## If set to "-", storageClassName: "", which disables dynamic provisioning
-  ## If undefined (the default) or set to null, no storageClassName spec is
-  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-  ##   GKE, AWS & OpenStack)
-  ##
-  # storageClass: "-"
+    ## Must include
+    mountPath: "/tmp/trickster"
+
+
+
 
 ## Annotations to be added to trickster pods
 ##
@@ -518,4 +532,3 @@ resources: {}
 ## Security context to be added to trickster pods
 ##
 securityContext: {}
-

--- a/deploy/helm/trickster/values.yaml
+++ b/deploy/helm/trickster/values.yaml
@@ -212,7 +212,8 @@ origins:
 #     # options are 'bbolt', 'badger', 'filesystem', 'memory', and 'redis'
 #     cacheType: memory
 
-#     # if using 'bbolt', 'badger', or 'filesystem' you must link a volume as defined below
+#     # if using 'bbolt', 'badger', or 'filesystem' you must link a volume as defined below in
+#     # the volumes section on the helm chart. Paths will automatically be generated. Just match the names.
       #volumeName: thing-volume
 
 #     ## Configuration options for the Cache Index
@@ -314,7 +315,7 @@ origins:
 #       idleCheckFrequencyMs: "60000"
 
 #     filesystem;
-
+#       # Nothing to include here - this is handled by helm templating. 
           
 #     ## Configuration options when using a bbolt Cache
 #     bbolt:
@@ -324,7 +325,8 @@ origins:
 #       # bucket defines the name of the BotlDb bucket (similar to a namespace) under which our key value store lives
 #       bucket: trickster
 
-#      badger:
+#     badger:
+#       # Nothing to include here - this is handled by helm templating. 
 
 # negativeCaches:
 # #  The 'default' negative cache config, mapped by all origins by default, is empty unless you populate it.
@@ -456,7 +458,10 @@ ingress:
   #   hosts:
   #     - chart-example.local
 
-
+## Enter volumes of type 'persistentVolume', or 'generic'
+## Below are the configuration options for each. 
+## Match the volume names to the volume name per cache.
+## Multiple caches may map to one volume config.
 volumes:
   persistent:
     ## If true, trickster will create/use a named Persistent Volume Claim
@@ -464,6 +469,7 @@ volumes:
     type: "persistentVolume"
     enabled: false
 
+    ## Must include
     mountPath: "/tmp/trickster"
   
     ## trickster data Persistent Volume access modes
@@ -494,9 +500,6 @@ volumes:
     ##   GKE, AWS & OpenStack)
     ##
     # storageClass: "-"
-
-    ## Must include
-    mountPath: "/tmp/trickster"
 
   generic:
     ## Will create an empty dir to be used

--- a/deploy/helm/trickster/values.yaml
+++ b/deploy/helm/trickster/values.yaml
@@ -214,7 +214,7 @@ origins:
 
 #     # if using 'bbolt', 'badger', or 'filesystem' you must link a volume as defined below in
 #     # the volumes section on the helm chart. Paths will automatically be generated. Just match the names.
-      #volumeName: thing-volume
+      #volumeName: example-volume-name
 
 #     ## Configuration options for the Cache Index
 #     # The Cache Index handles key management and retention for bbolt, filesystem and memory


### PR DESCRIPTION
# General
Fixes:
1. label selectors not matching labels
2. missing config mount path
3. unquoted `1.0` image tag truncates to `1`, which is not the same image tag.
4. change mounting path pattern now that we have multiple configs
5. fix ingress controller templating

# Details
### 1
The first issue relates to [label selector updates](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#label-selector-updates)

### 2
Not sure how the second issue came about. No matter what was changed my config values were not reflected -> missing volume mount. The helm templated trickster config was never being exposed in the pod.

### 3
Last issue is just a simple fix due to how helm does numbers.

### 4
This is probably the beefiest section of the rework.
The new scheme supports multiple many to one and many to many relationships between filesystem reliant caches and the underlying volumes present in Kubernetes.

Each cache now has a `volumeName` section that maps to the corresponding name present in the `volumes` section of the Values file. Multiple caches may map to a single volume. This is facilitated by `subDir`s on the volumeMount.

We may need to think this through harder as more use cases arise but for now the filesystem related caching option have simplified because of this mapping as the details of where to spin up a cache are handled in templating. 

Any given filesystem dependent cache will appear at the value generated by `.Values.volumes.[].mountPath/.cache.Name/`

### 5
just some mis-matched templating.


_Side Node:_ There could be a way better solution to these. I haven't touched helm in a while. If anyone has suggestions please say so.