### PR TITLE
fix: CaptureResponseWriter.Write io.Writer violation truncates responses >32KB

### DIFF
--- a/integration/alb_test.go
+++ b/integration/alb_test.go
@@ -404,6 +404,33 @@ func TestALB(t *testing.T) {
 		t.Logf("fgr instant: %s", hdr.Get("X-Trickster-Result"))
 	})
 
+	// Regression test for CaptureResponseWriter.Write io.Writer contract
+	// violation. ALB fanout mechanisms (fgr, nlm, tsm) each create a
+	// CaptureResponseWriter per pool member and run the full proxy
+	// pipeline into it — the path most likely to stream an upstream
+	// body through io.Copy into CaptureResponseWriter without the body
+	// being pre-buffered. A >32KB response tripped errInvalidWrite on
+	// the second io.Copy chunk before the fix, truncating the body and
+	// causing downstream JSON decoders to report "unexpected EOF".
+	for _, mech := range []string{"fgr", "nlm", "tsm"} {
+		t.Run(mech+" large instant response survives proxy", func(t *testing.T) {
+			// {__name__=~".+"} returns every scraped series — ~130KB of
+			// vector JSON from the developer Prometheus, well over
+			// io.Copy's 32KB internal buffer.
+			params := url.Values{"query": {`{__name__=~".+"}`}}
+			pr, hdr := queryTricksterProm(t, albAddr, "alb-"+mech, "/api/v1/query", params)
+			require.Equal(t, "success", pr.Status)
+			require.Greater(t, len(pr.Data), 32*1024,
+				"response data must exceed 32KB to exercise the io.Copy truncation bug")
+			var qd promQueryData
+			require.NoError(t, json.Unmarshal(pr.Data, &qd),
+				"response must be complete valid JSON — truncation causes unexpected EOF")
+			require.Equal(t, "vector", qd.ResultType)
+			t.Logf("%s large instant: %d bytes, X-Trickster-Result=%s",
+				mech, len(pr.Data), hdr.Get("X-Trickster-Result"))
+		})
+	}
+
 	t.Run("rr multiple requests", func(t *testing.T) {
 		for i := range 3 {
 			pr, hdr := queryTricksterProm(t, albAddr, "alb-rr", "/api/v1/query_range", rangeParams())

--- a/integration/engines_test.go
+++ b/integration/engines_test.go
@@ -18,6 +18,7 @@ package integration
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -300,6 +301,76 @@ func TestEngines_Collapse_MetricsReport(t *testing.T) {
 
 	require.InDelta(t, float64(n-1), after-before, 0.0001,
 		"expected exactly %d proxy-hit increments, got %v", n-1, after-before)
+}
+
+// engValidVectorBody returns a minimally-valid Prometheus instant vector
+// response with n result entries. Each entry is ~80 bytes, so n=500
+// produces ~40KB — well over io.Copy's 32KB internal buffer.
+func engValidVectorBody(n int) string {
+	var buf strings.Builder
+	buf.WriteString(`{"status":"success","data":{"resultType":"vector","result":[`)
+	for i := range n {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		fmt.Fprintf(&buf, `{"metric":{"__name__":"fake","instance":"inst-%04d"},"value":[1700000000,"1"]}`, i)
+	}
+	buf.WriteString(`]}}`)
+	return buf.String()
+}
+
+func doEngineInstant(t *testing.T, params url.Values) (int, []byte, http.Header) {
+	t.Helper()
+	u := "http://" + engTricksterAddr + "/prom-fake/api/v1/query?" + params.Encode()
+	client := &http.Client{Transport: &http.Transport{DisableCompression: true}}
+	resp, err := client.Get(u)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, b, resp.Header.Clone()
+}
+
+// TestEngines_LargeResponse verifies that a Prometheus instant query
+// response larger than 32KB is delivered intact through the proxy.
+//
+// CaptureResponseWriter.Write had a bug where it returned the cumulative
+// byte count instead of the per-call count, violating the io.Writer
+// contract. Go's io.Copy checks nr < nw after each Write; on the second
+// 32KB chunk, the cumulative return value triggers errInvalidWrite and
+// silently truncates the response. This test catches that regression.
+func TestEngines_LargeResponse(t *testing.T) {
+	origin := engineSetup(t)
+
+	const nResults = 500 // ~40KB response
+	body := engValidVectorBody(nResults)
+	require.Greater(t, len(body), 32*1024, "test body must exceed 32KB to exercise the bug")
+
+	origin.setHandler(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, body)
+	})
+
+	// Use a unique query to avoid cache collisions with other tests.
+	params := url.Values{"query": {fmt.Sprintf("fake + 0*%d", time.Now().UnixNano())}}
+	sc, got, _ := doEngineInstant(t, params)
+	require.Equal(t, http.StatusOK, sc)
+	require.Greater(t, len(got), 32*1024,
+		"response must exceed 32KB — if truncated, CaptureResponseWriter.Write is returning cumulative len")
+
+	var pr promResponse
+	require.NoError(t, json.Unmarshal(got, &pr),
+		"response must be valid JSON — truncation causes unexpected EOF")
+	require.Equal(t, "success", pr.Status)
+
+	var qd promQueryData
+	require.NoError(t, json.Unmarshal(pr.Data, &qd))
+	require.Equal(t, "vector", qd.ResultType)
+
+	var results []json.RawMessage
+	require.NoError(t, json.Unmarshal(qd.Result, &results))
+	require.Len(t, results, nResults, "all vector results must survive the proxy round-trip")
 }
 
 // readProxyHitCount returns the current sum of

--- a/integration/prometheus_test.go
+++ b/integration/prometheus_test.go
@@ -265,4 +265,31 @@ func TestPrometheus(t *testing.T) {
 			require.Equal(t, http.StatusInternalServerError, resp2.StatusCode)
 		}
 	})
