### PR TITLE
fix parsing issue in rules config

### DIFF
--- a/docs/rule.md
+++ b/docs/rule.md
@@ -87,8 +87,7 @@ rules:
     operation: prefix      # Basic Auth credentials are formatted as user:pass,
                            # so we can check if it is prefixed with $user:
     cases:
-      writers:
-        matches: # route johndoe and janedoe users to writer cluster
+      - matches: # writers
           - 'johndoe:'
           - 'janedoe:'
         next_route: example-writer-cluster

--- a/pkg/backends/rule/options/options.go
+++ b/pkg/backends/rule/options/options.go
@@ -82,7 +82,7 @@ type Options struct {
 	// configured Operation, such as the demonimator when the operation is modulus
 	OperationArg string `yaml:"operation_arg,omitempty"`
 	// RuleCaseOptions is the map of cases to apply to evaluate against this rule
-	CaseOptions CaseLookup `yaml:"cases,omitempty"`
+	CaseOptions CaseOptionsList `yaml:"cases,omitempty"`
 	// RedirectURL provides a URL to redirect the request in the default case, rather than
 	// handing off to the NextRoute
 	RedirectURL string `yaml:"redirect_url,omitempty"`
@@ -108,7 +108,7 @@ type CaseOptions struct {
 // Lookup is a map of Options
 type Lookup map[string]*Options
 
-type CaseLookup map[string]*CaseOptions
+type CaseOptionsList []*CaseOptions
 
 var ErrInvalidName = errors.New("invalid rule name")
 var restrictedNames = sets.New([]string{"", "none"})

--- a/pkg/backends/rule/parse.go
+++ b/pkg/backends/rule/parse.go
@@ -168,17 +168,17 @@ func (c *Client) parseOptions(o *ro.Options, rwi rewriter.InstructionsLookup) er
 			if v.ReqRewriterName != "" {
 				i, ok := rwi[v.ReqRewriterName]
 				if !ok {
-					return fmt.Errorf("invalid rewriter %s in rule %s case %s", k, o.Name, k)
+					return fmt.Errorf("invalid rewriter %d in rule %s", k, o.Name)
 				}
 				ri = i
 			}
 
 			if v.NextRoute == "" && v.RedirectURL == "" && v.ReqRewriterName == "" {
-				return fmt.Errorf("missing next_route in rule %s case %s", o.Name, k)
+				return fmt.Errorf("missing next_route in rule %s case %d", o.Name, k)
 			}
 
 			if len(v.Matches) == 0 {
-				return fmt.Errorf("missing matches in rule %s case %s", o.Name, k)
+				return fmt.Errorf("missing matches in rule %s case %d", o.Name, k)
 			}
 
 			rc := 0
@@ -188,7 +188,7 @@ func (c *Client) parseOptions(o *ro.Options, rwi rewriter.InstructionsLookup) er
 			} else if v.NextRoute != "" {
 				no, ok := c.clients[v.NextRoute]
 				if !ok {
-					return fmt.Errorf("unknown next_route %s in rule %s case %s",
+					return fmt.Errorf("unknown next_route %s in rule %s case %d",
 						v.NextRoute, o.Name, k)
 				}
 				nr = no.Router()

--- a/pkg/backends/rule/parse_test.go
+++ b/pkg/backends/rule/parse_test.go
@@ -189,43 +189,43 @@ func TestParseOptions(t *testing.T) {
 	}
 
 	expected = "invalid rewriter"
-	temp = ropts.CaseOptions["1"].ReqRewriterName
-	ropts.CaseOptions["1"].ReqRewriterName = "invalid"
+	temp = ropts.CaseOptions[0].ReqRewriterName
+	ropts.CaseOptions[0].ReqRewriterName = "invalid"
 	err = c.parseOptions(ropts, rwi)
-	ropts.CaseOptions["1"].ReqRewriterName = temp
+	ropts.CaseOptions[0].ReqRewriterName = temp
 	if err == nil || !strings.Contains(err.Error(), expected) {
 		t.Errorf("expected error for %s", expected)
 	}
 
 	expected = "missing next_route"
-	temp = ropts.CaseOptions["1"].ReqRewriterName
-	temp2 = ropts.CaseOptions["1"].RedirectURL
-	temp4 := ropts.CaseOptions["1"].NextRoute
-	ropts.CaseOptions["1"].ReqRewriterName = ""
-	ropts.CaseOptions["1"].RedirectURL = ""
-	ropts.CaseOptions["1"].NextRoute = ""
+	temp = ropts.CaseOptions[0].ReqRewriterName
+	temp2 = ropts.CaseOptions[0].RedirectURL
+	temp4 := ropts.CaseOptions[0].NextRoute
+	ropts.CaseOptions[0].ReqRewriterName = ""
+	ropts.CaseOptions[0].RedirectURL = ""
+	ropts.CaseOptions[0].NextRoute = ""
 	err = c.parseOptions(ropts, rwi)
-	ropts.CaseOptions["1"].ReqRewriterName = temp
-	ropts.CaseOptions["1"].RedirectURL = temp2
-	ropts.CaseOptions["1"].NextRoute = temp4
+	ropts.CaseOptions[0].ReqRewriterName = temp
+	ropts.CaseOptions[0].RedirectURL = temp2
+	ropts.CaseOptions[0].NextRoute = temp4
 	if err == nil || !strings.Contains(err.Error(), expected) {
 		t.Errorf("expected error for %s", expected)
 	}
 
 	expected = "missing matches in rule"
-	temp5 := ropts.CaseOptions["1"].Matches
-	ropts.CaseOptions["1"].Matches = []string{}
+	temp5 := ropts.CaseOptions[0].Matches
+	ropts.CaseOptions[0].Matches = []string{}
 	err = c.parseOptions(ropts, rwi)
-	ropts.CaseOptions["1"].Matches = temp5
+	ropts.CaseOptions[0].Matches = temp5
 	if err == nil || !strings.Contains(err.Error(), expected) {
 		t.Errorf("expected error for %s", expected)
 	}
 
 	expected = "unknown next_route"
-	temp = ropts.CaseOptions["1"].NextRoute
-	ropts.CaseOptions["1"].NextRoute = "invalid"
+	temp = ropts.CaseOptions[0].NextRoute
+	ropts.CaseOptions[0].NextRoute = "invalid"
 	err = c.parseOptions(ropts, rwi)
-	ropts.CaseOptions["1"].NextRoute = temp
+	ropts.CaseOptions[0].NextRoute = temp
 	if err == nil || !strings.Contains(err.Error(), expected) {
 		t.Errorf("expected error for %s", expected)
 	}

--- a/pkg/backends/rule/rule_test.go
+++ b/pkg/backends/rule/rule_test.go
@@ -111,22 +111,22 @@ func newTestRuleOpts() *ro.Options {
 	}
 }
 
-func newTestCaseOpts() ro.CaseLookup {
+func newTestCaseOpts() ro.CaseOptionsList {
 
-	return ro.CaseLookup{
-		"1": {
+	return ro.CaseOptionsList{
+		{
 			Matches:   []string{"trickster"},
 			NextRoute: "test-backend-2",
 		},
-		"2": {
+		{
 			Matches:         []string{providers.Proxy},
 			ReqRewriterName: "test-rewriter-4",
 		},
-		"3": {
+		{
 			Matches:     []string{"trickstercache"},
 			RedirectURL: "http://trickstercache.org",
 		},
-		"4": {
+		{
 			Matches:         []string{"true"},
 			ReqRewriterName: "test-rewriter-5",
 			RedirectURL:     "http://trickstercache.org",


### PR DESCRIPTION
this fixes an issue introduced in #865, which migrated from maps to slices for rule cases, to ensure the cases were parsed in the identical order every time the trickster configuration is loaded. The previous PR made the map->slice change internally on the parsed/compiled rules, but the external configuration struct was still utilizing a map for the case list, even though all of the documentation and example YAMLs had been updated to provide a slice.  This PR changes the `CaseOptions` field in the RuleOptions struct to a slice type to match the `cases` yaml field documentation, and updates tests + miscellaneous to account for the type change.