### PR TITLE
fix: [proxy/engines] skip caching truncated body on upstream range read error

### DIFF
--- a/pkg/proxy/engines/proxy_request.go
+++ b/pkg/proxy/engines/proxy_request.go
@@ -528,7 +528,18 @@ func (pr *proxyRequest) prepareResponse() {
 				pr.cacheStatus == status.LookupStatusRangeMiss) {
 			var b []byte
 			if pr.upstreamReader != nil {
-				b, _ = io.ReadAll(pr.upstreamReader)
+				var err error
+				b, err = io.ReadAll(pr.upstreamReader)
+				if err != nil {
+					// Upstream cut off mid-stream — b holds only a truncated
+					// prefix. Never cache a truncated body as if it were
+					// complete; a later request would see it as a valid hit.
+					// The current client still gets what we received, but
+					// writeToCache is cleared so pr.store() is skipped.
+					logger.Error("upstream read error during range extraction; skipping cache write",
+						logging.Pairs{"error": err})
+					pr.writeToCache = false
+				}
 			}
 			d = DocumentFromHTTPResponse(pr.upstreamResponse, b, pr.cachingPolicy)
 			pr.cacheBuffer = bytes.NewBuffer(b)

--- a/pkg/proxy/engines/proxy_request_test.go
+++ b/pkg/proxy/engines/proxy_request_test.go
@@ -269,6 +269,76 @@ func TestPrepareResponse(t *testing.T) {
 	pr.prepareResponse()
 }
 
+// truncatingReader returns some bytes from partial on the first Read, then
+// returns an error on the next call. It simulates an upstream HTTP body
+// that is cut off mid-stream (e.g. connection drop, idle timeout).
+type truncatingReader struct {
+	partial []byte
+	err     error
+	done    bool
+}
+
+func (r *truncatingReader) Read(p []byte) (int, error) {
+	if r.done {
+		return 0, r.err
+	}
+	n := copy(p, r.partial)
+	r.done = true
+	return n, nil // next Read returns the error
+}
+
+// TestPrepareResponse_UpstreamReadErrorSkipsCache is a regression test for
+// a silent-truncation cache-poisoning bug. When the range extraction path
+// reads the upstream body with io.ReadAll and the upstream errors mid-
+// stream, the partial bytes must not be cached as a complete document —
+// a subsequent request would see the truncated body as a valid cache hit.
+// The fix clears writeToCache on read error so the truncated body never
+// reaches pr.store().
+func TestPrepareResponse_UpstreamReadErrorSkipsCache(t *testing.T) {
+	logger.SetLogger(logging.ConsoleLogger(level.Error))
+	r, _ := http.NewRequest(http.MethodGet, "http://127.0.0.1/", nil)
+	r.Header.Set(headers.NameRange, "bytes=0-10")
+
+	o := &bo.Options{}
+	r = request.SetResources(r, request.NewResources(o, nil, nil, nil, nil, nil))
+
+	pr := proxyRequest{
+		Request:          r,
+		rsc:              request.GetResources(r),
+		cachingPolicy:    &CachingPolicy{},
+		upstreamResponse: &http.Response{StatusCode: http.StatusOK},
+		cacheDocument:    &HTTPDocument{},
+	}
+	pr.parseRequestRanges()
+	pr.cacheDocument.Ranges = pr.wantedRanges
+
+	// Simulate a truncated upstream: a few bytes arrive, then the
+	// connection drops with an unexpected EOF — the exact shape of
+	// the bug this test defends against.
+	pr.cacheStatus = status.LookupStatusKeyMiss
+	pr.writeToCache = true
+	pr.upstreamReader = &truncatingReader{
+		partial: []byte("trunc"),
+		err:     io.ErrUnexpectedEOF,
+	}
+	headers.Merge(pr.upstreamResponse.Header, http.Header{
+		headers.NameContentRange: {"bytes 0-99"}, // claims 100 bytes, we only got 5
+	})
+
+	pr.prepareResponse()
+
+	// The truncated body must not be promoted to a complete cache doc.
+	// pr.store() only persists when writeToCache is true, so the fix
+	// clears it on read error.
+	if pr.writeToCache {
+		t.Error("writeToCache must be cleared after upstream read error — " +
+			"a truncated body would otherwise be cached as complete")
+	}
+	if pr.cacheDocument != nil && pr.cacheDocument.isLoaded {
+		t.Error("cacheDocument.isLoaded must not be true when upstream read errored")
+	}
+}
+
 func TestPrepareResponsePreconditionFailed(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodGet, "http://127.0.0.1/", nil)
 	pr := proxyRequest{


### PR DESCRIPTION
## Description
<!-- Describe changes and the problem solved -->

Silent cache-poisoning bug in the range-request path. When `prepareResponse` extracts the upstream body for a range miss, it used `io.ReadAll` but discarded the error. If the upstream connection was cut off mid-stream, the truncated bytes were marked `isLoaded = true` and written to cache as a complete document — every subsequent range request would then hit that poisoned entry and serve the truncated body as a valid cache hit, indefinitely.

- Capture the `io.ReadAll` error at `pkg/proxy/engines/proxy_request.go:533`, log it, and clear `writeToCache` so `pr.store()` is skipped on the poisoned document
- Current client still gets whatever bytes we received (truncation is unavoidable post-hoc); the cache is no longer poisoned
- Test-first: `TestPrepareResponse_UpstreamReadErrorSkipsCache` uses a `truncatingReader` that returns partial bytes then `io.ErrUnexpectedEOF`; fails on main, passes with the fix

Found while auditing silent-error patterns after #976.

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [x] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.