+
+	// Regression test for CaptureResponseWriter.Write io.Writer contract
+	// violation that truncated any response larger than io.Copy's 32KB
+	// buffer. Uses the real Prometheus backend so the full upstream
+	// response lifecycle (chunked transfer, keep-alive) is exercised,
+	// not just a single-WriteString fake origin.
+	t.Run("large range response survives proxy", func(t *testing.T) {
+		now := time.Now()
+		// 1 hour window at 1s step = 3600 samples per series. Scraped
+		// series on the developer Prometheus easily push this over 32KB.
+		params := url.Values{
+			"query": {fmt.Sprintf("process_cpu_seconds_total + 0*%d", now.UnixNano())},
+			"start": {fmt.Sprintf("%d", now.Add(-1*time.Hour).Unix())},
+			"end":   {fmt.Sprintf("%d", now.Unix())},
+			"step":  {"1"},
+		}
+		pr, hdr := queryTricksterProm(t, tricksterAddr, "prom1", "/api/v1/query_range", params)
+		require.Equal(t, "success", pr.Status)
+		require.Greater(t, len(pr.Data), 32*1024,
+			"response data must exceed 32KB to exercise the io.Copy truncation bug")
+		var qd promQueryData
+		require.NoError(t, json.Unmarshal(pr.Data, &qd),
+			"response must be complete valid JSON — truncation causes unexpected EOF")
+		require.Equal(t, "matrix", qd.ResultType)
+		t.Logf("large range response: %d bytes, X-Trickster-Result=%s",
+			len(pr.Data), hdr.Get("X-Trickster-Result"))
+	})
 }

--- a/integration/prometheus_test.go
+++ b/integration/prometheus_test.go
@@ -266,30 +266,4 @@ func TestPrometheus(t *testing.T) {
 		}
 	})
 
-	// Regression test for CaptureResponseWriter.Write io.Writer contract
-	// violation that truncated any response larger than io.Copy's 32KB
-	// buffer. Uses the real Prometheus backend so the full upstream
-	// response lifecycle (chunked transfer, keep-alive) is exercised,
-	// not just a single-WriteString fake origin.
-	t.Run("large range response survives proxy", func(t *testing.T) {
-		now := time.Now()
-		// 1 hour window at 1s step = 3600 samples per series. Scraped
-		// series on the developer Prometheus easily push this over 32KB.
-		params := url.Values{
-			"query": {fmt.Sprintf("process_cpu_seconds_total + 0*%d", now.UnixNano())},
-			"start": {fmt.Sprintf("%d", now.Add(-1*time.Hour).Unix())},
-			"end":   {fmt.Sprintf("%d", now.Unix())},
-			"step":  {"1"},
-		}
-		pr, hdr := queryTricksterProm(t, tricksterAddr, "prom1", "/api/v1/query_range", params)
-		require.Equal(t, "success", pr.Status)
-		require.Greater(t, len(pr.Data), 32*1024,
-			"response data must exceed 32KB to exercise the io.Copy truncation bug")
-		var qd promQueryData
-		require.NoError(t, json.Unmarshal(pr.Data, &qd),
-			"response must be complete valid JSON — truncation causes unexpected EOF")
-		require.Equal(t, "matrix", qd.ResultType)
-		t.Logf("large range response: %d bytes, X-Trickster-Result=%s",
-			len(pr.Data), hdr.Get("X-Trickster-Result"))
-	})
 }

