### PR TITLE
fix: fortify health check status emits and reduce chatty logging

### DIFF
--- a/pkg/backends/alb/pool/health.go
+++ b/pkg/backends/alb/pool/health.go
@@ -20,6 +20,21 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 )
 
+// listenStatusUpdates bridges target health-status notifications into refresh
+// scheduling. It marks the pool list dirty for every received update and
+// coalesces worker wakeups via scheduleRefresh so bursty changes cannot strand
+// a stale healthy-target list.
+func (p *pool) listenStatusUpdates() {
+	for {
+		select {
+		case <-p.done:
+			return
+		case <-p.statusCh:
+			p.scheduleRefresh()
+		}
+	}
+}
+
 func (p *pool) checkHealth() {
 	for {
 		select {
@@ -27,7 +42,10 @@ func (p *pool) checkHealth() {
 			logger.Debug("stopping ALB pool", nil)
 			return
 		case <-p.ch: // msg arrives whenever the healthy list must be rebuilt
-			p.RefreshHealthy()
+			// this coalesces bursts of updates into a single refresh
+			for p.refreshPending.Swap(false) {
+				p.RefreshHealthy()
+			}
 		}
 	}
 }

--- a/pkg/backends/alb/pool/health_test.go
+++ b/pkg/backends/alb/pool/health_test.go
@@ -30,12 +30,12 @@ func TestCheckHealth(t *testing.T) {
 
 	tgt.hcStatus.Set(healthcheck.StatusPassing)
 
-	p := &pool{ch: make(chan bool), done: make(chan struct{}), targets: []*Target{tgt}, healthyFloor: -1}
+	p := &pool{ch: make(chan bool, 1), done: make(chan struct{}), targets: []*Target{tgt}, healthyFloor: -1}
 	go func() {
 		p.checkHealth()
 	}()
 	time.Sleep(150 * time.Millisecond)
-	p.ch <- true
+	p.scheduleRefresh()
 	time.Sleep(150 * time.Millisecond)
 	p.Stop()
 	time.Sleep(10 * time.Millisecond)

--- a/pkg/backends/alb/pool/health_test.go
+++ b/pkg/backends/alb/pool/health_test.go
@@ -17,6 +17,7 @@
 package pool
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -49,4 +50,45 @@ func TestCheckHealth(t *testing.T) {
 	if l != 1 {
 		t.Errorf("expected %d got %d", 1, l)
 	}
+}
+
+func TestBurstUpdatesEvictFailingTarget(t *testing.T) {
+	st1 := &healthcheck.Status{}
+	st2 := &healthcheck.Status{}
+	t1 := NewTarget(http.NotFoundHandler(), st1, nil)
+	t2 := NewTarget(http.NotFoundHandler(), st2, nil)
+	p := New(Targets{t1, t2}, 1)
+	defer p.Stop()
+
+	st1.Set(healthcheck.StatusPassing)
+	st2.Set(healthcheck.StatusPassing)
+
+	waitForHealthyTargetsLen(t, p, 2, 2*time.Second)
+
+	// Emit a burst of updates that may overrun subscriber channel buffers and
+	// drop intermediate notifications. Final state is failing.
+	for i := 0; i < 256; i++ {
+		st1.Set(healthcheck.StatusPassing)
+		st1.Set(healthcheck.StatusFailing)
+	}
+	st1.Set(healthcheck.StatusFailing)
+
+	waitForHealthyTargetsLen(t, p, 1, 2*time.Second)
+
+	got := p.HealthyTargets()
+	if len(got) != 1 || got[0] != t2 {
+		t.Fatalf("expected only target 2 to remain healthy, got: %#v", got)
+	}
+}
+
+func waitForHealthyTargetsLen(t *testing.T, p Pool, expected int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if len(p.HealthyTargets()) == expected {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d healthy targets; got %d", expected, len(p.HealthyTargets()))
 }

--- a/pkg/backends/alb/pool/pool.go
+++ b/pkg/backends/alb/pool/pool.go
@@ -42,10 +42,23 @@ type pool struct {
 	targets         Targets
 	healthyTargets  atomic.Pointer[Targets]
 	healthyHandlers atomic.Pointer[[]http.Handler]
+	refreshPending  atomic.Bool // sticky dirty flag indicating HealthyTargets must be rebuilt
 	healthyFloor    int
 	done            chan struct{}
+	statusCh        chan bool // receives raw health status change notifications from targets
 	ch              chan bool
 	mtx             sync.Mutex
+}
+
+// scheduleRefresh marks the healthy list as dirty and coalesces wakeups for
+// the refresh worker. The pending flag preserves refresh intent even when
+// bursty status changes saturate the channel.
+func (p *pool) scheduleRefresh() {
+	p.refreshPending.Store(true)
+	select {
+	case p.ch <- true:
+	default:
+	}
 }
 
 func (p *pool) RefreshHealthy() {

--- a/pkg/backends/alb/pool/target.go
+++ b/pkg/backends/alb/pool/target.go
@@ -37,14 +37,16 @@ func New(targets Targets, healthyFloor int) Pool {
 	p := &pool{
 		targets:      targets,
 		done:         make(chan struct{}),
-		ch:           make(chan bool, 16),
+		statusCh:     make(chan bool, 1),
+		ch:           make(chan bool, 1),
 		healthyFloor: healthyFloor,
 	}
-	p.ch <- true
+	p.scheduleRefresh()
 
 	for _, t := range targets {
-		t.hcStatus.RegisterSubscriber(p.ch)
+		t.hcStatus.RegisterSubscriber(p.statusCh)
 	}
+	go p.listenStatusUpdates()
 	go p.checkHealth()
 	return p
 }

--- a/pkg/backends/healthcheck/target.go
+++ b/pkg/backends/healthcheck/target.go
@@ -208,6 +208,7 @@ func (t *target) probeLoop(ctx context.Context) {
 func (t *target) probe(ctx context.Context) {
 	r := t.baseRequest.Clone(ctx)
 	resp, err := t.httpClient.Do(r)
+	st := t.status.Get()
 	var errCnt, successCnt int
 	var passed bool
 	var detail string
@@ -218,21 +219,24 @@ func (t *target) probe(ctx context.Context) {
 		errCnt = int(t.failConsecutiveCnt.Add(1))
 		t.successConsecutiveCnt.Store(0)
 
-		LogHealthCheckError(t.Name(), err, 0)
+		if st != StatusFailing {
+			LogHealthCheckError(t.Name(), err, 0)
+		}
 
 	case !t.isGoodCode(resp.StatusCode) || !t.isGoodHeader(resp.Header) || !t.isGoodBody(resp.Body):
 		errCnt = int(t.failConsecutiveCnt.Add(1))
 		t.successConsecutiveCnt.Store(0)
 		resp.Body.Close()
 
-		LogHealthCheckError(t.Name(), nil, resp.StatusCode)
+		if st != StatusFailing {
+			LogHealthCheckError(t.Name(), nil, resp.StatusCode)
+		}
 	default:
 		resp.Body.Close()
 		successCnt = int(t.successConsecutiveCnt.Add(1))
 		t.failConsecutiveCnt.Store(0)
 		passed = true
 	}
-	st := t.status.Get()
 	nst := StatusFailing
 	if (passed && successCnt >= t.recoveryThreshold) ||
 		(st == StatusPassing && errCnt < t.failureThreshold) {


### PR DESCRIPTION
## Description
This change makes several enhancements to health checks:
* Adds protection to prevent HC status changes from being dropped when the notification channel is saturated
* Adds burst test to validate fix for lossy status changes
* Reduces `error` log chattiness by suppressing health check errors for targets that are already marked as down/failing

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [x] Bug fix
- - [ ] New feature
- - [x] Optimization
- - [x] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
