### PR TITLE
retain pre-existing hc target status on config reload

### DIFF
--- a/pkg/backends/backends_test.go
+++ b/pkg/backends/backends_test.go
@@ -81,34 +81,34 @@ func TestStartHealthChecks(t *testing.T) {
 	c2, _ := New("test2", o2, nil, lm.NewRouter(), nil)
 
 	b := Backends{"test1": c1}
-	_, err := b.StartHealthChecks()
+	_, err := b.StartHealthChecks(nil)
 	if err != nil {
 		t.Error(err)
 	}
 
 	b = Backends{"test1": c1, "test2": c2}
-	_, err = b.StartHealthChecks()
+	_, err = b.StartHealthChecks(nil)
 	if err != nil {
 		t.Error(err)
 	}
 
 	o2.HealthCheck = nil
 	b = Backends{"test1": c1, "test2": c2}
-	_, err = b.StartHealthChecks()
+	_, err = b.StartHealthChecks(nil)
 	if err != nil {
 		t.Error(err)
 	}
 
 	o2.HealthCheck = ho.New()
 	b = Backends{"test1": c1, "test2": c2}
-	_, err = b.StartHealthChecks()
+	_, err = b.StartHealthChecks(nil)
 	if err != nil {
 		t.Error(err)
 	}
 
 	c2a := &testBackend{Backend: c2}
 	b = Backends{"test1": c1, "test2": c2a}
-	_, err = b.StartHealthChecks()
+	_, err = b.StartHealthChecks(nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/daemon/setup/setup.go
+++ b/pkg/daemon/setup/setup.go
@@ -28,6 +28,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/appinfo/usage"
 	"github.com/trickstercache/trickster/v2/pkg/backends"
 	"github.com/trickstercache/trickster/v2/pkg/backends/alb"
+	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
 	"github.com/trickstercache/trickster/v2/pkg/cache"
 	"github.com/trickstercache/trickster/v2/pkg/cache/index"
 	"github.com/trickstercache/trickster/v2/pkg/cache/manager"
@@ -199,7 +200,11 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 	if si.HealthChecker != nil {
 		si.HealthChecker.Shutdown()
 	}
-	si.HealthChecker, err = clients.StartHealthChecks()
+	var oldStatuses healthcheck.StatusLookup
+	if si.HealthChecker != nil {
+		oldStatuses = si.HealthChecker.Statuses()
+	}
+	si.HealthChecker, err = clients.StartHealthChecks(oldStatuses)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
this patches a minor defect where ALBs can return `502 Bad Gateway` for one or two seconds immediately following a config reload, due to the health check target statuses resetting as part of the reload. This patch captures the final health check status of all targets just prior to a reload, and passes those statuses through when initializing the reloaded config to avoid downtime