### PR TITLE
ci: cancel in progress workflows (to same PR/branch)

### DIFF
--- a/.github/workflows/ci-build-tests.yml
+++ b/.github/workflows/ci-build-tests.yml
@@ -16,6 +16,10 @@ on:
 
 name: CI Tests
 
+concurrency:
+  group: ci-build-tests-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Cancel in progress workflows for same reference (e.g. PR, branch). E.g. on new commit to branch, cancel prior workflow run(s).