### PR TITLE
chore: [docker] bump prometheus to 3.11.3

### DIFF
--- a/docs/developer/environment/docker-compose-data/prometheus-config/prometheus.yml
+++ b/docs/developer/environment/docker-compose-data/prometheus-config/prometheus.yml
@@ -3,6 +3,7 @@ global:
   scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
   evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
   # scrape_timeout is set to the global default (10s).
+  scrape_native_histograms: true
   scrape_protocols:
     - PrometheusProto
     - OpenMetricsText1.0.0

--- a/docs/developer/environment/docker-compose.yml
+++ b/docs/developer/environment/docker-compose.yml
@@ -39,7 +39,7 @@ services:
   # TSDBs
 
   prometheus:
-    image: prom/prometheus:v3.2.1
+    image: prom/prometheus:v3.11.3
     user: nobody
     volumes:
       - ./docker-compose-data/prometheus-config:/etc/prometheus
@@ -49,7 +49,6 @@ services:
       - '--storage.tsdb.path=/prometheus'
       - '--web.console.libraries=/usr/share/prometheus/console_libraries'
       - '--web.console.templates=/usr/share/prometheus/consoles'
-      - '--enable-feature=native-histograms'
     build:
       context: .
       network: host

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -5,7 +5,7 @@ networks:
 services:
 
   prometheus:
-    image: prom/prometheus:v3.2.1
+    image: prom/prometheus:v3.11.3
     volumes:
       - ./docker-compose-data/prometheus-config:/etc/prometheus
     command:


### PR DESCRIPTION
## Description

- Bump `prom/prometheus` from v3.2.1 → v3.11.3
- Drop `--enable-feature=native-histograms` / Set `scrape_native_histograms: true`

## Type of Change

- - [x] Infrastructure

## AI Disclosure

- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.