### PR TITLE
refactor: [options] use utility function for cloning simple structs

### DIFF
--- a/pkg/backends/alb/mech/ur/options/options.go
+++ b/pkg/backends/alb/mech/ur/options/options.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	"github.com/trickstercache/trickster/v2/pkg/config/types"
+	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
 	"github.com/trickstercache/trickster/v2/pkg/util/sets"
 )
 
@@ -80,11 +81,9 @@ func NewErrInvalidUserRouterOptions(backendName string) error {
 }
 
 func (o *Options) Clone() *Options {
-	return &Options{
-		DefaultBackend:    o.DefaultBackend,
-		NoRouteStatusCode: o.NoRouteStatusCode,
-		Users:             maps.Clone(o.Users),
-	}
+	out := pointers.Clone(o)
+	out.Users = maps.Clone(o.Users)
+	return out
 }
 
 // New returns a new User Router Options with default values

--- a/pkg/backends/prometheus/options/options.go
+++ b/pkg/backends/prometheus/options/options.go
@@ -17,8 +17,9 @@
 package options
 
 import (
-	"maps"
 	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
 )
 
 // Options stores information about Prometheus Options
@@ -33,10 +34,7 @@ func New() *Options {
 }
 
 func (o *Options) Clone() *Options {
-	return &Options{
-		InstantRound: o.InstantRound,
-		Labels:       maps.Clone(o.Labels),
-	}
+	return pointers.Clone(o)
 }
 
 func (o *Options) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/pkg/backends/rule/options/options.go
+++ b/pkg/backends/rule/options/options.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/trickstercache/trickster/v2/pkg/config/types"
+	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
 	"github.com/trickstercache/trickster/v2/pkg/util/sets"
 )
 
