### PR TITLE
update defaults for health check

### DIFF
--- a/pkg/backends/healthcheck/options/defaults.go
+++ b/pkg/backends/healthcheck/options/defaults.go
@@ -17,23 +17,10 @@
 package options
 
 import (
-	"net/http"
 	"time"
 )
 
 const (
-	// DefaultHealthCheckPath is the default value (noop) for Backends' Health Check Path
-	DefaultHealthCheckPath = "/"
-	// DefaultHealthCheckQuery is the default value (noop) for Backends' Health Check Query Parameters
-	DefaultHealthCheckQuery = ""
-	// DefaultHealthCheckVerb is the default value (noop) for Backends' Health Check Verb
-	DefaultHealthCheckVerb = http.MethodGet
 	// DefaultHealthCheckTimeout is the default duration for health check probes to wait before timing out
 	DefaultHealthCheckTimeout = 3 * time.Second
-	// DefaultHealthCheckRecoveryThreshold defines the default number of successful health checks
-	// following failure to indicate true recovery
-	DefaultHealthCheckRecoveryThreshold = 3
-	// DefaultHealthCheckFailureThreshold defines the default number of failed health checks
-	// following recovery or initial healthy to indicate true recovery
-	DefaultHealthCheckFailureThreshold = 3
 )

--- a/pkg/backends/healthcheck/options/options.go
+++ b/pkg/backends/healthcheck/options/options.go
@@ -19,7 +19,6 @@ package options
 import (
 	"errors"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -84,51 +83,12 @@ var _ types.ConfigOptions[Options] = &Options{}
 
 // New returns a new Options reference with default values
 func New() *Options {
-	return &Options{
-		Verb:              DefaultHealthCheckVerb,
-		Scheme:            "http",
-		Headers:           make(map[string]string),
-		Path:              DefaultHealthCheckPath,
-		Query:             DefaultHealthCheckQuery,
-		ExpectedCodes:     []int{http.StatusOK},
-		FailureThreshold:  DefaultHealthCheckFailureThreshold,
-		RecoveryThreshold: DefaultHealthCheckRecoveryThreshold,
-	}
+	return &Options{}
 }
 
-// Initialize sets up the healthcheck Options with default values where needed
+// Initialize currently unused for Health Check Options, since they are backend
+// provider-specific and initialized by backends.StartHealthChecks()
 func (o *Options) Initialize(_ string) error {
-	// Set default values if not already set
-	if o.Verb == "" {
-		o.Verb = DefaultHealthCheckVerb
-	}
-	if o.Scheme == "" {
-		o.Scheme = "http"
-	}
-	if o.Path == "" {
-		o.Path = DefaultHealthCheckPath
-	}
-	if o.Query == "" {
-		o.Query = DefaultHealthCheckQuery
-	}
-	if len(o.ExpectedCodes) == 0 {
-		o.ExpectedCodes = []int{http.StatusOK}
-	}
-	if o.FailureThreshold == 0 {
-		o.FailureThreshold = DefaultHealthCheckFailureThreshold
-	}
-	if o.RecoveryThreshold == 0 {
-		o.RecoveryThreshold = DefaultHealthCheckRecoveryThreshold
-	}
-	if o.Headers == nil {
-		o.Headers = make(map[string]string)
-	}
-
-	// Set hasExpectedBody flag if ExpectedBody is set
-	if o.ExpectedBody != "" {
-		o.hasExpectedBody = true
-	}
-
 	return nil
 }
 
@@ -255,14 +215,4 @@ func CalibrateTimeout(d time.Duration) time.Duration {
 		d = MinProbeWait
 	}
 	return d
-}
-
-func (o *Options) UnmarshalYAML(unmarshal func(any) error) error {
-	type loadOptions Options
-	lo := loadOptions(*(New()))
-	if err := unmarshal(&lo); err != nil {
-		return err
-	}
-	*o = Options(lo)
-	return nil
 }

--- a/pkg/config/testdata/example.alb.yaml
+++ b/pkg/config/testdata/example.alb.yaml
@@ -6,14 +6,7 @@ backends:
     keep_alive_timeout: 5m0s
     max_idle_conns: 20
     cache_name: default
-    healthcheck:
-      failure_threshold: 3
-      recovery_threshold: 3
-      verb: GET
-      scheme: http
-      path: /
-      expected_codes:
-      - 200
+    healthcheck: {}
     timeseries_retention_factor: 1024
     timeseries_eviction_method: oldest
     negative_cache_name: default
@@ -46,13 +39,7 @@ backends:
     cache_name: default
     healthcheck:
       interval: 1s
-      failure_threshold: 3
-      recovery_threshold: 3
-      verb: GET
-      scheme: http
       path: /health
-      expected_codes:
-      - 200
     timeseries_retention_factor: 1024
     timeseries_eviction_method: oldest
     negative_cache_name: default
@@ -85,13 +72,7 @@ backends:
     cache_name: default
     healthcheck:
       interval: 1s
-      failure_threshold: 3
-      recovery_threshold: 3
-      verb: GET
-      scheme: http
       path: /health
-      expected_codes:
-      - 200
     timeseries_retention_factor: 1024
     timeseries_eviction_method: oldest
     negative_cache_name: default
@@ -124,13 +105,6 @@ backends:
     cache_name: default
     healthcheck:
       interval: 1s
-      failure_threshold: 3
-      recovery_threshold: 3
-      verb: GET
-      scheme: http
-      path: /
-      expected_codes:
-      - 200
     timeseries_retention_factor: 1024
     timeseries_eviction_method: oldest
     negative_cache_name: default
@@ -163,13 +137,6 @@ backends:
     cache_name: default
     healthcheck:
       interval: 1s
