### PR TITLE
perf: [cache] use singleflight to de-duplicate cache lookups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.35.0
 	golang.org/x/crypto v0.38.0
 	golang.org/x/net v0.40.0
+	golang.org/x/sync v0.14.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v2 v2.4.0
 )


### PR DESCRIPTION
Use [singleflight](https://pkg.go.dev/golang.org/x/sync@v0.14.0/singleflight#Group) to suppress duplicate cache key lookups.

This should reduce cache lookups if there are concurrent queries for the same key.

Skipping this for the `RetrieveReference` call, since that is already working from memory, suppression won't help much there since the data is already local.