@@ -149,24 +150,7 @@ func (o *Options) Initialize(_ string) error {
 
 // Clone returns a perfect copy of the subject *Options
 func (o *Options) Clone() *Options {
-	return &Options{
-		Name:                   o.Name,
-		NextRoute:              o.NextRoute,
-		IngressReqRewriterName: o.IngressReqRewriterName,
-		EgressReqRewriterName:  o.EgressReqRewriterName,
-		NoMatchReqRewriterName: o.NoMatchReqRewriterName,
-		InputSource:            o.InputSource,
-		InputKey:               o.InputKey,
-		InputType:              o.InputType,
-		InputEncoding:          o.InputEncoding,
-		InputIndex:             o.InputIndex,
-		InputDelimiter:         o.InputDelimiter,
-		Operation:              o.Operation,
-		OperationArg:           o.OperationArg,
-		CaseOptions:            o.CaseOptions,
-		RedirectURL:            o.RedirectURL,
-		MaxRuleExecutions:      o.MaxRuleExecutions,
-	}
+	return pointers.Clone(o)
 }
 
 func (o *Options) Validate() (bool, error) {

--- a/pkg/config/mgmt/mgmt.go
+++ b/pkg/config/mgmt/mgmt.go
@@ -19,6 +19,8 @@ package mgmt
 import (
 	"errors"
 	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
 )
 
 // Options is a collection of configurations for trickster management features
@@ -85,14 +87,5 @@ func (o *Options) Validate() error {
 }
 
 func (o *Options) Clone() *Options {
-	return &Options{
-		ListenAddress:          o.ListenAddress,
-		ListenPort:             o.ListenPort,
-		ConfigHandlerPath:      o.ConfigHandlerPath,
-		PingHandlerPath:        o.PingHandlerPath,
-		HealthHandlerPath:      o.HealthHandlerPath,
-		PurgeByKeyHandlerPath:  o.PurgeByKeyHandlerPath,
-		PurgeByPathHandlerPath: o.PurgeByPathHandlerPath,
-		PprofServer:            o.PprofServer,
-	}
+	return pointers.Clone(o)
 }

--- a/pkg/config/testdata/example.alb.yaml
+++ b/pkg/config/testdata/example.alb.yaml
@@ -294,6 +294,7 @@ frontend:
   tls_listen_port: 8483
   max_request_body_size_bytes: 10485760
   truncate_request_body_too_large: false
+  read_header_timeout: 10s
 logging:
   log_level: INFO
 metrics:
@@ -314,3 +315,6 @@ mgmt:
   purge_by_key_path: /trickster/purge/key/
   purge_by_path_path: /trickster/purge/path/
   pprof_server: both
+  handler_path: /trickster/config/reload
+  drain_timeout: 30s
+  rate_limit: 3s

--- a/pkg/config/testdata/example.auth.yaml
+++ b/pkg/config/testdata/example.auth.yaml
@@ -177,6 +177,7 @@ frontend:
   tls_listen_port: 8483
   max_request_body_size_bytes: 10485760
   truncate_request_body_too_large: false
+  read_header_timeout: 10s
 logging:
   log_level: INFO
 metrics:
@@ -197,6 +198,9 @@ mgmt:
   purge_by_key_path: /trickster/purge/key/
   purge_by_path_path: /trickster/purge/path/
   pprof_server: both
+  handler_path: /trickster/config/reload
+  drain_timeout: 30s
+  rate_limit: 3s
 authenticators:
   example_auth_1:
     provider: basic

--- a/pkg/config/testdata/example.full.yaml
+++ b/pkg/config/testdata/example.full.yaml
@@ -69,6 +69,7 @@ frontend:
   tls_listen_port: 8483
   max_request_body_size_bytes: 10485760
   truncate_request_body_too_large: false
+  read_header_timeout: 10s
 logging:
   log_level: INFO
 metrics:
@@ -89,3 +90,6 @@ mgmt:
   purge_by_key_path: /trickster/purge/key/
   purge_by_path_path: /trickster/purge/path/
   pprof_server: both
+  handler_path: /trickster/config/reload
+  drain_timeout: 30s
+  rate_limit: 3s

--- a/pkg/config/testdata/exmple.sharding.yaml
+++ b/pkg/config/testdata/exmple.sharding.yaml
@@ -69,6 +69,7 @@ frontend:
   tls_listen_port: 8483
   max_request_body_size_bytes: 10485760
   truncate_request_body_too_large: false
+  read_header_timeout: 10s
 logging:
   log_level: info
 metrics:
@@ -89,3 +90,6 @@ mgmt:
   purge_by_key_path: /trickster/purge/key/
   purge_by_path_path: /trickster/purge/path/
   pprof_server: both
+  handler_path: /trickster/config/reload
+  drain_timeout: 30s
+  rate_limit: 3s

--- a/pkg/config/testdata/simple.prometheus.yaml
+++ b/pkg/config/testdata/simple.prometheus.yaml
@@ -68,6 +68,7 @@ frontend:
   tls_listen_port: 8483
   max_request_body_size_bytes: 10485760
   truncate_request_body_too_large: false
+  read_header_timeout: 10s
 logging:
   log_level: info
 metrics:
@@ -88,3 +89,6 @@ mgmt:
   purge_by_key_path: /trickster/purge/key/
   purge_by_path_path: /trickster/purge/path/
   pprof_server: both
+  handler_path: /trickster/config/reload
+  drain_timeout: 30s
+  rate_limit: 3s

--- a/pkg/config/testdata/simple.reverseproxycache.yaml
+++ b/pkg/config/testdata/simple.reverseproxycache.yaml
@@ -68,6 +68,7 @@ frontend:
   tls_listen_port: 8483
   max_request_body_size_bytes: 10485760
   truncate_request_body_too_large: false
+  read_header_timeout: 10s
 logging:
   log_level: info
 metrics:
@@ -88,3 +89,6 @@ mgmt:
   purge_by_key_path: /trickster/purge/key/
   purge_by_path_path: /trickster/purge/path/
   pprof_server: both
+  handler_path: /trickster/config/reload
+  drain_timeout: 30s
+  rate_limit: 3s

--- a/pkg/encoding/profile/profile.go
+++ b/pkg/encoding/profile/profile.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/trickstercache/trickster/v2/pkg/encoding/providers"
+	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
 	"github.com/trickstercache/trickster/v2/pkg/util/sets"
 )
 
@@ -49,16 +50,9 @@ type Profile struct {
 }
 
 func (p *Profile) Clone() *Profile {
-	return &Profile{
-		ClientAcceptEncoding: p.ClientAcceptEncoding,
-		Supported:            p.Supported,
-		SupportedHeaderVal:   p.SupportedHeaderVal,
-		NoTransform:          p.NoTransform,
-		ContentEncoding:      p.ContentEncoding,
-		CompressTypes:        p.CompressTypes,
-		ContentType:          p.ContentType,
-		Level:                p.Level,
-	}
+	out := pointers.Clone(p)
+	out.CompressTypes = p.CompressTypes.Clone()
+	return out
 }
 
 func (p *Profile) String() string {

--- a/pkg/frontend/options/options.go
+++ b/pkg/frontend/options/options.go
@@ -72,16 +72,11 @@ func (o *Options) Equal(o2 *Options) bool {
 
 // Clone returns a clone of the Options
 func (o *Options) Clone() *Options {
-	return &Options{
-		ListenAddress:               o.ListenAddress,
-		ListenPort:                  o.ListenPort,
-		TLSListenAddress:            o.TLSListenAddress,
-		TLSListenPort:               o.TLSListenPort,
-		ConnectionsLimit:            o.ConnectionsLimit,
-		ServeTLS:                    o.ServeTLS,
-		MaxRequestBodySizeBytes:     o.MaxRequestBodySizeBytes,
-		TruncateRequestBodyTooLarge: o.TruncateRequestBodyTooLarge,
+	out := pointers.Clone(o)
+	if o.MaxRequestBodySizeBytes != nil {
+		out.MaxRequestBodySizeBytes = pointers.New(*o.MaxRequestBodySizeBytes)
 	}
+	return out
 }
 
 func (o *Options) Initialize() error {

--- a/pkg/observability/logging/options/options.go
+++ b/pkg/observability/logging/options/options.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/trickstercache/trickster/v2/pkg/config/types"
+	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
 )
 
 // Options is a collection of Logging options
@@ -42,7 +43,7 @@ func New() *Options {
 
 // Clone returns a clone of the Options
 func (o *Options) Clone() *Options {
-	return &Options{LogLevel: o.LogLevel, LogFile: o.LogFile}
+	return pointers.Clone(o)
 }
 
 func (o *Options) Initialize(_ string) error {

--- a/pkg/observability/metrics/options/options.go
+++ b/pkg/observability/metrics/options/options.go
@@ -19,6 +19,7 @@ package options
 import (
 	"github.com/trickstercache/trickster/v2/pkg/config/types"
 	"github.com/trickstercache/trickster/v2/pkg/errors"
+	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
 )
 
 // Options is a collection of Metrics Collection configurations
@@ -41,10 +42,7 @@ func New() *Options {
 
 // Clone returns an exact copy of the Options
 func (o *Options) Clone() *Options {
-	return &Options{
-		ListenAddress: o.ListenAddress,
-		ListenPort:    o.ListenPort,
-	}
+	return pointers.Clone(o)
 }
 
 func (o *Options) Initialize(_ string) error {

--- a/pkg/observability/tracing/exporters/stdout/options/options.go
+++ b/pkg/observability/tracing/exporters/stdout/options/options.go
@@ -16,6 +16,8 @@
 
 package options
 
+import "github.com/trickstercache/trickster/v2/pkg/util/pointers"
+
 // Options is a collection of Stdout-specific options
 type Options struct {
 	PrettyPrint bool `yaml:"pretty_print,omitempty"`
@@ -28,7 +30,7 @@ func New() *Options {
 
 // Clone returns a perfect copy of the subject *Options
 func (o *Options) Clone() *Options {
-	return &Options{PrettyPrint: o.PrettyPrint}
+	return pointers.Clone(o)
 }
 
 func (o *Options) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/pkg/observability/tracing/options/options.go
+++ b/pkg/observability/tracing/options/options.go
@@ -64,18 +64,14 @@ func (o *Options) Clone() *Options {
 	if o.StdOutOptions != nil {
 		so = o.StdOutOptions.Clone()
 	}
-	return &Options{
-		Name:             o.Name,
-		Provider:         o.Provider,
-		ServiceName:      o.ServiceName,
-		Endpoint:         o.Endpoint,
-		SampleRate:       o.SampleRate,
-		Tags:             maps.Clone(o.Tags),
-		OmitTags:         maps.Clone(o.OmitTags),
-		OmitTagsList:     slices.Clone(o.OmitTagsList),
-		StdOutOptions:    so,
-		attachTagsToSpan: o.attachTagsToSpan,
+	out := pointers.Clone(o)
+	out.StdOutOptions = so
+	out.Tags = maps.Clone(o.Tags)
+	out.OmitTagsList = slices.Clone(o.OmitTagsList)
+	if o.SampleRate != nil {
+		out.SampleRate = pointers.New(*o.SampleRate)
 	}
+	return out
 }
 
 // ProcessTracingOptions enriches the configuration data of the provided Tracing Options collection

--- a/pkg/parsing/token/token.go
+++ b/pkg/parsing/token/token.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
 )
 
 // Common Tokens
@@ -57,11 +59,7 @@ var ErrParsingInt = errors.New("error parsing input for integer")
 
 // Clone makes a perfect copy of the subject Token
 func (t *Token) Clone() *Token {
-	return &Token{
-		Typ: t.Typ,
-		Pos: t.Pos,
-		Val: t.Val,
-	}
+	return pointers.Clone(t)
 }
 
 // Int64 attempts to return an int64 rendition of the token value

--- a/pkg/proxy/authenticator/options/options.go
+++ b/pkg/proxy/authenticator/options/options.go
@@ -23,6 +23,7 @@ import (
 	ae "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/errors"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/types"
 	"github.com/trickstercache/trickster/v2/pkg/util/files"
+	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
 	"github.com/trickstercache/trickster/v2/pkg/util/sets"
 )
 
@@ -50,17 +51,9 @@ func New() *Options {
 }
 
 func (o *Options) Clone() *Options {
-	out := &Options{
-		Name:            o.Name,
-		Provider:        o.Provider,
-		UsersFile:       o.UsersFile,
-		UsersFileFormat: o.UsersFileFormat,
-		UsersFormat:     o.UsersFormat,
-		Authenticator:   o.Authenticator,
-		Users:           maps.Clone(o.Users),
-		ProviderData:    maps.Clone(o.ProviderData),
-		ProxyPreserve:   o.ProxyPreserve,
-	}
+	out := pointers.Clone(o)
+	out.Users = maps.Clone(o.Users)
+	out.ProviderData = maps.Clone(o.ProviderData)
 	return out
 }
 

--- a/pkg/proxy/engines/caching_policy.go
+++ b/pkg/proxy/engines/caching_policy.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/trickstercache/trickster/v2/pkg/cache/status"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
 )
 
 //go:generate go tool msgp
@@ -60,29 +61,7 @@ type CachingPolicy struct {
 
 // Clone returns an exact copy of the Caching Policy
 func (cp *CachingPolicy) Clone() *CachingPolicy {
-	return &CachingPolicy{
-		IsFresh:               cp.IsFresh,
-		NoCache:               cp.NoCache,
-		NoTransform:           cp.NoTransform,
-		FreshnessLifetime:     cp.FreshnessLifetime,
-		CanRevalidate:         cp.CanRevalidate,
-		MustRevalidate:        cp.MustRevalidate,
-		LastModified:          cp.LastModified,
-		Expires:               cp.Expires,
-		Date:                  cp.Date,
-		LocalDate:             cp.LocalDate,
-		ETag:                  cp.ETag,
-		IsNegativeCache:       cp.IsNegativeCache,
-		IfNoneMatchValue:      cp.IfNoneMatchValue,
-		IfModifiedSinceTime:   cp.IfModifiedSinceTime,
-		IfUnmodifiedSinceTime: cp.IfUnmodifiedSinceTime,
-		IsClientConditional:   cp.IsClientConditional,
-		IsClientFresh:         cp.IsClientFresh,
-		HasIfModifiedSince:    cp.HasIfModifiedSince,
-		HasIfUnmodifiedSince:  cp.HasIfUnmodifiedSince,
-		HasIfNoneMatch:        cp.HasIfNoneMatch,
-		IfNoneMatchResult:     cp.IfNoneMatchResult,
-	}
+	return pointers.Clone(cp)
 }
 
 // ResetClientConditionals sets the request-specific conditional values of the subject

--- a/pkg/proxy/tls/options/options.go
+++ b/pkg/proxy/tls/options/options.go
@@ -21,6 +21,7 @@ import (
 	"slices"
 
 	"github.com/trickstercache/trickster/v2/pkg/config/types"
+	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
 )
 
 // Options is a collection of TLS-related client and server configurations
@@ -57,15 +58,9 @@ func New() *Options {
 
 // Clone returns an exact copy of the subject *Options
 func (o *Options) Clone() *Options {
-	return &Options{
-		FullChainCertPath:         o.FullChainCertPath,
-		PrivateKeyPath:            o.PrivateKeyPath,
-		ServeTLS:                  o.ServeTLS,
-		InsecureSkipVerify:        o.InsecureSkipVerify,
-		CertificateAuthorityPaths: slices.Clone(o.CertificateAuthorityPaths),
-		ClientCertPath:            o.ClientCertPath,
-		ClientKeyPath:             o.ClientKeyPath,
-	}
+	out := pointers.Clone(o)
+	out.CertificateAuthorityPaths = slices.Clone(o.CertificateAuthorityPaths)
+	return out
 }
 
 // Equal returns true if all exposed option members are equal

--- a/pkg/util/pointers/pointers_test.go
+++ b/pkg/util/pointers/pointers_test.go
@@ -16,7 +16,11 @@
 
 package pointers
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestNew(t *testing.T) {
 	const port = 8480
@@ -39,4 +43,28 @@ func TestNew(t *testing.T) {
 	if intPtr != nil {
 		t.Fatal("expected nil")
 	}
+}
+
+func TestClone(t *testing.T) {
+	type example struct {
+		Name    string
+		Details map[string]string
+	}
+	e := &example{
+		Name: "test",
+		Details: map[string]string{
+			"key1": "value1",
+			"key2": "value2",
+		},
+	}
+	// clone example
+	e2 := Clone(e)
+	require.NotNil(t, e2)
+	// modify original, verify clone is partially affected
+	e.Name = "modified"
+	e.Details["key1"] = "modifiedValue1"
+
+	require.Equal(t, "test", e2.Name, "expect simple fields to be safe from modification")
+	require.NotEqual(t, "value1", e2.Details["key1"], "expect pointer-based fields to be shallow copied, modification affects clone")
+	require.Equal(t, "modifiedValue1", e2.Details["key1"])
 }


### PR DESCRIPTION
Refactored (many of) the options `Clone` functions to make use of `utils/pointers.Clone`.

Based on the config testdata changes, it seems to have caught a few fields that were missed previously.