-      failure_threshold: 3
-      recovery_threshold: 3
-      verb: GET
-      scheme: http
-      path: /
-      expected_codes:
-      - 200
     timeseries_retention_factor: 1024
     timeseries_eviction_method: oldest
     negative_cache_name: default
@@ -199,14 +166,7 @@ backends:
     keep_alive_timeout: 5m0s
     max_idle_conns: 20
     cache_name: default
-    healthcheck:
-      failure_threshold: 3
-      recovery_threshold: 3
-      verb: GET
-      scheme: http
-      path: /
-      expected_codes:
-      - 200
+    healthcheck: {}
     timeseries_retention_factor: 1024
     timeseries_eviction_method: oldest
     negative_cache_name: default
@@ -241,14 +201,7 @@ backends:
     keep_alive_timeout: 5m0s
     max_idle_conns: 20
     cache_name: default
-    healthcheck:
-      failure_threshold: 3
-      recovery_threshold: 3
-      verb: GET
-      scheme: http
-      path: /
-      expected_codes:
-      - 200
+    healthcheck: {}
     timeseries_retention_factor: 1024
     timeseries_eviction_method: oldest
     negative_cache_name: default

--- a/pkg/config/testdata/example.auth.yaml
+++ b/pkg/config/testdata/example.auth.yaml
@@ -8,14 +8,7 @@ backends:
     keep_alive_timeout: 5m0s
     max_idle_conns: 20
     cache_name: default
-    healthcheck:
-      failure_threshold: 3
-      recovery_threshold: 3
-      verb: GET
-      scheme: http
-      path: /
-      expected_codes:
-      - 200
+    healthcheck: {}
     timeseries_retention_factor: 1024
     timeseries_eviction_method: oldest
     negative_cache_name: default
@@ -47,14 +40,7 @@ backends:
     keep_alive_timeout: 5m0s
     max_idle_conns: 20
     cache_name: default
-    healthcheck:
-      failure_threshold: 3
-      recovery_threshold: 3
-      verb: GET
-      scheme: http
-      path: /
-      expected_codes:
-      - 200
+    healthcheck: {}
     timeseries_retention_factor: 1024
     timeseries_eviction_method: oldest
     negative_cache_name: default
@@ -86,14 +72,7 @@ backends:
     keep_alive_timeout: 5m0s
     max_idle_conns: 20
     cache_name: default
-    healthcheck:
-      failure_threshold: 3
-      recovery_threshold: 3
-      verb: GET
-      scheme: http
-      path: /
-      expected_codes:
-      - 200
+    healthcheck: {}
     timeseries_retention_factor: 1024
     timeseries_eviction_method: oldest
     negative_cache_name: default
@@ -123,14 +102,7 @@ backends:
     keep_alive_timeout: 5m0s
     max_idle_conns: 20
     cache_name: default
-    healthcheck:
-      failure_threshold: 3
-      recovery_threshold: 3
-      verb: GET
-      scheme: http
-      path: /
-      expected_codes:
-      - 200
+    healthcheck: {}
     timeseries_retention_factor: 1024
     timeseries_eviction_method: oldest
     negative_cache_name: default

--- a/pkg/config/testdata/example.full.yaml
+++ b/pkg/config/testdata/example.full.yaml
@@ -8,14 +8,7 @@ backends:
     keep_alive_timeout: 5m0s
     max_idle_conns: 20
     cache_name: default
-    healthcheck:
-      failure_threshold: 3
-      recovery_threshold: 3
-      verb: GET
-      scheme: http
-      path: /
-      expected_codes:
-      - 200
+    healthcheck: {}
     timeseries_retention_factor: 1024
     timeseries_eviction_method: oldest
     negative_cache_name: default

--- a/pkg/config/testdata/exmple.sharding.yaml
+++ b/pkg/config/testdata/exmple.sharding.yaml
@@ -8,14 +8,7 @@ backends:
     keep_alive_timeout: 5m0s
     max_idle_conns: 20
     cache_name: default
-    healthcheck:
-      failure_threshold: 3
-      recovery_threshold: 3
-      verb: GET
-      scheme: http
-      path: /
-      expected_codes:
-      - 200
+    healthcheck: {}
     timeseries_retention_factor: 1024
     timeseries_eviction_method: oldest
     negative_cache_name: default

--- a/pkg/config/testdata/simple.prometheus.yaml
+++ b/pkg/config/testdata/simple.prometheus.yaml
@@ -8,14 +8,7 @@ backends:
     keep_alive_timeout: 5m0s
     max_idle_conns: 20
     cache_name: default
-    healthcheck:
-      failure_threshold: 3
-      recovery_threshold: 3
-      verb: GET
-      scheme: http
-      path: /
-      expected_codes:
-      - 200
+    healthcheck: {}
     timeseries_retention_factor: 1024
     timeseries_eviction_method: oldest
     negative_cache_name: default

--- a/pkg/config/testdata/simple.reverseproxycache.yaml
+++ b/pkg/config/testdata/simple.reverseproxycache.yaml
@@ -8,14 +8,7 @@ backends:
     keep_alive_timeout: 5m0s
     max_idle_conns: 20
     cache_name: default
-    healthcheck:
-      failure_threshold: 3
-      recovery_threshold: 3
-      verb: GET
-      scheme: http
-      path: /
-      expected_codes:
-      - 200
+    healthcheck: {}
     timeseries_retention_factor: 1024
     timeseries_eviction_method: oldest
     negative_cache_name: default


### PR DESCRIPTION
This removes the default configs for HealthChecks. Provider-specific defaults are already defined and instantiated by backends.StartHealthChecks(), but those were being overridden by these general default values.