### PR TITLE
remove gobal state from logging

### DIFF
--- a/internal/cache/badger/badger_test.go
+++ b/internal/cache/badger/badger_test.go
@@ -21,11 +21,12 @@ import (
 
 	"github.com/Comcast/trickster/internal/cache/status"
 	"github.com/Comcast/trickster/internal/config"
+	tl "github.com/Comcast/trickster/internal/util/log"
 	"github.com/Comcast/trickster/internal/util/metrics"
 )
 
 func init() {
-	metrics.Init(&config.TricksterConfig{})
+	metrics.Init(&config.TricksterConfig{}, tl.ConsoleLogger("error"))
 }
 
 const cacheType = "badger"
@@ -42,7 +43,7 @@ func newCacheConfig(t *testing.T) config.CachingConfig {
 func TestConfiguration(t *testing.T) {
 	cacheConfig := newCacheConfig(t)
 	defer os.RemoveAll(cacheConfig.Badger.Directory)
-	bc := Cache{Config: &cacheConfig}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	cfg := bc.Configuration()
 	if cfg.CacheType != cacheType {
@@ -53,7 +54,7 @@ func TestConfiguration(t *testing.T) {
 func TestBadgerCache_Connect(t *testing.T) {
 	cacheConfig := newCacheConfig(t)
 	defer os.RemoveAll(cacheConfig.Badger.Directory)
-	bc := Cache{Config: &cacheConfig}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	// it should connect
 	if err := bc.Connect(); err != nil {
@@ -66,7 +67,7 @@ func TestBadgerCache_ConnectFailed(t *testing.T) {
 	cacheConfig := newCacheConfig(t)
 	cacheConfig.Badger.Directory = "/root/trickster-test-noaccess"
 	os.RemoveAll(cacheConfig.Badger.Directory)
-	bc := Cache{Config: &cacheConfig}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	// it should connect
 	err := bc.Connect()
@@ -79,7 +80,7 @@ func TestBadgerCache_ConnectFailed(t *testing.T) {
 func TestBadgerCache_Store(t *testing.T) {
 	cacheConfig := newCacheConfig(t)
 	defer os.RemoveAll(cacheConfig.Badger.Directory)
-	bc := Cache{Config: &cacheConfig}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	if err := bc.Connect(); err != nil {
 		t.Error(err)
@@ -96,7 +97,7 @@ func TestBadgerCache_Store(t *testing.T) {
 func TestBadgerCache_Remove(t *testing.T) {
 	cacheConfig := newCacheConfig(t)
 	defer os.RemoveAll(cacheConfig.Badger.Directory)
-	bc := Cache{Config: &cacheConfig}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	if err := bc.Connect(); err != nil {
 		t.Error(err)
@@ -136,7 +137,7 @@ func TestBadgerCache_Remove(t *testing.T) {
 func TestBadgerCache_BulkRemove(t *testing.T) {
 	cacheConfig := newCacheConfig(t)
 	defer os.RemoveAll(cacheConfig.Badger.Directory)
-	bc := Cache{Config: &cacheConfig}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	if err := bc.Connect(); err != nil {
 		t.Error(err)
@@ -179,7 +180,7 @@ func TestBadgerCache_BulkRemove(t *testing.T) {
 func TestBadgerCache_Retrieve(t *testing.T) {
 	cacheConfig := newCacheConfig(t)
 	defer os.RemoveAll(cacheConfig.Badger.Directory)
-	bc := Cache{Config: &cacheConfig}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	if err := bc.Connect(); err != nil {
 		t.Error(err)
@@ -262,7 +263,7 @@ func TestBadgerCache_Close(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	cacheConfig := config.CachingConfig{CacheType: cacheType, Badger: config.BadgerCacheConfig{Directory: dir, ValueDirectory: dir}}
-	bc := Cache{Config: &cacheConfig}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	if err := bc.Connect(); err != nil {
 		t.Error(err)

--- a/internal/cache/bbolt/bbolt_test.go
+++ b/internal/cache/bbolt/bbolt_test.go
@@ -21,14 +21,13 @@ import (
 	"time"
 
 	"github.com/Comcast/trickster/internal/cache/status"
-	"github.com/Comcast/trickster/internal/util/log"
-
 	"github.com/Comcast/trickster/internal/config"
+	tl "github.com/Comcast/trickster/internal/util/log"
 	"github.com/Comcast/trickster/internal/util/metrics"
 )
 
 func init() {
-	metrics.Init(&config.TricksterConfig{})
+	metrics.Init(&config.TricksterConfig{}, tl.ConsoleLogger("error"))
 }
 
 const cacheType = "bbolt"
@@ -41,11 +40,10 @@ func newCacheConfig() config.CachingConfig {
 }
 
 func storeBenchmark(b *testing.B) Cache {
-	log.Logger = log.ConsoleLogger("none")
 	testDbPath := "/tmp/test.db"
 	os.Remove(testDbPath)
 	cacheConfig := config.CachingConfig{CacheType: cacheType, BBolt: config.BBoltCacheConfig{Filename: testDbPath, Bucket: "trickster_test"}, Index: config.CacheIndexConfig{ReapInterval: time.Second}}
-	bc := Cache{Config: &cacheConfig}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 	defer os.RemoveAll(cacheConfig.BBolt.Filename)
 
 	err := bc.Connect()
@@ -65,7 +63,7 @@ func storeBenchmark(b *testing.B) Cache {
 
 func TestConfiguration(t *testing.T) {
 	cacheConfig := newCacheConfig()
-	bc := Cache{Config: &cacheConfig}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 	cfg := bc.Configuration()
 	if cfg.CacheType != cacheType {
 		t.Errorf("expected %s got %s", cacheType, cfg.CacheType)
@@ -75,7 +73,7 @@ func TestConfiguration(t *testing.T) {
 func TestBboltCache_Connect(t *testing.T) {
 	cacheConfig := newCacheConfig()
 	defer os.RemoveAll(cacheConfig.BBolt.Filename)
-	bc := Cache{Config: &cacheConfig}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 	// it should connect
 	err := bc.Connect()
 	if err != nil {
@@ -88,7 +86,7 @@ func TestBboltCache_ConnectFailed(t *testing.T) {
 	const expected = `open /root/noaccess.bbolt:`
 	cacheConfig := newCacheConfig()
 	cacheConfig.BBolt.Filename = "/root/noaccess.bbolt"
-	bc := Cache{Config: &cacheConfig}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 	// it should connect
 	err := bc.Connect()
 	if err == nil {
@@ -106,7 +104,7 @@ func TestBboltCache_ConnectBadBucketName(t *testing.T) {
 	cacheConfig := newCacheConfig()
 	cacheConfig.BBolt.Bucket = ""
 	defer os.RemoveAll(cacheConfig.BBolt.Filename)
-	bc := Cache{Config: &cacheConfig}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 	// it should connect
 	err := bc.Connect()
 	if err == nil {
@@ -121,7 +119,7 @@ func TestBboltCache_ConnectBadBucketName(t *testing.T) {
 func TestBboltCache_Store(t *testing.T) {
 
 	cacheConfig := newCacheConfig()
-	bc := Cache{Config: &cacheConfig}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 	defer os.RemoveAll(cacheConfig.BBolt.Filename)
 
 	err := bc.Connect()
@@ -145,7 +143,7 @@ func BenchmarkCache_Store(b *testing.B) {
 func TestBboltCache_SetTTL(t *testing.T) {
 
 	cacheConfig := newCacheConfig()
-	bc := Cache{Config: &cacheConfig}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 	defer os.RemoveAll(cacheConfig.BBolt.Filename)
 
 	err := bc.Connect()
@@ -223,7 +221,7 @@ func TestBboltCache_StoreNoIndex(t *testing.T) {
 	const expected = `value for key [] not in cache`
 
 	cacheConfig := newCacheConfig()
-	bc := Cache{Config: &cacheConfig}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	err := bc.Connect()
 	if err != nil {
@@ -308,7 +306,7 @@ func BenchmarkCache_StoreNoIndex(b *testing.B) {
 func TestBboltCache_Remove(t *testing.T) {
 
 	cacheConfig := newCacheConfig()
-	bc := Cache{Config: &cacheConfig}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 	defer os.RemoveAll(cacheConfig.BBolt.Filename)
 
 	err := bc.Connect()
@@ -388,7 +386,7 @@ func BenchmarkCache_Remove(b *testing.B) {
 func TestBboltCache_BulkRemove(t *testing.T) {
 
 	cacheConfig := newCacheConfig()
-	bc := Cache{Config: &cacheConfig}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 	defer os.RemoveAll(cacheConfig.BBolt.Filename)
 
 	err := bc.Connect()
@@ -456,7 +454,7 @@ func TestBboltCache_Retrieve(t *testing.T) {
 	const expected2 = `value for key [cacheKey] could not be deserialized from cache`
 
 	cacheConfig := newCacheConfig()
-	bc := Cache{Config: &cacheConfig}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 	defer os.RemoveAll(cacheConfig.BBolt.Filename)
 
 	err := bc.Connect()

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/Comcast/trickster/internal/config"
+	tl "github.com/Comcast/trickster/internal/util/log"
 	"github.com/Comcast/trickster/internal/util/metrics"
 )
 
@@ -29,7 +30,7 @@ func init() {
 	testCacheName = "test-cache"
 	testCacheType = "test"
 
-	metrics.Init(&config.TricksterConfig{})
+	metrics.Init(&config.TricksterConfig{}, tl.ConsoleLogger("error"))
 
 }
 

--- a/internal/cache/filesystem/filesystem_test.go
+++ b/internal/cache/filesystem/filesystem_test.go
@@ -23,22 +23,21 @@ import (
 
 	"github.com/Comcast/trickster/internal/cache/status"
 	"github.com/Comcast/trickster/internal/config"
-	"github.com/Comcast/trickster/internal/util/log"
+	tl "github.com/Comcast/trickster/internal/util/log"
 	"github.com/Comcast/trickster/internal/util/metrics"
 )
 
 func init() {
-	metrics.Init(&config.TricksterConfig{})
+	metrics.Init(&config.TricksterConfig{}, tl.ConsoleLogger("error"))
 }
 
 const cacheType = "filesystem"
 const cacheKey = "cacheKey"
 
 func storeBenchmark(b *testing.B) Cache {
-	log.Logger = log.ConsoleLogger("none")
 	dir, _ := ioutil.TempDir("/tmp", cacheType)
 	cacheConfig := config.CachingConfig{CacheType: cacheType, Filesystem: config.FilesystemCacheConfig{CachePath: dir}, Index: config.CacheIndexConfig{ReapInterval: time.Second}}
-	fc := Cache{Config: &cacheConfig}
+	fc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 	defer os.RemoveAll(cacheConfig.BBolt.Filename)
 
 	err := fc.Connect()
@@ -67,7 +66,7 @@ func newCacheConfig(t *testing.T) config.CachingConfig {
 func TestConfiguration(t *testing.T) {
 	cacheConfig := newCacheConfig(t)
 	defer os.RemoveAll(cacheConfig.Filesystem.CachePath)
-	fc := Cache{Config: &cacheConfig}
+	fc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 	cfg := fc.Configuration()
 	if cfg.CacheType != cacheType {
 		t.Fatalf("expected %s got %s", cacheType, cfg.CacheType)
@@ -78,7 +77,7 @@ func TestFilesystemCache_Connect(t *testing.T) {
 
 	cacheConfig := newCacheConfig(t)
 	defer os.RemoveAll(cacheConfig.Filesystem.CachePath)
-	fc := Cache{Config: &cacheConfig}
+	fc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	// it should connect
 	err := fc.Connect()
@@ -91,7 +90,7 @@ func TestFilesystemCache_ConnectFailed(t *testing.T) {
 	const expected = `[/root/noaccess.trickster.filesystem.cache] directory is not writeable by trickster:`
 	cacheConfig := newCacheConfig(t)
 	cacheConfig.Filesystem.CachePath = "/root/noaccess.trickster.filesystem.cache"
-	fc := Cache{Config: &cacheConfig}
+	fc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 	// it should connect
 	err := fc.Connect()
 	if err == nil {
@@ -110,7 +109,7 @@ func TestFilesystemCache_Store(t *testing.T) {
 
 	cacheConfig := newCacheConfig(t)
 	defer os.RemoveAll(cacheConfig.Filesystem.CachePath)
-	fc := Cache{Config: &cacheConfig}
+	fc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	err := fc.Connect()
 	if err != nil {
@@ -155,7 +154,7 @@ func TestFilesystemCache_StoreNoIndex(t *testing.T) {
 
 	cacheConfig := newCacheConfig(t)
 	defer os.RemoveAll(cacheConfig.Filesystem.CachePath)
-	fc := Cache{Config: &cacheConfig}
+	fc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	err := fc.Connect()
 	if err != nil {
@@ -239,7 +238,7 @@ func BenchmarkCache_StoreNoIndex(b *testing.B) {
 func TestFilesystemCache_SetTTL(t *testing.T) {
 
 	cacheConfig := newCacheConfig(t)
-	fc := Cache{Config: &cacheConfig}
+	fc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 	defer os.RemoveAll(cacheConfig.Filesystem.CachePath)
 
 	err := fc.Connect()
@@ -320,7 +319,7 @@ func TestFilesystemCache_Retrieve(t *testing.T) {
 
 	cacheConfig := newCacheConfig(t)
 	defer os.RemoveAll(cacheConfig.Filesystem.CachePath)
-	fc := Cache{Config: &cacheConfig}
+	fc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	err := fc.Connect()
 	if err != nil {
@@ -462,7 +461,7 @@ func TestFilesystemCache_Remove(t *testing.T) {
 
 	cacheConfig := newCacheConfig(t)
 	defer os.RemoveAll(cacheConfig.Filesystem.CachePath)
-	fc := Cache{Config: &cacheConfig}
+	fc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	err := fc.Connect()
 	if err != nil {
@@ -543,7 +542,7 @@ func TestFilesystemCache_BulkRemove(t *testing.T) {
 
 	cacheConfig := newCacheConfig(t)
 	defer os.RemoveAll(cacheConfig.Filesystem.CachePath)
-	fc := Cache{Config: &cacheConfig}
+	fc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	err := fc.Connect()
 	if err != nil {

--- a/internal/cache/memory/memory_test.go
+++ b/internal/cache/memory/memory_test.go
@@ -21,12 +21,12 @@ import (
 
 	"github.com/Comcast/trickster/internal/cache/status"
 	"github.com/Comcast/trickster/internal/config"
-	"github.com/Comcast/trickster/internal/util/log"
+	tl "github.com/Comcast/trickster/internal/util/log"
 	"github.com/Comcast/trickster/internal/util/metrics"
 )
 
 func init() {
-	metrics.Init(&config.TricksterConfig{})
+	metrics.Init(&config.TricksterConfig{}, tl.ConsoleLogger("error"))
 }
 
 const cacheType = "memory"
@@ -40,9 +40,8 @@ func (r *testReferenceObject) Size() int {
 }
 
 func storeBenchmark(b *testing.B) Cache {
-	log.Logger = log.ConsoleLogger("none")
 	cacheConfig := config.CachingConfig{CacheType: cacheType, Index: config.CacheIndexConfig{ReapInterval: 0}}
-	mc := Cache{Config: &cacheConfig}
+	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	err := mc.Connect()
 	if err != nil {
@@ -68,7 +67,7 @@ func newCacheConfig(t *testing.T) config.CachingConfig {
 
 func TestConfiguration(t *testing.T) {
 	cacheConfig := newCacheConfig(t)
-	mc := Cache{Config: &cacheConfig}
+	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 	cfg := mc.Configuration()
 	if cfg.CacheType != cacheType {
 		t.Fatalf("expected %s got %s", cacheType, cfg.CacheType)
@@ -78,7 +77,7 @@ func TestConfiguration(t *testing.T) {
 func TestCache_Connect(t *testing.T) {
 
 	cacheConfig := newCacheConfig(t)
-	mc := Cache{Config: &cacheConfig}
+	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	// it should connect
 	err := mc.Connect()
@@ -90,7 +89,7 @@ func TestCache_Connect(t *testing.T) {
 func TestCache_StoreReferenceDirect(t *testing.T) {
 
 	cacheConfig := newCacheConfig(t)
-	mc := Cache{Config: &cacheConfig}
+	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	err := mc.Connect()
 	if err != nil {
@@ -113,7 +112,7 @@ func TestCache_StoreReferenceDirect(t *testing.T) {
 
 func TestCache_StoreReference(t *testing.T) {
 	cacheConfig := newCacheConfig(t)
-	mc := Cache{Config: &cacheConfig}
+	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	err := mc.Connect()
 	if err != nil {
@@ -128,7 +127,7 @@ func TestCache_StoreReference(t *testing.T) {
 
 func TestCache_Store(t *testing.T) {
 	cacheConfig := newCacheConfig(t)
-	mc := Cache{Config: &cacheConfig}
+	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	err := mc.Connect()
 	if err != nil {
@@ -150,7 +149,7 @@ func TestCache_Retrieve(t *testing.T) {
 	const expected1 = `value for key [cacheKey] not in cache`
 
 	cacheConfig := newCacheConfig(t)
-	mc := Cache{Config: &cacheConfig}
+	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	err := mc.Connect()
 	if err != nil {
@@ -237,13 +236,13 @@ func BenchmarkCache_Retrieve(b *testing.B) {
 
 func TestCache_Close(t *testing.T) {
 	cacheConfig := newCacheConfig(t)
-	mc := Cache{Config: &cacheConfig}
+	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 	mc.Close()
 }
 
 func TestCache_Remove(t *testing.T) {
 	cacheConfig := newCacheConfig(t)
-	mc := Cache{Config: &cacheConfig}
+	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	err := mc.Connect()
 	if err != nil {
@@ -321,7 +320,7 @@ func BenchmarkCache_Remove(b *testing.B) {
 
 func TestCache_BulkRemove(t *testing.T) {
 	cacheConfig := newCacheConfig(t)
-	mc := Cache{Config: &cacheConfig}
+	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	err := mc.Connect()
 	if err != nil {
@@ -385,7 +384,7 @@ func BenchmarkCache_BulkRemove(b *testing.B) {
 func TestMemoryCache_SetTTL(t *testing.T) {
 
 	cacheConfig := newCacheConfig(t)
-	mc := Cache{Config: &cacheConfig}
+	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
 
 	err := mc.Connect()
 	if err != nil {

--- a/internal/cache/redis/redis_test.go
+++ b/internal/cache/redis/redis_test.go
@@ -20,20 +20,19 @@ import (
 
 	"github.com/Comcast/trickster/internal/cache/status"
 	"github.com/Comcast/trickster/internal/config"
-	"github.com/Comcast/trickster/internal/util/log"
+	tl "github.com/Comcast/trickster/internal/util/log"
 	"github.com/Comcast/trickster/internal/util/metrics"
 
 	"github.com/alicebob/miniredis"
 )
 
 func init() {
-	metrics.Init(&config.TricksterConfig{})
+	metrics.Init(&config.TricksterConfig{}, tl.ConsoleLogger("error"))
 }
 
 const cacheKey = `cacheKey`
 
 func storeBenchmark(b *testing.B) (*Cache, func()) {
-	log.Logger = log.ConsoleLogger("none")
 	rc, close := setupRedisCache(clientTypeStandard)
 	err := rc.Connect()
 	if err != nil {
@@ -68,7 +67,7 @@ func setupRedisCache(ct clientType) (*Cache, func()) {
 	cacheConfig := &config.CachingConfig{CacheType: "redis", Redis: rcfg}
 	conf.Caches = map[string]*config.CachingConfig{"default": cacheConfig}
 
-	return &Cache{Config: cacheConfig}, close
+	return &Cache{Config: cacheConfig, Logger: tl.ConsoleLogger("error")}, close
 }
 
 func TestClientSelectionSentinel(t *testing.T) {
@@ -84,7 +83,7 @@ func TestClientSelectionSentinel(t *testing.T) {
 	if !ok {
 		t.Errorf("expected cache named %s", cacheName)
 	}
-	cache := Cache{Name: cacheName, Config: cfg}
+	cache := Cache{Name: cacheName, Config: cfg, Logger: tl.ConsoleLogger("error")}
 	if err != nil {
 		t.Error(err)
 	}
@@ -162,7 +161,7 @@ func TestClientSelectionCluster(t *testing.T) {
 	if !ok {
 		t.Errorf("expected cache named %s", cacheName)
 	}
-	cache := Cache{Name: cacheName, Config: cfg}
+	cache := Cache{Name: cacheName, Config: cfg, Logger: tl.ConsoleLogger("error")}
 	if err != nil {
 		t.Error(err)
 	}
@@ -185,7 +184,7 @@ func TestClientSelectionStandard(t *testing.T) {
 	if !ok {
 		t.Errorf("expected cache named %s", cacheName)
 	}
-	cache := Cache{Name: cacheName, Config: cfg}
+	cache := Cache{Name: cacheName, Config: cfg, Logger: tl.ConsoleLogger("error")}
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/cache/registration/registration.go
+++ b/internal/cache/registration/registration.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Comcast/trickster/internal/cache/memory"
 	"github.com/Comcast/trickster/internal/cache/redis"
 	"github.com/Comcast/trickster/internal/config"
+	tl "github.com/Comcast/trickster/internal/util/log"
 )
 
 // Cache Interface Types
@@ -45,10 +46,10 @@ const (
 // }
 
 // LoadCachesFromConfig iterates the Caching Config and Connects/Maps each Cache
-func LoadCachesFromConfig(conf *config.TricksterConfig) map[string]cache.Cache {
+func LoadCachesFromConfig(conf *config.TricksterConfig, logger *tl.TricksterLogger) map[string]cache.Cache {
 	caches := make(map[string]cache.Cache)
 	for k, v := range conf.Caches {
-		c := NewCache(k, v)
+		c := NewCache(k, v, logger)
 		caches[k] = c
 	}
 	return caches
@@ -65,22 +66,22 @@ func CloseCaches(caches map[string]cache.Cache) error {
 }
 
 // NewCache returns a Cache object based on the provided config.CachingConfig
-func NewCache(cacheName string, cfg *config.CachingConfig) cache.Cache {
+func NewCache(cacheName string, cfg *config.CachingConfig, logger *tl.TricksterLogger) cache.Cache {
 
 	var c cache.Cache
 
 	switch cfg.CacheType {
 	case ctFilesystem:
-		c = &filesystem.Cache{Name: cacheName, Config: cfg}
+		c = &filesystem.Cache{Name: cacheName, Config: cfg, Logger: logger}
 	case ctRedis:
-		c = &redis.Cache{Name: cacheName, Config: cfg}
+		c = &redis.Cache{Name: cacheName, Config: cfg, Logger: logger}
 	case ctBBolt:
-		c = &bbolt.Cache{Name: cacheName, Config: cfg}
+		c = &bbolt.Cache{Name: cacheName, Config: cfg, Logger: logger}
 	case ctBadger:
-		c = &badger.Cache{Name: cacheName, Config: cfg}
+		c = &badger.Cache{Name: cacheName, Config: cfg, Logger: logger}
 	default:
 		// Default to MemoryCache
-		c = &memory.Cache{Name: cacheName, Config: cfg}
+		c = &memory.Cache{Name: cacheName, Config: cfg, Logger: logger}
 	}
 
 	c.Connect()

--- a/internal/cache/registration/registration_test.go
+++ b/internal/cache/registration/registration_test.go
@@ -19,11 +19,12 @@ import (
 	"testing"
 
 	"github.com/Comcast/trickster/internal/config"
+	tl "github.com/Comcast/trickster/internal/util/log"
 	"github.com/Comcast/trickster/internal/util/metrics"
 )
 
 func init() {
-	metrics.Init(&config.TricksterConfig{})
+	metrics.Init(&config.TricksterConfig{}, tl.ConsoleLogger("error"))
 }
 
 func TestLoadCachesFromConfig(t *testing.T) {
@@ -46,7 +47,7 @@ func TestLoadCachesFromConfig(t *testing.T) {
 		}
 	}
 
-	caches := LoadCachesFromConfig(conf)
+	caches := LoadCachesFromConfig(conf, tl.ConsoleLogger("error"))
 	defer CloseCaches(caches)
 	_, ok := caches["default"]
 	if !ok {

--- a/internal/proxy/engines/access_logs.go
+++ b/internal/proxy/engines/access_logs.go
@@ -16,12 +16,12 @@ package engines
 import (
 	"net/http"
 
-	"github.com/Comcast/trickster/internal/util/log"
+	tl "github.com/Comcast/trickster/internal/util/log"
 )
 
-func logUpstreamRequest(originName, originType, handlerName, method, path, userAgent string, responseCode, size int, requestDuration float64) {
+func logUpstreamRequest(log *tl.TricksterLogger, originName, originType, handlerName, method, path, userAgent string, responseCode, size int, requestDuration float64) {
 	log.Debug("upstream request",
-		log.Pairs{
+		tl.Pairs{
 			"originName":  originName,
 			"originType":  originType,
 			"handlerName": handlerName,
@@ -34,9 +34,9 @@ func logUpstreamRequest(originName, originType, handlerName, method, path, userA
 		})
 }
 
-func logDownstreamRequest(r *http.Request) {
+func logDownstreamRequest(log *tl.TricksterLogger, r *http.Request) {
 	log.Debug("downtream request",
-		log.Pairs{
+		tl.Pairs{
 			"uri":       r.RequestURI,
 			"method":    r.Method,
 			"userAgent": r.UserAgent(),

--- a/internal/proxy/engines/access_logs_test.go
+++ b/internal/proxy/engines/access_logs_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/Comcast/trickster/internal/config"
-	"github.com/Comcast/trickster/internal/util/log"
+	tl "github.com/Comcast/trickster/internal/util/log"
 )
 
 func TestLogUpstreamRequest(t *testing.T) {
@@ -28,12 +28,12 @@ func TestLogUpstreamRequest(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "debug"}
-	log.Init(conf)
-	logUpstreamRequest("testOrigin", "testType", "testHandler", "testMethod", "testPath", "testUserAgent", 200, 0, 1.0)
+	log := tl.Init(conf)
+	logUpstreamRequest(log, "testOrigin", "testType", "testHandler", "testMethod", "testPath", "testUserAgent", 200, 0, 1.0)
 	if _, err := os.Stat(fileName); err != nil {
 		t.Errorf(err.Error())
 	}
-	log.Logger.Close()
+	log.Close()
 	os.Remove(fileName)
 }
 
@@ -43,18 +43,17 @@ func TestLogDownstreamRequest(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "debug"}
-	log.Init(conf)
-
+	log := tl.Init(conf)
 	r, err := http.NewRequest("get", "http://testOrigin", nil)
 	if err != nil {
 		t.Error(err)
 	}
 
-	logDownstreamRequest(r)
+	logDownstreamRequest(log, r)
 
 	if _, err := os.Stat(fileName); err != nil {
 		t.Errorf(err.Error())
 	}
-	log.Logger.Close()
+	log.Close()
 	os.Remove(fileName)
 }

--- a/internal/proxy/engines/cache_test.go
+++ b/internal/proxy/engines/cache_test.go
@@ -60,7 +60,7 @@ func TestMultiPartByteRange(t *testing.T) {
 	if err != nil {
 		t.Errorf("Could not load configuration: %s", err.Error())
 	}
-	caches := cr.LoadCachesFromConfig(conf)
+	caches := cr.LoadCachesFromConfig(conf, testLogger)
 	cache, ok := caches["default"]
 	if !ok {
 		t.Error(errors.New("could not load cache"))
@@ -71,7 +71,7 @@ func TestMultiPartByteRange(t *testing.T) {
 	resp2.Header.Add(headers.NameContentRange, "bytes 0-10/62")
 	resp2.Header.Add("Content-Type", "multipart/byteranges; boundary=ddffee123")
 	resp2.StatusCode = 200
-	d := DocumentFromHTTPResponse(resp2, []byte("This is a t"), nil)
+	d := DocumentFromHTTPResponse(resp2, []byte("This is a t"), nil, testLogger)
 
 	ctx := context.Background()
 	ctx = tc.WithResources(ctx, &request.Resources{OriginConfig: conf.Origins["default"]})
@@ -91,7 +91,7 @@ func TestCacheHitRangeRequest(t *testing.T) {
 		t.Errorf("Could not load configuration: %s", err.Error())
 	}
 
-	caches := cr.LoadCachesFromConfig(conf)
+	caches := cr.LoadCachesFromConfig(conf, testLogger)
 	cache, ok := caches["default"]
 	if !ok {
 		t.Error(errors.New("could not load cache"))
@@ -101,7 +101,7 @@ func TestCacheHitRangeRequest(t *testing.T) {
 	resp2.Header = make(http.Header)
 	resp2.Header.Add(headers.NameContentLength, strconv.Itoa(len(testRangeBody)))
 	resp2.StatusCode = 200
-	d := DocumentFromHTTPResponse(resp2, []byte(testRangeBody), nil)
+	d := DocumentFromHTTPResponse(resp2, []byte(testRangeBody), nil, testLogger)
 	ctx := context.Background()
 	ctx = tc.WithResources(ctx, &request.Resources{OriginConfig: conf.Origins["default"]})
 
@@ -130,7 +130,7 @@ func TestCacheHitRangeRequest2(t *testing.T) {
 		t.Errorf("Could not load configuration: %s", err.Error())
 	}
 
-	caches := cr.LoadCachesFromConfig(conf)
+	caches := cr.LoadCachesFromConfig(conf, testLogger)
 	cache, ok := caches["default"]
 	if !ok {
 		t.Error(errors.New("could not load cache"))
@@ -145,7 +145,7 @@ func TestCacheHitRangeRequest2(t *testing.T) {
 	resp2.ContentLength = int64(rl)
 	resp2.Header.Add(headers.NameContentRange, have.ContentRangeHeader(cl))
 	resp2.StatusCode = 206
-	d := DocumentFromHTTPResponse(resp2, []byte(testRangeBody[have.Start:have.End+1]), nil)
+	d := DocumentFromHTTPResponse(resp2, []byte(testRangeBody[have.Start:have.End+1]), nil, testLogger)
 	ctx := context.Background()
 	ctx = tc.WithResources(ctx, &request.Resources{OriginConfig: conf.Origins["default"]})
 
@@ -173,7 +173,7 @@ func TestCacheHitRangeRequest3(t *testing.T) {
 	if err != nil {
 		t.Errorf("Could not load configuration: %s", err.Error())
 	}
-	caches := cr.LoadCachesFromConfig(conf)
+	caches := cr.LoadCachesFromConfig(conf, testLogger)
 	cache, ok := caches["default"]
 	if !ok {
 		t.Error(errors.New("could not load cache"))
@@ -188,7 +188,7 @@ func TestCacheHitRangeRequest3(t *testing.T) {
 	resp2.ContentLength = int64(rl)
 	resp2.Header.Add(headers.NameContentRange, have.ContentRangeHeader(cl))
 	resp2.StatusCode = 206
-	d := DocumentFromHTTPResponse(resp2, []byte(testRangeBody[have.Start:have.End+1]), nil)
+	d := DocumentFromHTTPResponse(resp2, []byte(testRangeBody[have.Start:have.End+1]), nil, testLogger)
 	ctx := context.Background()
 	ctx = tc.WithResources(ctx, &request.Resources{OriginConfig: conf.Origins["default"]})
 
@@ -213,7 +213,7 @@ func TestPartialCacheMissRangeRequest(t *testing.T) {
 		t.Errorf("Could not load configuration: %s", err.Error())
 	}
 
-	caches := cr.LoadCachesFromConfig(conf)
+	caches := cr.LoadCachesFromConfig(conf, testLogger)
 	cache, ok := caches["default"]
 	if !ok {
 		t.Error(errors.New("could not load cache"))
@@ -228,7 +228,7 @@ func TestPartialCacheMissRangeRequest(t *testing.T) {
 	resp2.ContentLength = int64(rl)
 	resp2.Header.Add(headers.NameContentRange, have.ContentRangeHeader(cl))
 	resp2.StatusCode = 206
-	d := DocumentFromHTTPResponse(resp2, []byte(testRangeBody[have.Start:have.End+1]), nil)
+	d := DocumentFromHTTPResponse(resp2, []byte(testRangeBody[have.Start:have.End+1]), nil, testLogger)
 
 	ctx := context.Background()
 	ctx = tc.WithResources(ctx, &request.Resources{OriginConfig: conf.Origins["default"]})
@@ -257,7 +257,7 @@ func TestFullCacheMissRangeRequest(t *testing.T) {
 		t.Errorf("Could not load configuration: %s", err.Error())
 	}
 
-	caches := cr.LoadCachesFromConfig(conf)
+	caches := cr.LoadCachesFromConfig(conf, testLogger)
 	cache, ok := caches["default"]
 	if !ok {
 		t.Error(errors.New("could not load cache"))
@@ -272,7 +272,7 @@ func TestFullCacheMissRangeRequest(t *testing.T) {
 	resp2.ContentLength = int64(rl)
 	resp2.Header.Add(headers.NameContentRange, have.ContentRangeHeader(cl))
 	resp2.StatusCode = 206
-	d := DocumentFromHTTPResponse(resp2, []byte(testRangeBody[have.Start:have.End+1]), nil)
+	d := DocumentFromHTTPResponse(resp2, []byte(testRangeBody[have.Start:have.End+1]), nil, testLogger)
 
 	ctx := context.Background()
 	ctx = tc.WithResources(ctx, &request.Resources{OriginConfig: conf.Origins["default"]})
@@ -320,7 +320,7 @@ func TestRangeRequestFromClient(t *testing.T) {
 		t.Errorf("Could not load configuration: %s", err.Error())
 	}
 
-	caches := cr.LoadCachesFromConfig(conf)
+	caches := cr.LoadCachesFromConfig(conf, testLogger)
 	cache, ok := caches["default"]
 	if !ok {
 		t.Error(errors.New("could not load cache"))
@@ -329,7 +329,7 @@ func TestRangeRequestFromClient(t *testing.T) {
 	ctx := context.Background()
 	ctx = tc.WithResources(ctx, &request.Resources{OriginConfig: conf.Origins["default"]})
 
-	d := DocumentFromHTTPResponse(resp, bytes, nil)
+	d := DocumentFromHTTPResponse(resp, bytes, nil, testLogger)
 	err = WriteCache(ctx, cache, "testKey2", d, time.Duration(60)*time.Second, map[string]bool{"text/plain": true})
 	if err != nil {
 		t.Error(err)
@@ -364,7 +364,7 @@ func TestQueryCache(t *testing.T) {
 		t.Fatalf("Could not load configuration: %s", err.Error())
 	}
 
-	caches := registration.LoadCachesFromConfig(conf)
+	caches := registration.LoadCachesFromConfig(conf, testLogger)
 	defer registration.CloseCaches(caches)
 	cache, ok := caches["default"]
 	if !ok {
@@ -375,11 +375,11 @@ func TestQueryCache(t *testing.T) {
 	resp.Header = make(http.Header)
 	resp.StatusCode = 200
 	resp.Header.Add(headers.NameContentLength, "4")
-	d := DocumentFromHTTPResponse(resp, []byte(expected), nil)
+	d := DocumentFromHTTPResponse(resp, []byte(expected), nil, testLogger)
 	d.ContentType = "text/plain"
 
 	ctx := context.Background()
-	ctx = tc.WithResources(ctx, &request.Resources{OriginConfig: conf.Origins["default"]})
+	ctx = tc.WithResources(ctx, &request.Resources{OriginConfig: conf.Origins["default"], Logger: testLogger})
 
 	err = WriteCache(ctx, cache, "testKey", d, time.Duration(60)*time.Second, map[string]bool{"text/plain": true})
 	if err != nil {

--- a/internal/proxy/engines/document.go
+++ b/internal/proxy/engines/document.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Comcast/trickster/internal/proxy/headers"
 	"github.com/Comcast/trickster/internal/proxy/ranges/byterange"
 	"github.com/Comcast/trickster/internal/timeseries"
-	"github.com/Comcast/trickster/internal/util/log"
+	tl "github.com/Comcast/trickster/internal/util/log"
 )
 
 //go:generate msgp
@@ -105,7 +105,7 @@ func (d *HTTPDocument) LoadRangeParts() {
 }
 
 // ParsePartialContentBody parses a Partial Content response body into 0 or more discrete parts
-func (d *HTTPDocument) ParsePartialContentBody(resp *http.Response, body []byte) {
+func (d *HTTPDocument) ParsePartialContentBody(resp *http.Response, body []byte, log *tl.TricksterLogger) {
 
 	ct := resp.Header.Get(headers.NameContentType)
 	if cr := resp.Header.Get(headers.NameContentRange); cr != "" {
@@ -148,7 +148,7 @@ func (d *HTTPDocument) ParsePartialContentBody(resp *http.Response, body []byte)
 			d.RangeParts.Compress()
 			d.Ranges = d.RangeParts.Ranges()
 		} else {
-			log.Error("unable to parse multipart range response body", log.Pairs{"detail": err.Error})
+			log.Error("unable to parse multipart range response body", tl.Pairs{"detail": err.Error})
 		}
 	} else {
 		if !strings.HasPrefix(ct, headers.ValueMultipartByteRanges) {

--- a/internal/proxy/engines/document_test.go
+++ b/internal/proxy/engines/document_test.go
@@ -30,7 +30,7 @@ func TestDocumentFromHTTPResponse(t *testing.T) {
 	resp := &http.Response{}
 	resp.Header = http.Header{headers.NameContentRange: []string{"bytes 1-4/8"}}
 	resp.StatusCode = 206
-	d := DocumentFromHTTPResponse(resp, []byte("1234"), nil)
+	d := DocumentFromHTTPResponse(resp, []byte("1234"), nil, testLogger)
 
 	if len(d.Ranges) != 1 {
 		t.Errorf("expected 1 got %d", len(d.Ranges))
@@ -95,7 +95,7 @@ func TestParsePartialContentBodyNoRanges(t *testing.T) {
 
 	d := &HTTPDocument{}
 	resp := &http.Response{Header: make(http.Header)}
-	d.ParsePartialContentBody(resp, []byte("test"))
+	d.ParsePartialContentBody(resp, []byte("test"), testLogger)
 
 	if string(d.Body) != "test" {
 		t.Errorf("expected %s got %s", "test", string(d.Body))
@@ -113,7 +113,7 @@ func TestParsePartialContentBodySingleRange(t *testing.T) {
 		headers.NameContentRange: []string{"bytes 0-10/1222"},
 	}}
 
-	d.ParsePartialContentBody(resp, []byte("Lorem ipsum"))
+	d.ParsePartialContentBody(resp, []byte("Lorem ipsum"), testLogger)
 
 	if string(d.Body) != "" {
 		t.Errorf("expected %s got %s", "", string(d.Body))
@@ -149,7 +149,7 @@ Content-Range: bytes 10-20/1222
 Content-Type: text/plain; charset=utf-8
 
 m dolor sit
---c4fb8e6049a6fdb126d32fa0b15c21e3--`))
+--c4fb8e6049a6fdb126d32fa0b15c21e3--`), testLogger)
 
 	if string(d.Body) != "" {
 		t.Errorf("expected %s got %s", "", string(d.Body))
@@ -185,7 +185,7 @@ Content-Range: baytes 1s0-20/12s22x
 Content-Type: text/plain; charset=utf-8
 
 m dolor sit
---c4fb8e6049a6fdb126d32fa0b15c21e3--`))
+--c4fb8e6049a6fdb126d32fa0b15c21e3--`), testLogger)
 
 	if string(d.Body) != "" {
 		t.Errorf("expected %s got %s", "", string(d.Body))

--- a/internal/proxy/engines/httpproxy.go
+++ b/internal/proxy/engines/httpproxy.go
@@ -153,7 +153,7 @@ func PrepareFetchReader(r *http.Request) (io.ReadCloser, *http.Response, int64) 
 	resp, err := oc.HTTPClient.Do(r)
 
 	if err != nil {
-		log.Error("error downloading url", log.Pairs{"url": r.URL.String(), "detail": err.Error()})
+		rsc.Logger.Error("error downloading url", log.Pairs{"url": r.URL.String(), "detail": err.Error()})
 		// if there is an err and the response is nil, the server could not be reached; make a 502 for the downstream response
 		if resp == nil {
 			resp = &http.Response{StatusCode: http.StatusBadGateway, Request: r, Header: make(http.Header)}
@@ -190,7 +190,7 @@ func PrepareFetchReader(r *http.Request) (io.ReadCloser, *http.Response, int64) 
 		d, err := http.ParseTime(date)
 		if err == nil {
 			if offset := time.Since(d); time.Duration(math.Abs(float64(offset))) > time.Minute {
-				log.WarnOnce("clockoffset."+oc.Name,
+				rsc.Logger.WarnOnce("clockoffset."+oc.Name,
 					"clock offset between trickster host and origin is high and may cause data anomalies",
 					log.Pairs{
 						"originName":    oc.Name,

--- a/internal/proxy/engines/objectproxycache_test.go
+++ b/internal/proxy/engines/objectproxycache_test.go
@@ -823,7 +823,7 @@ func TestObjectProxyCacheRequestNegativeCache(t *testing.T) {
 	cfg.Paths = map[string]*config.PathConfig{
 		"/": pc,
 	}
-	r = r.WithContext(tc.WithResources(r.Context(), request.NewResources(cfg, pc, rsc.CacheConfig, rsc.CacheClient, rsc.OriginClient)))
+	r = r.WithContext(tc.WithResources(r.Context(), request.NewResources(cfg, pc, rsc.CacheConfig, rsc.CacheClient, rsc.OriginClient, rsc.Logger)))
 
 	_, e := testFetchOPC(r, http.StatusNotFound, "test", map[string]string{"status": "kmiss"})
 	for _, err = range e {

--- a/internal/proxy/engines/proxy_request.go
+++ b/internal/proxy/engines/proxy_request.go
@@ -27,7 +27,7 @@ import (
 	"github.com/Comcast/trickster/internal/proxy/headers"
 	"github.com/Comcast/trickster/internal/proxy/ranges/byterange"
 	"github.com/Comcast/trickster/internal/proxy/request"
-	"github.com/Comcast/trickster/internal/util/log"
+	tl "github.com/Comcast/trickster/internal/util/log"
 )
 
 type proxyRequest struct {
@@ -70,21 +70,25 @@ type proxyRequest struct {
 
 	collapsedForwarder ProgressiveCollapseForwarder
 	cachingPolicy      *CachingPolicy
+
+	Logger *tl.TricksterLogger
 }
 
 // newProxyRequest accepts the original inbound HTTP Request and Response
 // and returns a proxyRequest object
 func newProxyRequest(r *http.Request, w io.Writer) *proxyRequest {
 
+	rsc := request.GetResources(r)
+
 	pr := &proxyRequest{
 		Request:         r,
+		Logger:          rsc.Logger,
 		upstreamRequest: r.Clone(context.Background()),
 		contentLength:   -1,
 		responseWriter:  w,
 		started:         time.Now(),
 	}
 
-	rsc := request.GetResources(r)
 	pr.upstreamRequest = pr.upstreamRequest.WithContext(tctx.WithResources(pr.upstreamRequest.Context(), rsc))
 
 	return pr
@@ -93,6 +97,7 @@ func newProxyRequest(r *http.Request, w io.Writer) *proxyRequest {
 func (pr *proxyRequest) Clone() *proxyRequest {
 	return &proxyRequest{
 		Request:            pr.Request.Clone(context.Background()),
+		Logger:             pr.Logger,
 		cacheDocument:      pr.cacheDocument,
 		key:                pr.key,
 		cacheStatus:        pr.cacheStatus,
@@ -132,15 +137,16 @@ func (pr *proxyRequest) Fetch() ([]byte, *http.Response, time.Duration) {
 		resp.Body.Close()
 	}
 	if err != nil {
-		log.Error("error reading body from http response", log.Pairs{"url": pr.URL.String(), "detail": err.Error()})
+		pr.Logger.Error("error reading body from http response", tl.Pairs{"url": pr.URL.String(), "detail": err.Error()})
 		return []byte{}, resp, 0
 	}
 
 	elapsed := time.Since(start) // includes any time required to decompress the document for deserialization
 
-	ll := log.Logger.Level()
+	ll := pr.Logger.Level()
 	if ll == "trace" || ll == "debug" {
-		go logUpstreamRequest(oc.Name, oc.OriginType, handlerName, pr.Method, pr.URL.String(), pr.UserAgent(), resp.StatusCode, len(body), elapsed.Seconds())
+		go logUpstreamRequest(pr.Logger, oc.Name, oc.OriginType, handlerName,
+			pr.Method, pr.URL.String(), pr.UserAgent(), resp.StatusCode, len(body), elapsed.Seconds())
 	}
 
 	return body, resp, elapsed
@@ -453,7 +459,7 @@ func (pr *proxyRequest) prepareResponse() {
 			if pr.upstreamReader != nil {
 				b, _ = ioutil.ReadAll(pr.upstreamReader)
 			}
-			d = DocumentFromHTTPResponse(pr.upstreamResponse, b, pr.cachingPolicy)
+			d = DocumentFromHTTPResponse(pr.upstreamResponse, b, pr.cachingPolicy, pr.Logger)
 			pr.cacheBuffer = bytes.NewBuffer(b)
 			if pr.writeToCache {
 				d.isLoaded = true
@@ -585,7 +591,7 @@ func (pr *proxyRequest) reconstituteResponses() {
 					// is now invalid. lets go ahead and reset it.
 					b, _ := ioutil.ReadAll(resp.Body)
 					appendLock.Lock()
-					parts.ParsePartialContentBody(resp, b)
+					parts.ParsePartialContentBody(resp, b, pr.Logger)
 					appendLock.Unlock()
 					wg.Done()
 				}()
@@ -611,7 +617,7 @@ func (pr *proxyRequest) reconstituteResponses() {
 				if resp.StatusCode == http.StatusPartialContent {
 					b, _ := ioutil.ReadAll(resp.Body)
 					appendLock.Lock()
-					parts.ParsePartialContentBody(resp, b)
+					parts.ParsePartialContentBody(resp, b, pr.Logger)
 					appendLock.Unlock()
 				}
 				wg.Done()

--- a/internal/proxy/engines/proxy_request_test.go
+++ b/internal/proxy/engines/proxy_request_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Comcast/trickster/internal/proxy/headers"
 	"github.com/Comcast/trickster/internal/proxy/ranges/byterange"
 	"github.com/Comcast/trickster/internal/proxy/request"
+	tl "github.com/Comcast/trickster/internal/util/log"
 )
 
 func TestCheckCacheFreshness(t *testing.T) {
@@ -45,7 +46,7 @@ func TestParseRequestRanges(t *testing.T) {
 	r.Header.Set(headers.NameRange, "bytes=0-10")
 
 	oc := &config.OriginConfig{MultipartRangesDisabled: true}
-	r = request.SetResources(r, request.NewResources(oc, nil, nil, nil, nil))
+	r = request.SetResources(r, request.NewResources(oc, nil, nil, nil, nil, tl.ConsoleLogger("error")))
 
 	pr := proxyRequest{
 		Request:         r,
@@ -123,14 +124,14 @@ func TestDetermineCacheability(t *testing.T) {
 		t.Errorf("Could not load configuration: %s", err.Error())
 	}
 
-	caches := cr.LoadCachesFromConfig(conf)
+	caches := cr.LoadCachesFromConfig(conf, testLogger)
 	cache, ok := caches["default"]
 	if !ok {
 		t.Error(errors.New("could not load cache"))
 	}
 
 	r, _ := http.NewRequest(http.MethodGet, "http://127.0.0.1", nil)
-	r = request.SetResources(r, request.NewResources(nil, nil, cache.Configuration(), cache, nil))
+	r = request.SetResources(r, request.NewResources(nil, nil, cache.Configuration(), cache, nil, tl.ConsoleLogger("error")))
 
 	pr := proxyRequest{
 		Request:       r,
@@ -178,7 +179,7 @@ func TestPrepareResponse(t *testing.T) {
 	r.Header.Set(headers.NameRange, "bytes=0-10")
 
 	oc := &config.OriginConfig{}
-	r = request.SetResources(r, request.NewResources(oc, nil, nil, nil, nil))
+	r = request.SetResources(r, request.NewResources(oc, nil, nil, nil, nil, tl.ConsoleLogger("error")))
 
 	pr := proxyRequest{
 		Request:          r,
@@ -248,7 +249,7 @@ func TestPrepareRevalidationRequest(t *testing.T) {
 	r.Header.Set(headers.NameRange, "bytes=0-10,12-20")
 
 	oc := &config.OriginConfig{DearticulateUpstreamRanges: true}
-	r = request.SetResources(r, request.NewResources(oc, nil, nil, nil, nil))
+	r = request.SetResources(r, request.NewResources(oc, nil, nil, nil, nil, tl.ConsoleLogger("error")))
 
 	pr := proxyRequest{
 		Request:          r,
@@ -276,7 +277,7 @@ func TestPrepareRevalidationRequestNoRange(t *testing.T) {
 	r.Header.Set(headers.NameRange, "bytes=0-10,12-20")
 
 	oc := &config.OriginConfig{DearticulateUpstreamRanges: true}
-	r = request.SetResources(r, request.NewResources(oc, nil, nil, nil, nil))
+	r = request.SetResources(r, request.NewResources(oc, nil, nil, nil, nil, tl.ConsoleLogger("error")))
 
 	pr := proxyRequest{
 		Request:          r,
@@ -303,7 +304,7 @@ func TestPrepareUpstreamRequests(t *testing.T) {
 	r.Header.Set(headers.NameRange, "bytes=0-10,12-20")
 
 	oc := &config.OriginConfig{DearticulateUpstreamRanges: true}
-	r = request.SetResources(r, request.NewResources(oc, nil, nil, nil, nil))
+	r = request.SetResources(r, request.NewResources(oc, nil, nil, nil, nil, tl.ConsoleLogger("error")))
 
 	pr := proxyRequest{
 		Request:          r,

--- a/internal/proxy/handlers/local_test.go
+++ b/internal/proxy/handlers/local_test.go
@@ -22,6 +22,7 @@ import (
 	tc "github.com/Comcast/trickster/internal/proxy/context"
 	"github.com/Comcast/trickster/internal/proxy/headers"
 	"github.com/Comcast/trickster/internal/proxy/request"
+	tl "github.com/Comcast/trickster/internal/util/log"
 )
 
 func TestHandleLocalResponse(t *testing.T) {
@@ -41,7 +42,7 @@ func TestHandleLocalResponse(t *testing.T) {
 		ResponseHeaders:   map[string]string{headers.NameTricksterResult: "1234"},
 	}
 
-	r = r.WithContext(tc.WithResources(r.Context(), request.NewResources(nil, pc, nil, nil, nil)))
+	r = r.WithContext(tc.WithResources(r.Context(), request.NewResources(nil, pc, nil, nil, nil, tl.ConsoleLogger("error"))))
 
 	HandleLocalResponse(w, r)
 	resp := w.Result()
@@ -87,7 +88,7 @@ func TestHandleLocalResponseBadResponseCode(t *testing.T) {
 		ResponseHeaders:   map[string]string{headers.NameTricksterResult: "1234"},
 	}
 
-	r = r.WithContext(tc.WithResources(r.Context(), request.NewResources(nil, pc, nil, nil, nil)))
+	r = r.WithContext(tc.WithResources(r.Context(), request.NewResources(nil, pc, nil, nil, nil, tl.ConsoleLogger("error"))))
 
 	HandleLocalResponse(w, r)
 	resp := w.Result()
@@ -126,7 +127,7 @@ func TestHandleLocalResponseNoPathConfig(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "http://0/trickster/", nil)
 
-	r = r.WithContext(tc.WithResources(r.Context(), request.NewResources(nil, nil, nil, nil, nil)))
+	r = r.WithContext(tc.WithResources(r.Context(), request.NewResources(nil, nil, nil, nil, nil, tl.ConsoleLogger("error"))))
 
 	HandleLocalResponse(w, r)
 	resp := w.Result()

--- a/internal/proxy/origins/clickhouse/clickhouse.go
+++ b/internal/proxy/origins/clickhouse/clickhouse.go
@@ -73,11 +73,6 @@ func (c *Client) SetCache(cc cache.Cache) {
 	c.cache = cc
 }
 
-// SetUpstreamLogging enables or disables the logging of upstream requests
-func (c *Client) SetUpstreamLogging(logUpstreamRequest bool) {
-	c.logUpstreamRequest = logUpstreamRequest
-}
-
 // ParseTimeRangeQuery parses the key parts of a TimeRangeQuery from the inbound HTTP Request
 func (c *Client) ParseTimeRangeQuery(r *http.Request) (*timeseries.TimeRangeQuery, error) {
 

--- a/internal/proxy/origins/clickhouse/clickhouse_test.go
+++ b/internal/proxy/origins/clickhouse/clickhouse_test.go
@@ -21,11 +21,12 @@ import (
 	cr "github.com/Comcast/trickster/internal/cache/registration"
 	"github.com/Comcast/trickster/internal/config"
 	"github.com/Comcast/trickster/internal/proxy/origins"
+	tl "github.com/Comcast/trickster/internal/util/log"
 	"github.com/Comcast/trickster/internal/util/metrics"
 )
 
 func init() {
-	metrics.Init(&config.TricksterConfig{})
+	metrics.Init(&config.TricksterConfig{}, tl.ConsoleLogger("error"))
 }
 
 func TestClickhouseClientInterfacing(t *testing.T) {
@@ -53,7 +54,7 @@ func TestNewClient(t *testing.T) {
 		t.Fatalf("Could not load configuration: %s", err.Error())
 	}
 
-	caches := cr.LoadCachesFromConfig(conf)
+	caches := cr.LoadCachesFromConfig(conf, tl.ConsoleLogger("error"))
 	defer cr.CloseCaches(caches)
 	cache, ok := caches["default"]
 	if !ok {
@@ -95,7 +96,7 @@ func TestCache(t *testing.T) {
 		t.Fatalf("Could not load configuration: %s", err.Error())
 	}
 
-	caches := cr.LoadCachesFromConfig(conf)
+	caches := cr.LoadCachesFromConfig(conf, tl.ConsoleLogger("error"))
 	defer cr.CloseCaches(caches)
 	cache, ok := caches["default"]
 	if !ok {

--- a/internal/proxy/origins/clickhouse/handler_health_test.go
+++ b/internal/proxy/origins/clickhouse/handler_health_test.go
@@ -20,12 +20,13 @@ import (
 
 	"github.com/Comcast/trickster/internal/config"
 	"github.com/Comcast/trickster/internal/proxy/request"
+	tl "github.com/Comcast/trickster/internal/util/log"
 	"github.com/Comcast/trickster/internal/util/metrics"
 	tu "github.com/Comcast/trickster/internal/util/testing"
 )
 
 func init() {
-	metrics.Init(&config.TricksterConfig{})
+	metrics.Init(&config.TricksterConfig{}, tl.ConsoleLogger("error"))
 }
 
 func TestHealthHandler(t *testing.T) {

--- a/internal/proxy/origins/influxdb/handler_query_test.go
+++ b/internal/proxy/origins/influxdb/handler_query_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Comcast/trickster/internal/config"
 	"github.com/Comcast/trickster/internal/proxy/errors"
 	"github.com/Comcast/trickster/internal/proxy/request"
+	tl "github.com/Comcast/trickster/internal/util/log"
 	"github.com/Comcast/trickster/internal/util/metrics"
 	tu "github.com/Comcast/trickster/internal/util/testing"
 
@@ -29,7 +30,7 @@ import (
 )
 
 func init() {
-	metrics.Init(&config.TricksterConfig{})
+	metrics.Init(&config.TricksterConfig{}, tl.ConsoleLogger("error"))
 }
 
 func TestParseTimeRangeQuery(t *testing.T) {

--- a/internal/proxy/origins/influxdb/influxdb.go
+++ b/internal/proxy/origins/influxdb/influxdb.go
@@ -67,8 +67,3 @@ func (c *Client) Name() string {
 func (c *Client) SetCache(cc cache.Cache) {
 	c.cache = cc
 }
-
-// SetUpstreamLogging enables or disables the logging of upstream requests
-func (c *Client) SetUpstreamLogging(logUpstreamRequest bool) {
-	c.logUpstreamRequest = logUpstreamRequest
-}

--- a/internal/proxy/origins/influxdb/influxdb_test.go
+++ b/internal/proxy/origins/influxdb/influxdb_test.go
@@ -19,6 +19,7 @@ import (
 	cr "github.com/Comcast/trickster/internal/cache/registration"
 	"github.com/Comcast/trickster/internal/config"
 	"github.com/Comcast/trickster/internal/proxy/origins"
+	tl "github.com/Comcast/trickster/internal/util/log"
 )
 
 func TestInfluxDBClientInterfacing(t *testing.T) {
@@ -46,7 +47,7 @@ func TestNewClient(t *testing.T) {
 		t.Fatalf("Could not load configuration: %s", err.Error())
 	}
 
-	caches := cr.LoadCachesFromConfig(conf)
+	caches := cr.LoadCachesFromConfig(conf, tl.ConsoleLogger("error"))
 	defer cr.CloseCaches(caches)
 	cache, ok := caches["default"]
 	if !ok {
@@ -88,7 +89,7 @@ func TestCache(t *testing.T) {
 		t.Fatalf("Could not load configuration: %s", err.Error())
 	}
 
-	caches := cr.LoadCachesFromConfig(conf)
+	caches := cr.LoadCachesFromConfig(conf, tl.ConsoleLogger("error"))
 	defer cr.CloseCaches(caches)
 	cache, ok := caches["default"]
 	if !ok {

--- a/internal/proxy/origins/irondb/handler_caql_test.go
+++ b/internal/proxy/origins/irondb/handler_caql_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Comcast/trickster/internal/config"
 	"github.com/Comcast/trickster/internal/proxy/request"
 	"github.com/Comcast/trickster/internal/timeseries"
+	tl "github.com/Comcast/trickster/internal/util/log"
 	tu "github.com/Comcast/trickster/internal/util/testing"
 )
 
@@ -71,7 +72,7 @@ func TestCaqlHandlerSetExtent(t *testing.T) {
 		t.Error(err)
 	}
 
-	r = request.SetResources(r, request.NewResources(cfg, nil, nil, nil, client))
+	r = request.SetResources(r, request.NewResources(cfg, nil, nil, nil, client, tl.ConsoleLogger("error")))
 
 	now := time.Now()
 	then := now.Add(-5 * time.Hour)

--- a/internal/proxy/origins/irondb/handler_fetch_test.go
+++ b/internal/proxy/origins/irondb/handler_fetch_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Comcast/trickster/internal/config"
 	"github.com/Comcast/trickster/internal/proxy/request"
 	"github.com/Comcast/trickster/internal/timeseries"
+	tl "github.com/Comcast/trickster/internal/util/log"
 	tu "github.com/Comcast/trickster/internal/util/testing"
 )
 
@@ -91,7 +92,7 @@ func TestFetchHandlerSetExtent(t *testing.T) {
 		t.Error(err)
 	}
 
-	r = request.SetResources(r, request.NewResources(cfg, nil, nil, nil, client))
+	r = request.SetResources(r, request.NewResources(cfg, nil, nil, nil, client, tl.ConsoleLogger("error")))
 
 	now := time.Now()
 	then := now.Add(-5 * time.Hour)

--- a/internal/proxy/origins/irondb/handler_histogram_test.go
+++ b/internal/proxy/origins/irondb/handler_histogram_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Comcast/trickster/internal/proxy/errors"
 	"github.com/Comcast/trickster/internal/proxy/request"
 	"github.com/Comcast/trickster/internal/timeseries"
+	tl "github.com/Comcast/trickster/internal/util/log"
 	tu "github.com/Comcast/trickster/internal/util/testing"
 )
 
@@ -176,7 +177,7 @@ func TestHistogramHandlerSetExtent(t *testing.T) {
 		t.Error(err)
 	}
 
-	r = request.SetResources(r, request.NewResources(cfg, nil, nil, nil, client))
+	r = request.SetResources(r, request.NewResources(cfg, nil, nil, nil, client, tl.ConsoleLogger("error")))
 
 	now := time.Now()
 	then := now.Add(-5 * time.Hour)
@@ -209,7 +210,7 @@ func TestHistogramHandlerFastForwardURLError(t *testing.T) {
 		t.Error(err)
 	}
 
-	rsc := request.NewResources(cfg, nil, nil, nil, client)
+	rsc := request.NewResources(cfg, nil, nil, nil, client, tl.ConsoleLogger("error"))
 	r = request.SetResources(r, rsc)
 
 	r.URL.Path = "/histogram/x/900/300/00112233-4455-6677-8899-aabbccddeeff/metric"

--- a/internal/proxy/origins/irondb/handler_rollup_test.go
+++ b/internal/proxy/origins/irondb/handler_rollup_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Comcast/trickster/internal/proxy/errors"
 	"github.com/Comcast/trickster/internal/proxy/request"
 	"github.com/Comcast/trickster/internal/timeseries"
+	tl "github.com/Comcast/trickster/internal/util/log"
 	tu "github.com/Comcast/trickster/internal/util/testing"
 )
 
@@ -72,7 +73,7 @@ func TestRollupHandlerSetExtent(t *testing.T) {
 		t.Error(err)
 	}
 
-	r = request.SetResources(r, request.NewResources(cfg, nil, nil, nil, client))
+	r = request.SetResources(r, request.NewResources(cfg, nil, nil, nil, client, tl.ConsoleLogger("error")))
 
 	now := time.Now()
 	then := now.Add(-5 * time.Hour)
@@ -99,7 +100,7 @@ func TestRollupHandlerParseTimeRangeQuery(t *testing.T) {
 		t.Error(err)
 	}
 
-	r = request.SetResources(r, request.NewResources(cfg, nil, nil, nil, client))
+	r = request.SetResources(r, request.NewResources(cfg, nil, nil, nil, client, tl.ConsoleLogger("error")))
 
 	// case where everything is good
 	r.URL.RawQuery = "start_ts=0&end_ts=900&rollup_span=300s&type=average"

--- a/internal/proxy/origins/irondb/irondb.go
+++ b/internal/proxy/origins/irondb/irondb.go
@@ -133,8 +133,3 @@ func (c *Client) Name() string {
 func (c *Client) SetCache(cc cache.Cache) {
 	c.cache = cc
 }
-
-// SetUpstreamLogging enables or disables the logging of upstream requests
-func (c *Client) SetUpstreamLogging(logUpstreamRequest bool) {
-	c.logUpstreamRequest = logUpstreamRequest
-}

--- a/internal/proxy/origins/irondb/irondb_test.go
+++ b/internal/proxy/origins/irondb/irondb_test.go
@@ -19,12 +19,13 @@ import (
 	cr "github.com/Comcast/trickster/internal/cache/registration"
 	"github.com/Comcast/trickster/internal/config"
 	"github.com/Comcast/trickster/internal/proxy/origins"
+	tl "github.com/Comcast/trickster/internal/util/log"
 	"github.com/Comcast/trickster/internal/util/metrics"
 )
 
 func init() {
 	// Initialize Trickster instrumentation metrics.
-	metrics.Init(&config.TricksterConfig{})
+	metrics.Init(&config.TricksterConfig{}, tl.ConsoleLogger("error"))
 }
 
 func TestIRONdbClientInterfacing(t *testing.T) {
@@ -51,7 +52,7 @@ func TestNewClient(t *testing.T) {
 		t.Fatalf("Could not load configuration: %s", err.Error())
 	}
 
-	caches := cr.LoadCachesFromConfig(conf)
+	caches := cr.LoadCachesFromConfig(conf, tl.ConsoleLogger("error"))
 	defer cr.CloseCaches(caches)
 	cache, ok := caches["default"]
 	if !ok {
@@ -91,7 +92,7 @@ func TestCache(t *testing.T) {
 		t.Fatalf("Could not load configuration: %s", err.Error())
 	}
 
-	caches := cr.LoadCachesFromConfig(conf)
+	caches := cr.LoadCachesFromConfig(conf, tl.ConsoleLogger("error"))
 	defer cr.CloseCaches(caches)
 	cache, ok := caches["default"]
 	if !ok {

--- a/internal/proxy/origins/irondb/url_test.go
+++ b/internal/proxy/origins/irondb/url_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Comcast/trickster/internal/proxy/errors"
 	"github.com/Comcast/trickster/internal/proxy/request"
 	"github.com/Comcast/trickster/internal/timeseries"
+	tl "github.com/Comcast/trickster/internal/util/log"
 )
 
 func TestSetExtent(t *testing.T) {
@@ -49,7 +50,7 @@ func TestSetExtent(t *testing.T) {
 	client.makeExtentSetters()
 
 	pcs := client.DefaultPathConfigs(oc)
-	rsc := request.NewResources(oc, nil, nil, nil, client)
+	rsc := request.NewResources(oc, nil, nil, nil, client, tl.ConsoleLogger("error"))
 
 	cases := []struct {
 		handler  string
@@ -208,7 +209,7 @@ func TestFastForwardURL(t *testing.T) {
 
 	pcs := client.DefaultPathConfigs(oc)
 
-	rsc := request.NewResources(oc, nil, nil, nil, client)
+	rsc := request.NewResources(oc, nil, nil, nil, client, tl.ConsoleLogger("error"))
 
 	cases := []struct {
 		handler string
@@ -374,7 +375,8 @@ func TestParseTimerangeQuery(t *testing.T) {
 	client := &Client{name: "test"}
 	r, _ := http.NewRequest(http.MethodGet, "http://127.0.0.1/", nil)
 
-	r = request.SetResources(r, request.NewResources(client.config, &config.PathConfig{}, nil, nil, client))
+	r = request.SetResources(r, request.NewResources(client.config, &config.PathConfig{},
+		nil, nil, client, tl.ConsoleLogger("error")))
 
 	_, err := client.ParseTimeRangeQuery(r)
 	if err == nil || err != expected {

--- a/internal/proxy/origins/prometheus/handler_health_test.go
+++ b/internal/proxy/origins/prometheus/handler_health_test.go
@@ -20,12 +20,13 @@ import (
 
 	"github.com/Comcast/trickster/internal/config"
 	"github.com/Comcast/trickster/internal/proxy/request"
+	tl "github.com/Comcast/trickster/internal/util/log"
 	"github.com/Comcast/trickster/internal/util/metrics"
 	tu "github.com/Comcast/trickster/internal/util/testing"
 )
 
 func init() {
-	metrics.Init(&config.TricksterConfig{})
+	metrics.Init(&config.TricksterConfig{}, tl.ConsoleLogger("error"))
 }
 
 func TestHealthHandler(t *testing.T) {

--- a/internal/proxy/origins/prometheus/prometheus.go
+++ b/internal/proxy/origins/prometheus/prometheus.go
@@ -82,11 +82,6 @@ func (c *Client) SetCache(cc cache.Cache) {
 	c.cache = cc
 }
 
-// SetUpstreamLogging enables or disables the logging of upstream requests
-func (c *Client) SetUpstreamLogging(logUpstreamRequest bool) {
-	c.logUpstreamRequest = logUpstreamRequest
-}
-
 // Configuration returns the upstream Configuration for this Client
 func (c *Client) Configuration() *config.OriginConfig {
 	return c.config

--- a/internal/proxy/origins/prometheus/prometheus_test.go
+++ b/internal/proxy/origins/prometheus/prometheus_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Comcast/trickster/internal/config"
 	"github.com/Comcast/trickster/internal/proxy/errors"
 	"github.com/Comcast/trickster/internal/proxy/origins"
+	tl "github.com/Comcast/trickster/internal/util/log"
 )
 
 func TestPrometheusClientInterfacing(t *testing.T) {
@@ -52,7 +53,7 @@ func TestNewClient(t *testing.T) {
 		t.Fatalf("Could not load configuration: %s", err.Error())
 	}
 
-	caches := cr.LoadCachesFromConfig(conf)
+	caches := cr.LoadCachesFromConfig(conf, tl.ConsoleLogger("error"))
 	defer cr.CloseCaches(caches)
 	cache, ok := caches["default"]
 	if !ok {
@@ -137,7 +138,7 @@ func TestCache(t *testing.T) {
 		t.Fatalf("Could not load configuration: %s", err.Error())
 	}
 
-	caches := cr.LoadCachesFromConfig(conf)
+	caches := cr.LoadCachesFromConfig(conf, tl.ConsoleLogger("error"))
 	defer cr.CloseCaches(caches)
 	cache, ok := caches["default"]
 	if !ok {

--- a/internal/proxy/origins/reverseproxycache/handler_health_test.go
+++ b/internal/proxy/origins/reverseproxycache/handler_health_test.go
@@ -21,12 +21,13 @@ import (
 
 	"github.com/Comcast/trickster/internal/config"
 	"github.com/Comcast/trickster/internal/proxy/request"
+	tl "github.com/Comcast/trickster/internal/util/log"
 	"github.com/Comcast/trickster/internal/util/metrics"
 	tu "github.com/Comcast/trickster/internal/util/testing"
 )
 
 func init() {
-	metrics.Init(&config.TricksterConfig{})
+	metrics.Init(&config.TricksterConfig{}, tl.ConsoleLogger("error"))
 }
 
 func TestHealthHandler(t *testing.T) {

--- a/internal/proxy/origins/reverseproxycache/rpc.go
+++ b/internal/proxy/origins/reverseproxycache/rpc.go
@@ -67,7 +67,3 @@ func (c *Client) Name() string {
 func (c *Client) SetCache(cc cache.Cache) {
 	c.cache = cc
 }
-
-// SetUpstreamLogging enables or disables the logging of upstream requests
-func (c *Client) SetUpstreamLogging(_ bool) {
-}

--- a/internal/proxy/origins/timeseries_client.go
+++ b/internal/proxy/origins/timeseries_client.go
@@ -48,6 +48,4 @@ type TimeseriesClient interface {
 	HTTPClient() *http.Client
 	// SetCache sets the Cache object the client will use when caching origin content
 	SetCache(cache.Cache)
-	// SetUpstreamLogging enables or disables the logging of upstream requests
-	SetUpstreamLogging(bool)
 }

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -23,12 +23,13 @@ import (
 	"time"
 
 	"github.com/Comcast/trickster/internal/config"
+	tl "github.com/Comcast/trickster/internal/util/log"
 	"github.com/Comcast/trickster/internal/util/metrics"
 	"github.com/gorilla/mux"
 )
 
 func init() {
-	metrics.Init(&config.TricksterConfig{})
+	metrics.Init(&config.TricksterConfig{}, tl.ConsoleLogger("error"))
 }
 
 func TestNewHTTPClient(t *testing.T) {
@@ -93,7 +94,7 @@ func TestNewHTTPClient(t *testing.T) {
 
 func TestNewListenerErr(t *testing.T) {
 	config.NewConfig()
-	l, err := NewListener("-", 0, 0, nil)
+	l, err := NewListener("-", 0, 0, nil, tl.ConsoleLogger("error"))
 	if err == nil {
 		l.Close()
 		t.Errorf("expected error: %s", `listen tcp: lookup -: no such host`)
@@ -116,7 +117,7 @@ func TestNewListenerTLS(t *testing.T) {
 		t.Error(err)
 	}
 
-	l, err := NewListener("", 0, 0, tlsConfig)
+	l, err := NewListener("", 0, 0, tlsConfig, tl.ConsoleLogger("error"))
 	defer l.Close()
 	if err != nil {
 		t.Error(err)
@@ -172,7 +173,7 @@ func TestListenerConnectionLimitWorks(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.Name, func(t *testing.T) {
-			l, err := NewListener("", tc.ListenPort, tc.ConnectionsLimit, nil)
+			l, err := NewListener("", tc.ListenPort, tc.ConnectionsLimit, nil, tl.ConsoleLogger("error"))
 			defer l.Close()
 
 			go func() {

--- a/internal/proxy/request/resources.go
+++ b/internal/proxy/request/resources.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Comcast/trickster/internal/proxy/context"
 	"github.com/Comcast/trickster/internal/proxy/origins"
 	"github.com/Comcast/trickster/internal/timeseries"
+	tl "github.com/Comcast/trickster/internal/util/log"
 )
 
 // Resources is a collection of resources a Trickster request would need to fulfill the client request
@@ -35,6 +36,7 @@ type Resources struct {
 	OriginClient      origins.Client
 	AlternateCacheTTL time.Duration
 	TimeRangeQuery    *timeseries.TimeRangeQuery
+	Logger            *tl.TricksterLogger
 }
 
 // Clone returns an exact copy of the subject Resources collection
@@ -48,17 +50,20 @@ func (r Resources) Clone() *Resources {
 		OriginClient:      r.OriginClient,
 		AlternateCacheTTL: r.AlternateCacheTTL,
 		TimeRangeQuery:    r.TimeRangeQuery,
+		Logger:            r.Logger,
 	}
 }
 
 // NewResources returns a new Resources collection based on the provided inputs
-func NewResources(oc *config.OriginConfig, pc *config.PathConfig, cc *config.CachingConfig, c cache.Cache, client origins.Client) *Resources {
+func NewResources(oc *config.OriginConfig, pc *config.PathConfig, cc *config.CachingConfig,
+	c cache.Cache, client origins.Client, logger *tl.TricksterLogger) *Resources {
 	return &Resources{
 		OriginConfig: oc,
 		PathConfig:   pc,
 		CacheConfig:  cc,
 		CacheClient:  c,
 		OriginClient: client,
+		Logger:       logger,
 	}
 }
 

--- a/internal/proxy/request/resources_test.go
+++ b/internal/proxy/request/resources_test.go
@@ -20,10 +20,11 @@ import (
 	"time"
 
 	tc "github.com/Comcast/trickster/internal/proxy/context"
+	tl "github.com/Comcast/trickster/internal/util/log"
 )
 
 func TestNewAndCloneResources(t *testing.T) {
-	r := NewResources(nil, nil, nil, nil, nil)
+	r := NewResources(nil, nil, nil, nil, nil, tl.ConsoleLogger("error"))
 	r.AlternateCacheTTL = time.Duration(1) * time.Second
 	r2 := r.Clone()
 	if r2.AlternateCacheTTL != r.AlternateCacheTTL {
@@ -32,7 +33,7 @@ func TestNewAndCloneResources(t *testing.T) {
 }
 
 func TestGetAndSetResources(t *testing.T) {
-	r := NewResources(nil, nil, nil, nil, nil)
+	r := NewResources(nil, nil, nil, nil, nil, tl.ConsoleLogger("error"))
 	r.AlternateCacheTTL = time.Duration(1) * time.Second
 	req, _ := http.NewRequest(http.MethodGet, "http://127.0.0.1/", nil)
 	ctx := context.Background()

--- a/internal/util/log/log.go
+++ b/internal/util/log/log.go
@@ -31,7 +31,7 @@ import (
 )
 
 // Logger is the handle to the common TricksterLogger
-var Logger *TricksterLogger
+// var Logger *TricksterLogger
 
 func mapToArray(event string, detail Pairs) []interface{} {
 	a := make([]interface{}, (len(detail)*2)+2)
@@ -58,18 +58,21 @@ func mapToArray(event string, detail Pairs) []interface{} {
 	return a
 }
 
-var onceMutex *sync.Mutex
-var onceRanEntries map[string]bool
+// DefaultLogger returns the default logger, which is the console logger at level "info"
+func DefaultLogger() *TricksterLogger {
+	return ConsoleLogger("info")
+}
 
-func init() {
-	Logger = ConsoleLogger("info")
-	onceRanEntries = make(map[string]bool)
-	onceMutex = &sync.Mutex{}
+func noopLogger() *TricksterLogger {
+	return &TricksterLogger{
+		onceRanEntries: make(map[string]bool),
+		onceMutex:      &sync.Mutex{},
+	}
 }
 
 // ConsoleLogger returns a TricksterLogger object that prints log events to the Console
 func ConsoleLogger(logLevel string) *TricksterLogger {
-	l := &TricksterLogger{}
+	l := noopLogger()
 
 	wr := os.Stdout
 
@@ -110,9 +113,9 @@ func ConsoleLogger(logLevel string) *TricksterLogger {
 // Init returns a TricksterLogger for the provided logging configuration. The
 // returned TricksterLogger will write to files distinguished from other TricksterLoggers by the
 // instance string.
-func Init(conf *config.TricksterConfig) {
-	l := &TricksterLogger{}
+func Init(conf *config.TricksterConfig) *TricksterLogger {
 
+	l := noopLogger()
 	var wr io.Writer
 
 	if conf.Logging.LogFile == "" {
@@ -164,8 +167,7 @@ func Init(conf *config.TricksterConfig) {
 		l.closer = c
 	}
 
-	Logger = l
-
+	return l
 }
 
 // Pairs represents a key=value pair that helps to describe a log event
@@ -176,107 +178,110 @@ type TricksterLogger struct {
 	logger log.Logger
 	closer io.Closer
 	level  string
+
+	onceMutex      *sync.Mutex
+	onceRanEntries map[string]bool
 }
 
 // Info sends an "INFO" event to the TricksterLogger
-func Info(event string, detail Pairs) {
-	level.Info(Logger.logger).Log(mapToArray(event, detail)...)
+func (tl *TricksterLogger) Info(event string, detail Pairs) {
+	level.Info(tl.logger).Log(mapToArray(event, detail)...)
 }
 
 // InfoOnce sends a "INFO" event to the TricksterLogger only once per key.
 // Returns true if this invocation was the first, and thus sent to the TricksterLogger
-func InfoOnce(key string, event string, detail Pairs) bool {
-	onceMutex.Lock()
-	defer onceMutex.Unlock()
+func (tl *TricksterLogger) InfoOnce(key string, event string, detail Pairs) bool {
+	tl.onceMutex.Lock()
+	defer tl.onceMutex.Unlock()
 	key = "info." + key
-	if _, ok := onceRanEntries[key]; !ok {
-		onceRanEntries[key] = true
-		Info(event, detail)
+	if _, ok := tl.onceRanEntries[key]; !ok {
+		tl.onceRanEntries[key] = true
+		tl.Info(event, detail)
 		return true
 	}
 	return false
 }
 
 // Warn sends an "WARN" event to the TricksterLogger
-func Warn(event string, detail Pairs) {
-	level.Warn(Logger.logger).Log(mapToArray(event, detail)...)
+func (tl *TricksterLogger) Warn(event string, detail Pairs) {
+	level.Warn(tl.logger).Log(mapToArray(event, detail)...)
 }
 
 // WarnOnce sends a "WARN" event to the TricksterLogger only once per key.
 // Returns true if this invocation was the first, and thus sent to the TricksterLogger
-func WarnOnce(key string, event string, detail Pairs) bool {
-	onceMutex.Lock()
-	defer onceMutex.Unlock()
+func (tl *TricksterLogger) WarnOnce(key string, event string, detail Pairs) bool {
+	tl.onceMutex.Lock()
+	defer tl.onceMutex.Unlock()
 	key = "warn." + key
-	if _, ok := onceRanEntries[key]; !ok {
-		onceRanEntries[key] = true
-		Warn(event, detail)
+	if _, ok := tl.onceRanEntries[key]; !ok {
+		tl.onceRanEntries[key] = true
+		tl.Warn(event, detail)
 		return true
 	}
 	return false
 }
 
-// HasWarnedOnce returns true if a warning for the key has already been sent to the TricksterLoggerr
-func HasWarnedOnce(key string) bool {
-	onceMutex.Lock()
-	defer onceMutex.Unlock()
+// HasWarnedOnce returns true if a warning for the key has already been sent to the TricksterLogger
+func (tl *TricksterLogger) HasWarnedOnce(key string) bool {
+	tl.onceMutex.Lock()
+	defer tl.onceMutex.Unlock()
 	key = "warn." + key
-	_, ok := onceRanEntries[key]
+	_, ok := tl.onceRanEntries[key]
 	return ok
 }
 
 // Error sends an "ERROR" event to the TricksterLogger
-func Error(event string, detail Pairs) {
-	level.Error(Logger.logger).Log(mapToArray(event, detail)...)
+func (tl *TricksterLogger) Error(event string, detail Pairs) {
+	level.Error(tl.logger).Log(mapToArray(event, detail)...)
 }
 
 // ErrorOnce sends an "ERROR" event to the TricksterLogger only once per key
 // Returns true if this invocation was the first, and thus sent to the TricksterLogger
-func ErrorOnce(key string, event string, detail Pairs) bool {
-	onceMutex.Lock()
-	defer onceMutex.Unlock()
+func (tl *TricksterLogger) ErrorOnce(key string, event string, detail Pairs) bool {
+	tl.onceMutex.Lock()
+	defer tl.onceMutex.Unlock()
 	key = "error." + key
-	if _, ok := onceRanEntries[key]; !ok {
-		onceRanEntries[key] = true
-		Error(event, detail)
+	if _, ok := tl.onceRanEntries[key]; !ok {
+		tl.onceRanEntries[key] = true
+		tl.Error(event, detail)
 		return true
 	}
 	return false
 }
 
 // Debug sends an "DEBUG" event to the TricksterLogger
-func Debug(event string, detail Pairs) {
-	level.Debug(Logger.logger).Log(mapToArray(event, detail)...)
+func (tl *TricksterLogger) Debug(event string, detail Pairs) {
+	level.Debug(tl.logger).Log(mapToArray(event, detail)...)
 }
 
 // Trace sends a "TRACE" event to the TricksterLogger
-func Trace(event string, detail Pairs) {
+func (tl *TricksterLogger) Trace(event string, detail Pairs) {
 	// go-kit/log/level does not support Trace, so implemented separately here
-	if Logger.level == "trace" {
+	if tl.level == "trace" {
 		detail["level"] = "trace"
-		Logger.logger.Log(mapToArray(event, detail)...)
+		tl.logger.Log(mapToArray(event, detail)...)
 	}
 }
 
 // Fatal sends a "FATAL" event to the TricksterLogger and exits the program with the provided exit code
-func Fatal(code int, event string, detail Pairs) {
+func (tl *TricksterLogger) Fatal(code int, event string, detail Pairs) {
 	// go-kit/log/level does not support Fatal, so implemented separately here
 	detail["level"] = "fatal"
-	Logger.logger.Log(mapToArray(event, detail)...)
+	tl.logger.Log(mapToArray(event, detail)...)
 	if code >= 0 {
 		os.Exit(code)
 	}
 }
 
 // Level returns the configured Log Level
-func (l TricksterLogger) Level() string {
-	return l.level
+func (tl *TricksterLogger) Level() string {
+	return tl.level
 }
 
 // Close closes any opened file handles that were used for logging.
-func (l TricksterLogger) Close() {
-	if l.closer != nil {
-		l.closer.Close()
+func (tl *TricksterLogger) Close() {
+	if tl.closer != nil {
+		tl.closer.Close()
 	}
 }
 

--- a/internal/util/log/log_test.go
+++ b/internal/util/log/log_test.go
@@ -46,10 +46,10 @@ func TestInit(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogLevel: "info"}
-	Init(conf)
-	defer Logger.Close()
-	if Logger.level != "info" {
-		t.Errorf("expected %s got %s", "info", Logger.level)
+	log := Init(conf)
+	defer log.Close()
+	if log.level != "info" {
+		t.Errorf("expected %s got %s", "info", log.level)
 	}
 }
 
@@ -60,13 +60,13 @@ func TestNewLogger_LogFile(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 1}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "info"}
-	Init(conf)
-	defer Logger.Close()
-	Info("test entry", Pairs{"testKey": "testVal"})
+	log := Init(conf)
+	defer log.Close()
+	log.Info("test entry", Pairs{"testKey": "testVal"})
 	if _, err := os.Stat(instanceFileName); err != nil {
 		t.Errorf(err.Error())
 	}
-	Logger.Close()
+	log.Close()
 	os.Remove(instanceFileName)
 }
 
@@ -76,13 +76,13 @@ func TestNewLoggerDebug_LogFile(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "debug"}
-	Init(conf)
-	defer Logger.Close()
-	Debug("test entry", Pairs{"testKey": "testVal"})
+	log := Init(conf)
+	defer log.Close()
+	log.Debug("test entry", Pairs{"testKey": "testVal"})
 	if _, err := os.Stat(fileName); err != nil {
 		t.Errorf(err.Error())
 	}
-	Logger.Close()
+	log.Close()
 	os.Remove(fileName)
 }
 
@@ -92,13 +92,13 @@ func TestNewLoggerWarn_LogFile(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "warn"}
-	Init(conf)
-	defer Logger.Close()
-	Warn("test entry", Pairs{"testKey": "testVal"})
+	log := Init(conf)
+	defer log.Close()
+	log.Warn("test entry", Pairs{"testKey": "testVal"})
 	if _, err := os.Stat(fileName); err != nil {
 		t.Errorf(err.Error())
 	}
-	Logger.Close()
+	log.Close()
 	os.Remove(fileName)
 }
 
@@ -108,37 +108,37 @@ func TestNewLoggerWarnOnce_LogFile(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "x"}
-	Init(conf)
-	defer Logger.Close()
+	log := Init(conf)
+	defer log.Close()
 
 	key := "warnonce-test-key"
 
-	if HasWarnedOnce(key) {
+	if log.HasWarnedOnce(key) {
 		t.Errorf("expected %t got %t", false, true)
 	}
 
-	ok := WarnOnce(key, "test entry", Pairs{"testKey": "testVal"})
+	ok := log.WarnOnce(key, "test entry", Pairs{"testKey": "testVal"})
 	if !ok {
 		t.Errorf("expected %t got %t", true, ok)
 	}
 
-	if !HasWarnedOnce(key) {
+	if !log.HasWarnedOnce(key) {
 		t.Errorf("expected %t got %t", true, false)
 	}
 
-	ok = WarnOnce(key, "test entry", Pairs{"testKey": "testVal"})
+	ok = log.WarnOnce(key, "test entry", Pairs{"testKey": "testVal"})
 	if ok {
 		t.Errorf("expected %t got %t", false, ok)
 	}
 
-	if !HasWarnedOnce(key) {
+	if !log.HasWarnedOnce(key) {
 		t.Errorf("expected %t got %t", true, false)
 	}
 
 	if _, err := os.Stat(fileName); err != nil {
 		t.Errorf(err.Error())
 	}
-	Logger.Close()
+	log.Close()
 	os.Remove(fileName)
 }
 
@@ -148,13 +148,13 @@ func TestNewLoggerError_LogFile(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "error"}
-	Init(conf)
-	defer Logger.Close()
-	Error("test entry", Pairs{"testKey": "testVal"})
+	log := Init(conf)
+	defer log.Close()
+	log.Error("test entry", Pairs{"testKey": "testVal"})
 	if _, err := os.Stat(fileName); err != nil {
 		t.Errorf(err.Error())
 	}
-	Logger.Close()
+	log.Close()
 	os.Remove(fileName)
 }
 
@@ -164,15 +164,15 @@ func TestNewLoggerErrorOnce_LogFile(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "x"}
-	Init(conf)
-	defer Logger.Close()
+	log := Init(conf)
+	defer log.Close()
 
-	ok := ErrorOnce("erroroonce-test-key", "test entry", Pairs{"testKey": "testVal"})
+	ok := log.ErrorOnce("erroroonce-test-key", "test entry", Pairs{"testKey": "testVal"})
 	if !ok {
 		t.Errorf("expected %t got %t", true, ok)
 	}
 
-	ok = ErrorOnce("erroroonce-test-key", "test entry", Pairs{"testKey": "testVal"})
+	ok = log.ErrorOnce("erroroonce-test-key", "test entry", Pairs{"testKey": "testVal"})
 	if ok {
 		t.Errorf("expected %t got %t", false, ok)
 	}
@@ -180,7 +180,7 @@ func TestNewLoggerErrorOnce_LogFile(t *testing.T) {
 	if _, err := os.Stat(fileName); err != nil {
 		t.Errorf(err.Error())
 	}
-	Logger.Close()
+	log.Close()
 	os.Remove(fileName)
 }
 
@@ -190,13 +190,13 @@ func TestNewLoggerTrace_LogFile(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "trace"}
-	Init(conf)
-	defer Logger.Close()
-	Trace("test entry", Pairs{"testKey": "testVal"})
+	log := Init(conf)
+	defer log.Close()
+	log.Trace("test entry", Pairs{"testKey": "testVal"})
 	if _, err := os.Stat(fileName); err != nil {
 		t.Errorf(err.Error())
 	}
-	Logger.Close()
+	log.Close()
 	os.Remove(fileName)
 }
 
@@ -206,13 +206,13 @@ func TestNewLoggerDefault_LogFile(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "x"}
-	Init(conf)
-	defer Logger.Close()
-	Info("test entry", Pairs{"testKey": "testVal"})
+	log := Init(conf)
+	defer log.Close()
+	log.Info("test entry", Pairs{"testKey": "testVal"})
 	if _, err := os.Stat(fileName); err != nil {
 		t.Errorf(err.Error())
 	}
-	Logger.Close()
+	log.Close()
 	os.Remove(fileName)
 }
 
@@ -222,14 +222,14 @@ func TestNewLoggerInfoOnce_LogFile(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "info"}
-	Init(conf)
-	defer Logger.Close()
-	ok := InfoOnce("infoonce-test-key", "test entry", Pairs{"testKey": "testVal"})
+	log := Init(conf)
+	defer log.Close()
+	ok := log.InfoOnce("infoonce-test-key", "test entry", Pairs{"testKey": "testVal"})
 	if !ok {
 		t.Errorf("expected %t got %t", true, ok)
 	}
 
-	ok = InfoOnce("infoonce-test-key", "test entry", Pairs{"testKey": "testVal"})
+	ok = log.InfoOnce("infoonce-test-key", "test entry", Pairs{"testKey": "testVal"})
 	if ok {
 		t.Errorf("expected %t got %t", false, ok)
 	}
@@ -238,7 +238,7 @@ func TestNewLoggerInfoOnce_LogFile(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	Logger.Close()
+	log.Close()
 	os.Remove(fileName)
 }
 
@@ -248,12 +248,12 @@ func TestNewLoggerFatal_LogFile(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "debug"}
-	Init(conf)
-	defer Logger.Close()
-	Fatal(-1, "test entry", Pairs{"testKey": "testVal"})
+	log := Init(conf)
+	defer log.Close()
+	log.Fatal(-1, "test entry", Pairs{"testKey": "testVal"})
 	if _, err := os.Stat(fileName); err != nil {
 		t.Errorf(err.Error())
 	}
-	Logger.Close()
+	log.Close()
 	os.Remove(fileName)
 }

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -24,7 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/Comcast/trickster/internal/config"
-	"github.com/Comcast/trickster/internal/util/log"
+	tl "github.com/Comcast/trickster/internal/util/log"
 )
 
 const (
@@ -99,11 +99,11 @@ var ProxyConnectionFailed prometheus.Counter
 var o sync.Once
 
 // Init initializes the instrumented metrics and starts the listener endpoint
-func Init(conf *config.TricksterConfig) {
-	o.Do(initialize(conf))
+func Init(conf *config.TricksterConfig, log *tl.TricksterLogger) {
+	o.Do(initialize(conf, log))
 }
 
-func initialize(conf *config.TricksterConfig) func() {
+func initialize(conf *config.TricksterConfig, log *tl.TricksterLogger) func() {
 	return func() {
 		FrontendRequestStatus = prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -314,11 +314,11 @@ func initialize(conf *config.TricksterConfig) func() {
 		if conf.Metrics != nil && conf.Metrics.ListenPort > 0 {
 			go func() {
 
-				log.Info("metrics http endpoint starting", log.Pairs{"address": conf.Metrics.ListenAddress, "port": fmt.Sprintf("%d", conf.Metrics.ListenPort)})
+				log.Info("metrics http endpoint starting", tl.Pairs{"address": conf.Metrics.ListenAddress, "port": fmt.Sprintf("%d", conf.Metrics.ListenPort)})
 
 				http.Handle("/metrics", promhttp.Handler())
 				if err := http.ListenAndServe(fmt.Sprintf("%s:%d", conf.Metrics.ListenAddress, conf.Metrics.ListenPort), nil); err != nil {
-					log.Error("unable to start metrics http server", log.Pairs{"detail": err.Error()})
+					log.Error("unable to start metrics http server", tl.Pairs{"detail": err.Error()})
 					os.Exit(1)
 				}
 			}()

--- a/internal/util/middleware/config_context.go
+++ b/internal/util/middleware/config_context.go
@@ -21,16 +21,18 @@ import (
 	"github.com/Comcast/trickster/internal/proxy/context"
 	"github.com/Comcast/trickster/internal/proxy/origins"
 	"github.com/Comcast/trickster/internal/proxy/request"
+	tl "github.com/Comcast/trickster/internal/util/log"
 )
 
 // WithResourcesContext ...
-func WithResourcesContext(client origins.Client, oc *config.OriginConfig, c cache.Cache, p *config.PathConfig, next http.Handler) http.Handler {
+func WithResourcesContext(client origins.Client, oc *config.OriginConfig,
+	c cache.Cache, p *config.PathConfig, l *tl.TricksterLogger, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var resources *request.Resources
 		if c == nil {
-			resources = request.NewResources(oc, p, nil, nil, client)
+			resources = request.NewResources(oc, p, nil, nil, client, l)
 		} else {
-			resources = request.NewResources(oc, p, c.Configuration(), c, client)
+			resources = request.NewResources(oc, p, c.Configuration(), c, client, l)
 		}
 		next.ServeHTTP(w, r.WithContext(context.WithResources(r.Context(), resources)))
 	})

--- a/internal/util/testing/testing.go
+++ b/internal/util/testing/testing.go
@@ -27,6 +27,7 @@ import (
 	tc "github.com/Comcast/trickster/internal/proxy/context"
 	th "github.com/Comcast/trickster/internal/proxy/headers"
 	"github.com/Comcast/trickster/internal/proxy/request"
+	tl "github.com/Comcast/trickster/internal/util/log"
 	"github.com/Comcast/trickster/internal/util/metrics"
 	tr "github.com/Comcast/trickster/internal/util/tracing/registration"
 	"github.com/Comcast/trickster/pkg/promsim"
@@ -67,7 +68,7 @@ func NewTestInstance(
 	originType, urlPath, logLevel string,
 ) (*httptest.Server, *httptest.ResponseRecorder, *http.Request, *http.Client, error) {
 
-	metrics.Init(&config.TricksterConfig{}) // TODO: move after conf.Load
+	metrics.Init(&config.TricksterConfig{}, tl.ConsoleLogger("error")) // TODO: move after conf.Load
 
 	isBasicTestServer := false
 
@@ -93,7 +94,7 @@ func NewTestInstance(
 		return nil, nil, nil, nil, fmt.Errorf("Could not load configuration: %s", err.Error())
 	}
 
-	caches := cr.LoadCachesFromConfig(conf)
+	caches := cr.LoadCachesFromConfig(conf, tl.ConsoleLogger("error"))
 	cache, ok := caches["default"]
 	if !ok {
 		return nil, nil, nil, nil, err
@@ -109,7 +110,7 @@ func NewTestInstance(
 	oc := conf.Origins["default"]
 	p := NewTestPathConfig(oc, DefaultPathConfigs, urlPath)
 
-	tracer, _, _ := tr.Init(oc.TracingConfig)
+	tracer, _, _ := tr.Init(oc.TracingConfig, tl.ConsoleLogger("error"))
 	// TODO worry about running closures for cleanup once the test is complete
 	oc.TracingConfig.Tracer = tracer
 
@@ -117,7 +118,7 @@ func NewTestInstance(
 		p.ResponseHeaders = respHeaders
 	}
 
-	rsc := request.NewResources(oc, p, cache.Configuration(), cache, nil)
+	rsc := request.NewResources(oc, p, cache.Configuration(), cache, nil, tl.ConsoleLogger("error"))
 	r = r.WithContext(tc.WithResources(r.Context(), rsc))
 
 	c := NewTestWebClient()

--- a/internal/util/tracing/registration/registration.go
+++ b/internal/util/tracing/registration/registration.go
@@ -21,7 +21,7 @@ import (
 	"go.opentelemetry.io/otel/api/trace"
 
 	"github.com/Comcast/trickster/internal/config"
-	"github.com/Comcast/trickster/internal/util/log"
+	tl "github.com/Comcast/trickster/internal/util/log"
 	"github.com/Comcast/trickster/internal/util/tracing"
 )
 
@@ -30,7 +30,7 @@ type Flushers []func()
 
 // RegisterAll registers all Tracers in the provided configuration, and returns
 // their Flushers
-func RegisterAll(cfg *config.TricksterConfig) (Flushers, error) {
+func RegisterAll(cfg *config.TricksterConfig, log *tl.TricksterLogger) (Flushers, error) {
 
 	if cfg == nil {
 		return nil, errors.New("no config provided")
@@ -60,7 +60,7 @@ func RegisterAll(cfg *config.TricksterConfig) (Flushers, error) {
 			}
 
 			if _, ok := activeTracers[oc.TracingConfigName]; !ok {
-				tracer, flusher, err := Init(tc)
+				tracer, flusher, err := Init(tc, log)
 				if err != nil {
 					return nil, err
 				}
@@ -75,7 +75,7 @@ func RegisterAll(cfg *config.TricksterConfig) (Flushers, error) {
 }
 
 // Init initializes tracing and returns a function to flush the tracer. Flush should be called on server shutdown.
-func Init(cfg *config.TracingConfig) (trace.Tracer, func(), error) {
+func Init(cfg *config.TracingConfig, log *tl.TricksterLogger) (trace.Tracer, func(), error) {
 
 	if cfg == nil {
 		log.Info(
@@ -85,7 +85,7 @@ func Init(cfg *config.TracingConfig) (trace.Tracer, func(), error) {
 	}
 	log.Debug(
 		"Trace Init",
-		log.Pairs{
+		tl.Pairs{
 			"Implementation": cfg.Implementation,
 			"Collector":      cfg.CollectorEndpoint,
 			"Type":           tracing.TracerImplementations[cfg.Implementation],

--- a/internal/util/tracing/registration/registration_test.go
+++ b/internal/util/tracing/registration/registration_test.go
@@ -18,12 +18,13 @@ import (
 	"testing"
 
 	"github.com/Comcast/trickster/internal/config"
+	tl "github.com/Comcast/trickster/internal/util/log"
 )
 
 func TestRegisterAll(t *testing.T) {
 
 	// test nil config
-	f, err := RegisterAll(nil)
+	f, err := RegisterAll(nil, tl.ConsoleLogger("error"))
 	if err == nil {
 		t.Error(errors.New("expected error for no config provided"))
 	}
@@ -32,7 +33,7 @@ func TestRegisterAll(t *testing.T) {
 	}
 
 	// test good config
-	f, err = RegisterAll(config.NewConfig())
+	f, err = RegisterAll(config.NewConfig(), tl.ConsoleLogger("error"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -44,28 +45,28 @@ func TestRegisterAll(t *testing.T) {
 	cfg := config.NewConfig()
 	tc := cfg.Origins["default"].TracingConfig
 	tc.Implementation = "foo"
-	_, err = RegisterAll(cfg)
+	_, err = RegisterAll(cfg, tl.ConsoleLogger("error"))
 	if err == nil {
 		t.Error("expected error for invalid tracing implementation")
 	}
 
 	// test empty implementation
 	tc.Implementation = ""
-	f, _ = RegisterAll(cfg)
+	f, _ = RegisterAll(cfg, tl.ConsoleLogger("error"))
 	if len(f) > 0 {
 		t.Errorf("expected %d got %d", 0, len(f))
 	}
 
 	// test nil tracing config
 	cfg.Origins["default"].TracingConfig = nil
-	f, _ = RegisterAll(cfg)
+	f, _ = RegisterAll(cfg, tl.ConsoleLogger("error"))
 	if len(f) > 0 {
 		t.Errorf("expected %d got %d", 0, len(f))
 	}
 
 	// test nil origin config
 	cfg.Origins = nil
-	_, err = RegisterAll(cfg)
+	_, err = RegisterAll(cfg, tl.ConsoleLogger("error"))
 	if err == nil {
 		t.Error(errors.New("expected error for invalid tracing implementation"))
 	}
@@ -73,7 +74,7 @@ func TestRegisterAll(t *testing.T) {
 }
 
 func TestInit(t *testing.T) {
-	tr, _, _ := Init(nil)
+	tr, _, _ := Init(nil, tl.ConsoleLogger("error"))
 	if tr == nil {
 		t.Error("expected non-nil (noop) tracer")
 	}


### PR DESCRIPTION
This PR removes the global state variables from the log package.

Notes: 

Packages can no longer import the logging package and call out to Info(), Warn() etc. All functions in all packages must be passed (or be of types) *http.Request, *log.TricksterLogger, cache.Cache implementation or *proxyRequest; in order to get access to logging functions.

The logger is added to the Resources collection set in the context of each inbound http request (which also includes the request's cache layer handle, etc). This ensures any HTTP handler can access the logging interface via the request context, and should be compatible with our efforts to support reloading the config without a process start, since subsequent inbound requests after the config is reloaded would be provided with the new logger reference.

The Trickster *ProxyRequest type, which is a derivative of *http.Request and used to handle all requests, now has a member for the logger reference; this is set from the context when a *ProxyRequest is created from an *http.Request, to avoid having to have all of the proxy functionality constantly pulling the logger from the context.

A logger member has also been added to most Cache implementations (but no change to the interface itself) and is set at registration. So we may need to iterate the caches and update this reference when the logging config changes, when we implement in-process config reload. 