### PR TITLE
fix health check scoping issue

### DIFF
--- a/pkg/backends/alb/pool/health.go
+++ b/pkg/backends/alb/pool/health.go
@@ -40,8 +40,8 @@ func (p *pool) checkHealth() {
 			for _, t := range p.targets {
 				if t.hcStatus.Get() >= p.healthyFloor {
 					h[k] = t.handler
+					k++
 				}
-				k++
 			}
 			h = h[:k]
 			p.healthy.Store(&h)


### PR DESCRIPTION
This fix corrects an issue with ALB Health Checks where a nil http.Handler pointer is inserted into the healthy pool list when a target is deemed unhealthy, due to an iterator scoping defect.