### PR TITLE
perf: optimize startup when there are many health-checked backends

### DIFF
--- a/pkg/backends/healthcheck/healthcheck.go
+++ b/pkg/backends/healthcheck/healthcheck.go
@@ -85,7 +85,7 @@ func (hc *healthChecker) Register(name, description string, o *ho.Options,
 	}
 	hc.targets[t.name] = t
 	if t.interval > 0 {
-		t.Start(context.Background())
+		go t.Start(context.Background())
 	}
 	hc.statuses[t.name] = t.status
 	return t.status, nil
@@ -96,7 +96,7 @@ func (hc *healthChecker) Unregister(name string) {
 		return
 	}
 	if t, ok := hc.targets[name]; ok && t != nil {
-		t.Stop()
+		go t.Stop()
 		delete(hc.targets, t.name)
 		delete(hc.statuses, t.name)
 	}

--- a/pkg/backends/healthcheck/healthcheck.go
+++ b/pkg/backends/healthcheck/healthcheck.go
@@ -96,7 +96,7 @@ func (hc *healthChecker) Unregister(name string) {
 		return
 	}
 	if t, ok := hc.targets[name]; ok && t != nil {
-		go t.Stop()
+		t.Stop()
 		delete(hc.targets, t.name)
 		delete(hc.statuses, t.name)
 	}

--- a/pkg/backends/healthcheck/healthcheck.go
+++ b/pkg/backends/healthcheck/healthcheck.go
@@ -85,7 +85,7 @@ func (hc *healthChecker) Register(name, description string, o *ho.Options,
 	}
 	hc.targets[t.name] = t
 	if t.interval > 0 {
-		go t.Start(context.Background())
+		t.Start(context.Background())
 	}
 	hc.statuses[t.name] = t.status
 	return t.status, nil

--- a/pkg/backends/healthcheck/target.go
+++ b/pkg/backends/healthcheck/target.go
@@ -180,13 +180,13 @@ func (t *target) Stop() {
 }
 
 func (t *target) probeLoop(ctx context.Context) {
-	t.probe(ctx) // perform initial probe
-	ticker := time.NewTicker(t.interval)
 	t.wg.Go(func() {
+		t.probe(ctx) // perform initial probe
+		ticker := time.NewTicker(t.interval)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ctx.Done():
-				ticker.Stop()
 				return // probe complete, stop loop and prevent goroutine leak
 			case <-ticker.C:
 				t.probe(ctx)

--- a/pkg/backends/options/options.go
+++ b/pkg/backends/options/options.go
@@ -130,6 +130,8 @@ type Options struct {
 	// shards are not aligned to the epoch at a specific step. MaxShardSizeMS must be perfectly
 	// divisible by ShardStep when both are > 0, or the configuration is invalid
 	ShardStep time.Duration `yaml:"shard_step,omitempty"`
+	// ProxyOnly, when true, will cause this backend to bypass caching while handling the request
+	ProxyOnly bool `yaml:"proxy_only,omitempty"`
 
 	// ALBOptions holds the options for ALBs
 	ALBOptions *ao.Options `yaml:"alb,omitempty"`

--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -54,7 +54,7 @@ import (
 func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request, modeler *timeseries.Modeler) {
 	rsc := request.GetResources(r)
 	o := rsc.BackendOptions
-	if o != nil && o.ProxyOnly {
+	if o == nil || o.ProxyOnly {
 		DoProxy(w, r, true)
 		return
 	}

--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -53,11 +53,16 @@ import (
 // request while caching the results for subsequent requests of the same data
 func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request, modeler *timeseries.Modeler) {
 	rsc := request.GetResources(r)
+	o := rsc.BackendOptions
+	if o != nil && o.ProxyOnly {
+		DoProxy(w, r, true)
+		return
+	}
+
 	if modeler != nil {
 		rsc.TSMarshaler = modeler.WireMarshalWriter
 		rsc.TSUnmarshaler = modeler.WireUnmarshaler
 	}
-	o := rsc.BackendOptions
 	ctx, span := tspan.NewChildSpan(r.Context(), rsc.Tracer, "DeltaProxyCacheRequest")
 	if span != nil {
 		defer span.End()

--- a/pkg/proxy/engines/objectproxycache.go
+++ b/pkg/proxy/engines/objectproxycache.go
@@ -396,6 +396,10 @@ func cacheResponseHandler(s status.LookupStatus) func(*proxyRequest) error {
 func fetchViaObjectProxyCache(w io.Writer, r *http.Request) (*http.Response, status.LookupStatus) {
 	rsc := request.GetResources(r)
 	o := rsc.BackendOptions
+	if o != nil && o.ProxyOnly {
+		return nil, status.LookupStatusProxyOnly
+	}
+
 	cc := rsc.CacheClient
 
 	pr := newProxyRequest(r, w)

--- a/pkg/proxy/engines/objectproxycache.go
+++ b/pkg/proxy/engines/objectproxycache.go
@@ -396,7 +396,7 @@ func cacheResponseHandler(s status.LookupStatus) func(*proxyRequest) error {
 func fetchViaObjectProxyCache(w io.Writer, r *http.Request) (*http.Response, status.LookupStatus) {
 	rsc := request.GetResources(r)
 	o := rsc.BackendOptions
-	if o != nil && o.ProxyOnly {
+	if o == nil || o.ProxyOnly {
 		return nil, status.LookupStatusProxyOnly
 	}
 


### PR DESCRIPTION
This fixes a startup bottleneck with health check initialization, and separately revives the `ProxyOnly` backend flag from Trickster 1.0.x, removed in 1.1.x.

### ProxyOnly
Back in the day, we had a ProxyOnly setting, but that was replaced eventually by just changing the backend provider type to `reverseproxy`. Now that we have ALB features specific to time series (namely tsm), users may want to utilize features like TSM without necessarily using the caching features. I actually needed that exact setup to help debug this bottleneck, so I added it back in the process. Since it has been useful to me, it may be useful to others, so I kept it in here. The way it works is the DeltaProxyCache and ObjectProxyCache will both check the request's corresponding backend first thing; if it is configured for ProxyOnly, the Cache function will immediately hand the request off to the Proxy handler without doing any caching.

### Health Checks
At startup, the backends.StartHealthChecks routine iterates each health check that has an interval configured, and runs  hc.Start() to bootstrap them. The root cause of the latency is that Start() blocks on the initial target probe response, causing the application startup to be slower and slower based on upon how many health check targets are configured and summation of network + server latency across all applicable health checks. To resolve, the initial probe is moved to inside of the probeLoop goroutine but before the ticker loop.