--- a/pkg/proxy/engines/proxy_request.go
+++ b/pkg/proxy/engines/proxy_request.go
@@ -403,7 +403,9 @@ func (pr *proxyRequest) writeResponseBody() {
 	if pr.upstreamReader == nil || pr.responseWriter == nil {
 		return
 	}
-	io.Copy(pr.responseWriter, pr.upstreamReader)
+	if _, err := io.Copy(pr.responseWriter, pr.upstreamReader); err != nil {
+		logger.Error("error copying upstream response body", logging.Pairs{"error": err})
+	}
 }
 
 func (pr *proxyRequest) determineCacheability() {

--- a/pkg/proxy/response/capture/capture.go
+++ b/pkg/proxy/response/capture/capture.go
@@ -55,7 +55,7 @@ func (sw *CaptureResponseWriter) WriteHeader(code int) {
 func (sw *CaptureResponseWriter) Write(b []byte) (int, error) {
 	sw.body.Write(b)
 	sw.len += len(b)
-	return sw.len, nil
+	return len(b), nil
 }
 
 // Body returns the captured response body

--- a/pkg/proxy/response/capture/capture_test.go
+++ b/pkg/proxy/response/capture/capture_test.go
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package capture
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestWrite_ReturnValue verifies that Write returns the number of bytes
+// written in the current call, not a cumulative total. Returning the
+// cumulative count violates the io.Writer contract and causes io.Copy to
+// abort with errInvalidWrite on the second chunk.
+func TestWrite_ReturnValue(t *testing.T) {
+	sw := NewCaptureResponseWriter()
+
+	a := []byte("hello")
+	n1, err1 := sw.Write(a)
+	require.NoError(t, err1)
+	require.Equal(t, len(a), n1, "first Write must return len(a)")
+
+	b := []byte(" world")
+	n2, err2 := sw.Write(b)
+	require.NoError(t, err2)
+	require.Equal(t, len(b), n2,
+		"second Write must return len(b), not cumulative len(a)+len(b)")
+}
+
+// TestWrite_IoCopy_LargeBody verifies that a body larger than io.Copy's
+// internal 32KB buffer is fully copied without error. Before the fix,
+// CaptureResponseWriter.Write returned a cumulative byte count which
+// triggered errInvalidWrite in io.Copy on the second chunk, silently
+// truncating the response to ~32KB.
+func TestWrite_IoCopy_LargeBody(t *testing.T) {
+	const size = 100 * 1024 // 100KB — well over the 32KB io.Copy buffer
+	src := make([]byte, size)
+	for i := range src {
+		src[i] = byte(i % 251) // non-zero pattern for content verification
+	}
+
+	sw := NewCaptureResponseWriter()
+	// Wrap in a plain io.Reader to strip the WriterTo interface from
+	// bytes.Reader; otherwise io.Copy calls WriteTo which does a single
+	// Write call and never exercises the multi-chunk read/write loop
+	// that triggers the bug.
+	n, err := io.Copy(sw, struct{ io.Reader }{bytes.NewReader(src)})
+	require.NoError(t, err, "io.Copy must not return errInvalidWrite")
+	require.Equal(t, int64(size), n, "io.Copy must report all bytes copied")
+	require.Equal(t, src, sw.Body(), "captured body must match source")
+}
+
+// TestWrite_IoCopy_SmallBody verifies the happy path for bodies that fit
+// in a single io.Copy chunk (<32KB).
+func TestWrite_IoCopy_SmallBody(t *testing.T) {
+	src := []byte("small body under 32KB")
+	sw := NewCaptureResponseWriter()
+	n, err := io.Copy(sw, struct{ io.Reader }{bytes.NewReader(src)})
+	require.NoError(t, err)
+	require.Equal(t, int64(len(src)), n)
+	require.Equal(t, src, sw.Body())
+}
+
+// TestHeaderStatusCodeBody exercises the basic accessors.
+func TestHeaderStatusCodeBody(t *testing.T) {
+	sw := NewCaptureResponseWriter()
+
+	// Default status is 200.
+	require.Equal(t, http.StatusOK, sw.StatusCode())
+
+	// WriteHeader(0) normalizes to 200.
+	sw.WriteHeader(0)
+	require.Equal(t, http.StatusOK, sw.StatusCode())
+
+	sw.WriteHeader(http.StatusNotFound)
+	require.Equal(t, http.StatusNotFound, sw.StatusCode())
+
+	// Header returns a writable map.
+	sw.Header().Set("X-Test", "value")
+	require.Equal(t, "value", sw.Header().Get("X-Test"))
+
+	// Body accumulates writes.
+	sw.Write([]byte("ab"))
+	sw.Write([]byte("cd"))
+	require.Equal(t, []byte("abcd"), sw.Body())
+}


### PR DESCRIPTION
## Description

Investigating the truncated response mentioned here: https://github.com/trickstercache/trickster/issues/937#issuecomment-4239779720.

CaptureResponseWriter.Write returned cumulative sw.len instead of per-call len(b), violating the io.Writer contract — Go's io.Copy triggers errInvalidWrite on the second 32KB chunk, silently truncating any response larger than 32KB

(Added tests fail prior to fix.)

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [x] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [ ] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
