### PR TITLE
health status page refinements

### DIFF
--- a/pkg/proxy/handlers/health/health.go
+++ b/pkg/proxy/handlers/health/health.go
@@ -401,13 +401,13 @@ func formatDetail(bs backendStatus) string {
 	}
 	parts := make([]string, 0, 3)
 	if len(bs.UnavailablePoolMembers) > 0 {
-		parts = append(parts, fmt.Sprintf("u:[%s]", strings.Join(bs.UnavailablePoolMembers, ", ")))
+		parts = append(parts, fmt.Sprintf("u:[%s]", strings.Join(bs.UnavailablePoolMembers, ",")))
 	}
 	if len(bs.AvailablePoolMembers) > 0 {
-		parts = append(parts, fmt.Sprintf("a:[%s]", strings.Join(bs.AvailablePoolMembers, ", ")))
+		parts = append(parts, fmt.Sprintf("a:[%s]", strings.Join(bs.AvailablePoolMembers, ",")))
 	}
 	if len(bs.UncheckedPoolMembers) > 0 {
-		parts = append(parts, fmt.Sprintf("nc:[%s]", strings.Join(bs.UncheckedPoolMembers, ", ")))
+		parts = append(parts, fmt.Sprintf("nc:[%s]", strings.Join(bs.UncheckedPoolMembers, ",")))
 	}
 	if len(parts) == 0 {
 		return ""


### PR DESCRIPTION
this PR fixes a defect where User Router-based ALBs always report as unavailable in the health status page, due their use of the `default_backend` and `to_backend` fields for routing, rather than the `pool` slice.  It also de-duplicates backends that are used multiple times in the same ALB pool for weighting, so they only show once per-ALB in the availability status lists.

Old:
```
prom1    prometheus     available
prom2    prometheus     available
clk1     clickhouse     available
clk2     clickhouse     available
alb1     alb (ur)       unavailable
alb2     alb (rr)       available a:[prom1, prom1, prom1, prom2]
```

New:
```
prom1    prometheus     available
prom2    prometheus     available
clk1     clickhouse     available
clk2     clickhouse     available
alb1     alb (ur)       available a:[clk1,clk2]
alb2     alb (rr)       available a:[prom1,prom2]
```
