### PR TITLE
refactor health check status page

### DIFF
--- a/docs/alb.md
+++ b/docs/alb.md
@@ -449,7 +449,7 @@ $ curl "http://${trickster-fqdn}:8481/trickster/health?json" | jq
 
 {
   "title": "Trickster Backend Health Status",
-  "udpateTime": "2020-01-01 00:00:00 UTC",
+  "updateTime": "2020-01-01 00:00:00 UTC",
   "available": [
     {
       "name": "flux-01",

--- a/docs/health.md
+++ b/docs/health.md
@@ -8,6 +8,12 @@ Trickster provides a `/trickster/ping` endpoint that returns a response of `200 
 
 Trickster offers `health` endpoints for monitoring the health of the Trickster service with respect to its upstream connection to origin servers.
 
+### General Endppoint
+
+The main health check path is `/trickster/health`, which by default will return a `text/plain` summary of the backend health. You can request YAML or JSON format using the appropriate `Accept` header, or by providing a `?json` or `?yaml` query param.
+
+### Backend-Specific Endpoints
+
 Each configured backend's health check path is `/trickster/health/BACKEND_NAME`. For example, if your backend is named `foo`, you can perform a health check of the upstream server at `http://<trickster_address:port>/trickster/health/foo`.
 
 The backend health path prefix `/trickster/health/` is customizable. See the [example.full.yaml](../examples/conf/example.full.yaml) for more info about setting the `health_handler_path` configuration, or refer to this example:

--- a/pkg/daemon/setup/setup.go
+++ b/pkg/daemon/setup/setup.go
@@ -48,10 +48,10 @@ import (
 	pnh "github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/ping"
 	ph "github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/purge"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/reload"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/listener"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
 	"github.com/trickstercache/trickster/v2/pkg/routing"
-	"github.com/trickstercache/trickster/v2/pkg/proxy/listener"
 )
 
 var mtx sync.Mutex
@@ -199,7 +199,7 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 	}
 	alb.StartALBPools(clients, si.HealthChecker.Statuses())
 	routing.RegisterDefaultBackendRoutes(r, newConf, clients, tracers)
-	routing.RegisterHealthHandler(mr, newConf.MgmtConfig.HealthHandlerPath, si.HealthChecker)
+	routing.RegisterHealthHandler(mr, newConf.MgmtConfig.HealthHandlerPath, si.HealthChecker, clients)
 	applyListenerConfigs(newConf, si.Config, r, rh, mr, tracers, clients, errorFunc, lg)
 
 	metrics.LastReloadSuccessfulTimestamp.Set(float64(time.Now().Unix()))

--- a/pkg/proxy/handlers/health/health.go
+++ b/pkg/proxy/handlers/health/health.go
@@ -102,26 +102,24 @@ func (hs *healthStatus) Tabular() string {
 
 	if len(hs.Unavailable) > 0 {
 		for _, k := range hs.Unavailable {
-			detail := formatALBSummary(k)
-			downSince := k.DownSince
-			fmt.Fprintf(tw, "%s\t%s\t%s %s%s\n", k.Name, k.Provider,
-				statusToString(-1, downSince != ""), downSince, detail)
+			fmt.Fprintf(tw, "%s\t%s\t%s %s%s\n", k.Name, formatProvider(k),
+				statusToString(-1, k.DownSince != ""), k.DownSince, formatDetail(k))
 		}
 		tw.Write([]byte("\t\t\t\n"))
 	}
 
 	if len(hs.Available) > 0 {
 		for _, k := range hs.Available {
-			detail := formatALBSummary(k)
-			fmt.Fprintf(tw, "%s\t%s\t%s%s\n", k.Name, k.Provider, statusToString(1, false), detail)
+			fmt.Fprintf(tw, "%s\t%s\t%s%s\n", k.Name, formatProvider(k),
+				statusToString(1, false), formatDetail(k))
 		}
 		tw.Write([]byte("\t\t\t\n"))
 	}
 
 	if len(hs.Unchecked) > 0 {
 		for _, k := range hs.Unchecked {
-			detail := formatALBSummary(k)
-			fmt.Fprintf(tw, "%s\t%s\t%s%s\n", k.Name, k.Provider, statusToString(0, false), detail)
+			fmt.Fprintf(tw, "%s\t%s\t%s%s\n", k.Name, formatProvider(k),
+				statusToString(0, false), formatDetail(k))
 		}
 		tw.Write([]byte("\n"))
 	}
@@ -368,7 +366,14 @@ func statusToString(i int, hasSince bool) string {
 	return "not configured for automated health checks"
 }
 
-func formatALBSummary(bs backendStatus) string {
+func formatProvider(bs backendStatus) string {
+	if bs.Provider == providers.ALB && bs.Mechanism != "" {
+		return fmt.Sprintf("%s (%s)", bs.Provider, bs.Mechanism)
+	}
+	return bs.Provider
+}
+
+func formatDetail(bs backendStatus) string {
 	if bs.Provider != providers.ALB {
 		return ""
 	}

--- a/pkg/proxy/handlers/health/health.go
+++ b/pkg/proxy/handlers/health/health.go
@@ -71,8 +71,28 @@ type healthStatus struct {
 
 var updateLock sync.Mutex
 
-// String renders a text/plain-compatible version of the status page
 func (hs *healthStatus) String() string {
+	return hs.Tabular()
+}
+
+func (hs *healthStatus) JSON() string {
+	b, err := json.Marshal(hs)
+	if err != nil {
+		return "{}"
+	}
+	return string(b)
+}
+
+func (hs *healthStatus) YAML() string {
+	b, err := yaml.Marshal(hs)
+	if err != nil {
+		return "---"
+	}
+	return string(b)
+}
+
+// Tabular renders a text/plain-compatible version of the status page
+func (hs *healthStatus) Tabular() string {
 	txt := &strings.Builder{}
 	fmt.Fprintf(txt, "\n%s            last change: %s\n", hs.Title, hs.UpdateTime)
 	txt.WriteString("-------------------------------------------------------------------------------\n\n")
@@ -329,18 +349,8 @@ func udpateStatusText(hc healthcheck.HealthChecker, hd *healthDetail, backends b
 		}
 	}
 
-	b, err := json.Marshal(status)
-	if err != nil {
-		b = []byte("{}")
-	}
-
-	y, err := yaml.Marshal(status)
-	if err != nil {
-		y = []byte("---")
-	}
-
-	hd.detail.Store(&detail{text: status.String(), json: string(b),
-		yaml: string(y), lastModified: lastModified})
+	hd.detail.Store(&detail{text: status.Tabular(), json: status.JSON(),
+		yaml: status.YAML(), lastModified: lastModified})
 }
 
 func statusToString(i int, hasSince bool) string {

--- a/pkg/proxy/handlers/health/health.go
+++ b/pkg/proxy/handlers/health/health.go
@@ -63,7 +63,7 @@ type backendStatus struct {
 
 type healthStatus struct {
 	Title       string          `json:"title" yaml:"title"`
-	UpdateTime  string          `json:"udpateTime" yaml:"updateTime"`
+	UpdateTime  string          `json:"updateTime" yaml:"updateTime"`
 	Unavailable []backendStatus `json:"unavailable,omitempty" yaml:"unavailable,omitempty"`
 	Available   []backendStatus `json:"available,omitempty" yaml:"available,omitempty"`
 	Unchecked   []backendStatus `json:"unchecked,omitempty" yaml:"unchecked,omitempty"`
@@ -186,7 +186,7 @@ func StatusHandler(hc healthcheck.HealthChecker, backends backends.Backends) htt
 }
 
 func builder(hc healthcheck.HealthChecker, hd *healthDetail, backends backends.Backends) {
-	udpateStatusText(hc, hd, backends) // setup the initial status page text
+	updateStatusText(hc, hd, backends) // setup the initial status page text
 	notifier := make(chan bool, 32)
 	for _, c := range hc.Statuses() {
 		c.RegisterSubscriber(notifier)
@@ -198,14 +198,14 @@ func builder(hc healthcheck.HealthChecker, hd *healthDetail, backends backends.B
 		case <-closer: // a bool comes over closer when the Health Checker is closing down, so the builder should as well
 			return
 		case <-notifier: // a bool comes over notifier when the status text should be rebuilt
-			udpateStatusText(hc, hd, backends)
+			updateStatusText(hc, hd, backends)
 		}
 	}
 }
 
 const title = "Trickster Backend Health Status"
 
-func udpateStatusText(hc healthcheck.HealthChecker, hd *healthDetail, backends backends.Backends) {
+func updateStatusText(hc healthcheck.HealthChecker, hd *healthDetail, backends backends.Backends) {
 	updateLock.Lock()
 	defer updateLock.Unlock()
 

--- a/pkg/proxy/handlers/health/health.go
+++ b/pkg/proxy/handlers/health/health.go
@@ -129,8 +129,10 @@ func (hs *healthStatus) Tabular() string {
 	tw.Flush()
 	txt.Write(b.Bytes())
 	txt.WriteString("-------------------------------------------------------------------------------\n")
-	fmt.Fprintf(txt, "You can also provide a '%s: %s' Header or query param ?json\n",
+	fmt.Fprintf(txt, "For JSON, provide a '%s: %s' Header or query param ?json\n",
 		headers.NameAccept, headers.ValueApplicationJSON)
+	fmt.Fprintf(txt, "For YAML, provide a '%s: %s' Header or query param ?yaml\n",
+		headers.NameAccept, headers.ValueApplicationYAML)
 
 	return txt.String()
 }

--- a/pkg/proxy/headers/detect.go
+++ b/pkg/proxy/headers/detect.go
@@ -45,6 +45,11 @@ func AcceptsJSON(r *http.Request) bool {
 	return AcceptsContentType(r, ValueApplicationJSON)
 }
 
+// AcceptsYAML returns true if r has an Accept: application/yaml header
+func AcceptsYAML(r *http.Request) bool {
+	return AcceptsContentType(r, ValueApplicationYAML)
+}
+
 // AcceptsCSV returns true if r has an Accept: application/csv header
 func AcceptsCSV(r *http.Request) bool {
 	return AcceptsContentType(r, ValueApplicationCSV)

--- a/pkg/proxy/headers/headers.go
+++ b/pkg/proxy/headers/headers.go
@@ -33,6 +33,8 @@ const (
 	ValueApplicationCSV = "application/csv"
 	// ValueApplicationJSON represents the HTTP Header Value of "application/json"
 	ValueApplicationJSON = "application/json"
+	// ValueApplicationYAML represents the HTTP Header Value of "application/yaml"
+	ValueApplicationYAML = "application/yaml"
 	// ValueApplicationFlux represents the HTTP Header Value of "application/vnd.flux"
 	ValueApplicationFlux = "application/vnd.flux"
 	// ValueChunked represents the HTTP Header Value of "chunked"

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -117,8 +117,8 @@ func RegisterProxyRoutes(conf *config.Config, clients backends.Backends,
 
 // RegisterHealthHandler registers the main health handler
 func RegisterHealthHandler(router router.Router, path string,
-	hc healthcheck.HealthChecker) {
-	router.RegisterRoute(path, nil, nil, false, health.StatusHandler(hc))
+	hc healthcheck.HealthChecker, backends backends.Backends) {
+	router.RegisterRoute(path, nil, nil, false, health.StatusHandler(hc, backends))
 }
 
 func registerBackendRoutes(r router.Router, metricsRouter router.Router,

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -61,7 +61,7 @@ func TestRegisterHealthHandler(t *testing.T) {
 	router := lm.NewRouter()
 	path := "/test"
 	hc := healthcheck.New()
-	RegisterHealthHandler(router, path, hc)
+	RegisterHealthHandler(router, path, hc, nil)
 }
 
 func TestRegisterProxyRoutes(t *testing.T) {


### PR DESCRIPTION
this PR overhauls the Health Check Status Page with these improvements:

* Replaces manual JSON body construction w/ a struct->marshal in `JSON()`
* Extracts Text Output builder to a `Tabular()` function. 
* ^^ effectively separates the data structure construction from its Stringers.
* Supports yaml output via `?yaml` url param or `Accept: application/yaml`
* Adds ALB and Pool health status to the outputs
  * an ALB is considered available if at least 1 pool member is available or unchecked.
* Serves a `Last-Modified` header and supports `304` responses to `If-Modified-Since` requests.
* adds `updateLock` mutex to `updateStatusText` to  ensure it runs in singleton
* Reorders the output order to Unavailable, Available, Unchecked, to ensure the most important section is first

Old Output (Plaintext)
```
Trickster Backend Health Status            last change: 2025-12-08 07:08:58 UTC
-------------------------------------------------------------------------------

prom1        prometheus   available

prom2        prometheus   unavailable since 2025-12-08 07:08:58 UTC

prom3        prometheus   not configured for automated health checks

-------------------------------------------------------------------------------
```

New Output (Plaintext)
```
Trickster Backend Health Status            last change: 2025-12-08 07:08:58 UTC
-------------------------------------------------------------------------------

prom2        prometheus   unavailable since 2025-12-08 07:08:58 UTC

prom1        prometheus   available
alb1         alb (tsm)    available u:[prom2] a:[prom1] nc:[prom3]

prom3        prometheus   not configured for automated health checks

-------------------------------------------------------------------------------
```

New Output (JSON)
```json
{
  "title": "Trickster Backend Health Status",
  "updateTime": "2025-12-08 07:08:58 UTC",
  "unavailable": [
    {
      "name": "prom2",
      "provider": "prometheus",
      "downSince": "2025-12-08 07:08:58 UTC",
      "detail": "required status code mismatch, got [500] expected one of [200]"
    }
  ],
  "available": [
    {
      "name": "prom1",
      "provider": "prometheus"
    },
    {
      "name": "alb1",
      "provider": "alb",
      "mechanism": "tsm",
      "unavailablePoolMembers": [ "prom2" ],
      "availablePoolMembers": [ "prom1" ],
      "uncheckedPoolMembers": [ "prom3" ]
    }
  ],
  "unchecked": [
    {
      "name": "prom3",
      "provider": "prometheus"
    }
  ]
}
```

Fixes #876 