### PR TITLE
ensure proper routing of pprof

### DIFF
--- a/pkg/daemon/setup/listeners.go
+++ b/pkg/daemon/setup/listeners.go
@@ -181,5 +181,4 @@ func applyListenerConfigs(conf, oldConf *config.Config,
 	} else {
 		lg.UpdateRouter("mgmtListener", mr)
 	}
-
 }

--- a/pkg/daemon/setup/listeners.go
+++ b/pkg/daemon/setup/listeners.go
@@ -143,15 +143,15 @@ func applyListenerConfigs(conf, oldConf *config.Config,
 		false, metrics.Handler())
 	metricsRouter.RegisterRoute(conf.MgmtConfig.ConfigHandlerPath, nil, nil,
 		false, http.HandlerFunc(ch.HandlerFunc(conf)))
+	if conf.MgmtConfig.PprofServer == "both" || conf.MgmtConfig.PprofServer == "mgmt" {
+		pprof.RegisterRoutes("mgmt", metricsRouter)
+	}
 
 	// if the Metrics HTTP port is configured, then set up the http listener instance
 	if conf.Metrics != nil && conf.Metrics.ListenPort > 0 &&
 		(!hasOldMC || (conf.Metrics.ListenAddress != oldConf.Metrics.ListenAddress ||
 			conf.Metrics.ListenPort != oldConf.Metrics.ListenPort)) {
 		lg.DrainAndClose("metricsListener", 0)
-		if conf.MgmtConfig.PprofServer == "both" || conf.MgmtConfig.PprofServer == "metrics" {
-			pprof.RegisterRoutes("metrics", metricsRouter)
-		}
 		go lg.StartListener("metricsListener",
 			conf.Metrics.ListenAddress, conf.Metrics.ListenPort,
 			conf.Frontend.ConnectionsLimit, nil, metricsRouter, nil, errorFunc, 0, conf.Frontend.ReadHeaderTimeout)
@@ -166,19 +166,20 @@ func applyListenerConfigs(conf, oldConf *config.Config,
 		false, reloadHandler)
 	mr.RegisterRoute(conf.MgmtConfig.PurgeByPathHandlerPath, nil, nil,
 		true, http.HandlerFunc(ph.PathHandler(conf.MgmtConfig.PurgeByPathHandlerPath, &o)))
+	if conf.MgmtConfig.PprofServer == "both" || conf.MgmtConfig.PprofServer == "mgmt" {
+		pprof.RegisterRoutes("mgmt", mr)
+	}
 
 	// if the Management HTTP port is configured, then set up the http listener instance
 	if conf.MgmtConfig != nil && conf.MgmtConfig.ListenPort > 0 &&
 		(!hasOldRC || (conf.MgmtConfig.ListenAddress != oldConf.MgmtConfig.ListenAddress ||
 			conf.MgmtConfig.ListenPort != oldConf.MgmtConfig.ListenPort)) {
 		lg.DrainAndClose("mgmtListener", time.Millisecond*500)
-		if conf.MgmtConfig.PprofServer == "both" || conf.MgmtConfig.PprofServer == "mgmt" {
-			pprof.RegisterRoutes("mgmt", mr)
-		}
 		go lg.StartListener("mgmtListener",
 			conf.MgmtConfig.ListenAddress, conf.MgmtConfig.ListenPort,
 			conf.Frontend.ConnectionsLimit, nil, mr, nil, errorFunc, 0, conf.Frontend.ReadHeaderTimeout)
 	} else {
 		lg.UpdateRouter("mgmtListener", mr)
 	}
+
 }

--- a/pkg/observability/pprof/pprof.go
+++ b/pkg/observability/pprof/pprof.go
@@ -29,7 +29,7 @@ import (
 func RegisterRoutes(routerName string, r router.Router) {
 	logger.Info("registering pprof /debug routes", logging.Pairs{"routerName": routerName})
 	r.RegisterRoute("/debug/pprof/", nil, nil,
-		false, http.HandlerFunc(pprof.Index))
+		true, http.HandlerFunc(pprof.Index))
 	r.RegisterRoute("/debug/pprof/cmdline", nil, nil,
 		false, http.HandlerFunc(pprof.Cmdline))
 	r.RegisterRoute("/debug/pprof/profile", nil, nil,


### PR DESCRIPTION
this fixes an issue where some pprof paths handled by pprof.Index were returning 404, and ensures that pprof properly routes after config reloads.