### PR TITLE
Fix health probe runtime error

### DIFF
--- a/internal/util/middleware/config_context.go
+++ b/internal/util/middleware/config_context.go
@@ -26,7 +26,12 @@ import (
 // WithResourcesContext ...
 func WithResourcesContext(client origins.Client, oc *config.OriginConfig, c cache.Cache, p *config.PathConfig, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resources := request.NewResources(oc, p, c.Configuration(), c, client)
+		var resources *request.Resources
+		if c == nil {
+			resources = request.NewResources(oc, p, nil, nil, client)
+		} else {
+			resources = request.NewResources(oc, p, c.Configuration(), c, client)
+		}
 		next.ServeHTTP(w, r.WithContext(context.WithResources(r.Context(), resources)))
 	})
 }


### PR DESCRIPTION
```
2020/02/13 14:41:11 http: panic serving 127.0.0.1:56594: runtime error: invalid memory address or nil pointer dereference
goroutine 462008 [running]:
net/http.(*conn).serve.func1(0xc0000b1540)
	/usr/local/go/src/net/http/server.go:1767 +0x139
panic(0xacdb80, 0x1154c30)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/Comcast/trickster/internal/util/middleware.WithResourcesContext.func1(0xca2460, 0xc000191180, 0xc0003eef00)
	/go/src/github.com/Comcast/trickster/internal/util/middleware/config_context.go:29 +0x83
net/http.HandlerFunc.ServeHTTP(0xc000157130, 0xca2460, 0xc000191180, 0xc0003eef00)
	/usr/local/go/src/net/http/server.go:2007 +0x44
github.com/gorilla/mux.(*Router).ServeHTTP(0xc00017e000, 0xca2460, 0xc000191180, 0xc0003eeb00)
	/go/pkg/mod/github.com/gorilla/mux@v1.7.3/mux.go:212 +0xe2
github.com/gorilla/handlers.CompressHandlerLevel.func1(0xca2460, 0xc000191180, 0xc0003eeb00)
	/go/pkg/mod/github.com/gorilla/handlers@v1.4.2/compress.go:148 +0x19b
net/http.HandlerFunc.ServeHTTP(0xc00021e1a0, 0xca2460, 0xc000191180, 0xc0003eeb00)
	/usr/local/go/src/net/http/server.go:2007 +0x44
net/http.serverHandler.ServeHTTP(0xc0001901c0, 0xca2460, 0xc000191180, 0xc0003eeb00)
	/usr/local/go/src/net/http/server.go:2802 +0xa4
net/http.(*conn).serve(0xc0000b1540, 0xca4720, 0xc0006b3700)
	/usr/local/go/src/net/http/server.go:1890 +0x875
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:2928 +0x384
```