### PR TITLE
fix: [alb/tsm] prom avg outer aggregation with POST

### DIFF
--- a/pkg/backends/prometheus/tsm_provider.go
+++ b/pkg/backends/prometheus/tsm_provider.go
@@ -17,10 +17,14 @@
 package prometheus
 
 import (
+	"maps"
 	"net/http"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends/prometheus/promql"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/params"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
 )
 
@@ -65,19 +69,32 @@ func (c *Client) ClassifyMerge(query string) (strategy int, needsDualQuery bool,
 // replaced by "sum" and one by "count" — with the rewritten expression injected
 // into the Prometheus "query" parameter. Both GET (query string) and POST
 // (request body) encodings are handled transparently by params.SetRequestValues.
-func (c *Client) RewriteForWeightedAvg(r *http.Request, query string) (sumReq, countReq *http.Request) {
+func (c *Client) RewriteForWeightedAvg(r *http.Request, query string) (*http.Request, *http.Request) {
+
+	// Read the original params from r
+	qp, _, _ := params.GetRequestValues(r)
+
+	// construct the sumReq
 	sumQuery := promql.ReplaceOuterAggregator(query, "avg", "sum")
+	sumReq, err := request.Clone(r)
+	if err != nil {
+		logger.Error("failed to clone avg aggregator sumReq",
+			logging.Pairs{"error": err})
+	}
+	sumQP := maps.Clone(qp)
+	sumQP.Set(promQueryParam, sumQuery)
+	params.SetRequestValues(sumReq, sumQP)
+
+	// construct the countReq
 	countQuery := promql.ReplaceOuterAggregator(query, "avg", "count")
-
-	sumReq = r.Clone(r.Context())
-	qp, _, _ := params.GetRequestValues(sumReq)
-	qp.Set(promQueryParam, sumQuery)
-	params.SetRequestValues(sumReq, qp)
-
-	countReq = r.Clone(r.Context())
-	qp, _, _ = params.GetRequestValues(countReq)
-	qp.Set(promQueryParam, countQuery)
-	params.SetRequestValues(countReq, qp)
+	countReq, err := request.Clone(r)
+	if err != nil {
+		logger.Error("failed to clone avg aggregator countReq",
+			logging.Pairs{"error": err})
+	}
+	countQP := maps.Clone(qp)
+	countQP.Set(promQueryParam, countQuery)
+	params.SetRequestValues(countReq, countQP)
 
 	return sumReq, countReq
 }

--- a/pkg/backends/prometheus/tsm_provider_test.go
+++ b/pkg/backends/prometheus/tsm_provider_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/params"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
 )
@@ -152,6 +153,13 @@ func TestRewriteForWeightedAvgPOST(t *testing.T) {
 			}
 			if s := gotCache.Get("start"); s != "1000" {
 				t.Errorf("rsc.RequestBody start param: got %q, want %q", s, "1000")
+			}
+
+			// Verify subsequent provider parsing sees the rewritten body, not a
+			// stale PostForm cache populated when the original avg body was read.
+			gotParsed, _, _ := params.GetRequestValues(tc.req)
+			if q := gotParsed.Get("query"); q != tc.wantQ {
+				t.Errorf("reparsed query param: got %q, want %q", q, tc.wantQ)
 			}
 		})
 	}

--- a/pkg/backends/prometheus/tsm_provider_test.go
+++ b/pkg/backends/prometheus/tsm_provider_test.go
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
+)
+
+func TestClassifyMerge(t *testing.T) {
+	tests := []struct {
+		query          string
+		wantStrategy   int
+		wantDualQuery  bool
+		wantWarnSubstr string // non-empty means a warning containing this substring is expected
+	}{
+		// no outer aggregator → dedup
+		{"up", int(dataset.MergeStrategyDedup), false, ""},
+		{"rate(http_requests_total[5m])", int(dataset.MergeStrategyDedup), false, ""},
+		// sum family → sum, no dual query
+		{"sum(up)", int(dataset.MergeStrategySum), false, ""},
+		{"sum by (job) (up)", int(dataset.MergeStrategySum), false, ""},
+		{"count(up)", int(dataset.MergeStrategySum), false, ""},
+		{"count_values(\"code\", http_requests_total)", int(dataset.MergeStrategySum), false, ""},
+		// avg → sum strategy + dual query
+		{"avg(up)", int(dataset.MergeStrategySum), true, ""},
+		{"avg by (region) (up)", int(dataset.MergeStrategySum), true, ""},
+		// min / max
+		{"min(up)", int(dataset.MergeStrategyMin), false, ""},
+		{"max(up)", int(dataset.MergeStrategyMax), false, ""},
+		// unsupported aggregators → dedup + warning containing the operator name
+		{"stddev(up)", int(dataset.MergeStrategyDedup), false, "stddev"},
+		{"stdvar(up)", int(dataset.MergeStrategyDedup), false, "stdvar"},
+		{"quantile(0.9, up)", int(dataset.MergeStrategyDedup), false, "quantile"},
+		{"topk(5, up)", int(dataset.MergeStrategyDedup), false, "topk"},
+		{"bottomk(5, up)", int(dataset.MergeStrategyDedup), false, "bottomk"},
+		{"limitk(5, up)", int(dataset.MergeStrategyDedup), false, "limitk"},
+		{"limit_ratio(0.5, up)", int(dataset.MergeStrategyDedup), false, "limit_ratio"},
+		// group → default → dedup, no warning
+		{"group(up)", int(dataset.MergeStrategyDedup), false, ""},
+	}
+
+	c := &Client{}
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			strategy, dualQuery, warning := c.ClassifyMerge(tt.query)
+			if strategy != tt.wantStrategy {
+				t.Errorf("strategy: got %d, want %d", strategy, tt.wantStrategy)
+			}
+			if dualQuery != tt.wantDualQuery {
+				t.Errorf("needsDualQuery: got %v, want %v", dualQuery, tt.wantDualQuery)
+			}
+			if tt.wantWarnSubstr != "" {
+				if !strings.Contains(warning, tt.wantWarnSubstr) {
+					t.Errorf("warning %q does not contain %q", warning, tt.wantWarnSubstr)
+				}
+			} else if warning != "" {
+				t.Errorf("expected no warning, got %q", warning)
+			}
+		})
+	}
+}
+
+// TestRewriteForWeightedAvgPOST verifies that the sum and count requests
+// produced for a POST query carry the rewritten query in both the body and
+// rsc.RequestBody — not the stale original avg body.
+func TestRewriteForWeightedAvgPOST(t *testing.T) {
+	const origBody = "query=avg%28up%29&start=1000&end=2000&step=15"
+	r, _ := http.NewRequest(http.MethodPost,
+		"http://example.com/api/v1/query_range",
+		io.NopCloser(bytes.NewBufferString(origBody)))
+	r.Header.Set(headers.NameContentType, headers.ValueXFormURLEncoded)
+
+	// Attach resources with body pre-cached, as ServeHTTP would have done.
+	rsc := &request.Resources{RequestBody: []byte(origBody)}
+	r = request.SetResources(r, rsc)
+
+	c := &Client{}
+	sumReq, countReq := c.RewriteForWeightedAvg(r, "avg(up)")
+
+	for _, tc := range []struct {
+		name  string
+		req   *http.Request
+		wantQ string
+	}{
+		{"sum", sumReq, "sum(up)"},
+		{"count", countReq, "count(up)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Verify the URL query string.
+			gotURL, err := url.ParseQuery(tc.req.URL.RawQuery)
+			if err != nil {
+				t.Fatalf("parse URL RawQuery: %v", err)
+			}
+			if q := gotURL.Get("query"); q != tc.wantQ {
+				t.Errorf("URL query param: got %q, want %q", q, tc.wantQ)
+			}
+			if s := gotURL.Get("start"); s != "1000" {
+				t.Errorf("URL start param: got %q, want %q", s, "1000")
+			}
+
+			// Verify the request body.
+			bodyBytes, err := io.ReadAll(tc.req.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			gotBody, err := url.ParseQuery(string(bodyBytes))
+			if err != nil {
+				t.Fatalf("parse body: %v", err)
+			}
+			if q := gotBody.Get("query"); q != tc.wantQ {
+				t.Errorf("body query param: got %q, want %q", q, tc.wantQ)
+			}
+			if s := gotBody.Get("start"); s != "1000" {
+				t.Errorf("body start param: got %q, want %q", s, "1000")
+			}
+
+			// Verify rsc.RequestBody is also in sync (critical for
+			// CloneWithoutResources in scatter goroutines).
+			gotRsc := request.GetResources(tc.req)
+			if gotRsc == nil {
+				t.Fatal("expected non-nil resources")
+			}
+			gotCache, err := url.ParseQuery(string(gotRsc.RequestBody))
+			if err != nil {
+				t.Fatalf("parse rsc.RequestBody: %v", err)
+			}
+			if q := gotCache.Get("query"); q != tc.wantQ {
+				t.Errorf("rsc.RequestBody query param: got %q, want %q", q, tc.wantQ)
+			}
+			if s := gotCache.Get("start"); s != "1000" {
+				t.Errorf("rsc.RequestBody start param: got %q, want %q", s, "1000")
+			}
+		})
+	}
+}
+
+// TestRewriteForWeightedAvg_GET verifies that for a GET request the rewritten
+// query lands in r.URL.RawQuery and that no body is written.
+func TestRewriteForWeightedAvgGET(t *testing.T) {
+	r, _ := http.NewRequest(http.MethodGet,
+		"http://example.com/api/v1/query_range?query=avg%28up%29&start=1000&end=2000&step=15",
+		nil)
+
+	c := &Client{}
+	sumReq, countReq := c.RewriteForWeightedAvg(r, "avg(up)")
+
+	for _, tc := range []struct {
+		name  string
+		req   *http.Request
+		wantQ string
+	}{
+		{"sum", sumReq, "sum(up)"},
+		{"count", countReq, "count(up)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotURL, err := url.ParseQuery(tc.req.URL.RawQuery)
+			if err != nil {
+				t.Fatalf("parse URL RawQuery: %v", err)
+			}
+			if q := gotURL.Get("query"); q != tc.wantQ {
+				t.Errorf("URL query param: got %q, want %q", q, tc.wantQ)
+			}
+			if s := gotURL.Get("start"); s != "1000" {
+				t.Errorf("URL start param: got %q, want %q", s, "1000")
+			}
+
+			// GET requests must have no body.
+			if tc.req.Body != nil {
+				b, _ := io.ReadAll(tc.req.Body)
+				if len(b) > 0 {
+					t.Errorf("expected empty body for GET, got %q", string(b))
+				}
+			}
+
+			// rsc.RequestBody should not be set for GET.
+			if gotRsc := request.GetResources(tc.req); gotRsc != nil {
+				if len(gotRsc.RequestBody) > 0 {
+					t.Errorf("expected empty rsc.RequestBody for GET, got %q",
+						string(gotRsc.RequestBody))
+				}
+			}
+		})
+	}
+}

--- a/pkg/proxy/params/params.go
+++ b/pkg/proxy/params/params.go
@@ -135,6 +135,13 @@ func GetRequestValues(r *http.Request) (url.Values, []byte, bool) {
 func SetRequestValues(r *http.Request, v url.Values) {
 	s := v.Encode()
 	r.URL.RawQuery = s
+	if r.MultipartForm != nil {
+		// prevents temp file leakage before clearing the pointer
+		_ = r.MultipartForm.RemoveAll()
+	}
+	r.Form = nil
+	r.PostForm = nil
+	r.MultipartForm = nil
 	if methods.HasBody(r.Method) {
 		// also reset the body so the upstream request carries the updated params
 		if r.Body != nil {

--- a/pkg/proxy/params/params.go
+++ b/pkg/proxy/params/params.go
@@ -140,7 +140,12 @@ func SetRequestValues(r *http.Request, v url.Values) {
 		if r.Body != nil {
 			r.Body.Close()
 		}
-		r.ContentLength = int64(len(s))
-		r.Body = io.NopCloser(strings.NewReader(s))
+		b := []byte(s)
+		r.ContentLength = int64(len(b))
+		r.Body = io.NopCloser(bytes.NewReader(b))
+		// keep the resource body cache in sync
+		if rsc := request.GetResources(r); rsc != nil {
+			rsc.RequestBody = b
+		}
 	}
 }

--- a/pkg/proxy/params/params_test.go
+++ b/pkg/proxy/params/params_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 )
 
 func TestUpdateParams(t *testing.T) {
@@ -172,6 +173,44 @@ func TestGetRequestValues_POSTFormBodyOverridesURL(t *testing.T) {
 	}
 	if len(v["step"]) != 1 {
 		t.Errorf("expected single merged value, got %v", v["step"])
+	}
+}
+
+// TestSetRequestValues_SyncsRequestBodyCache verifies that SetRequestValues
+// updates rsc.RequestBody so that CloneWithoutResources picks up the rewritten
+// body rather than the stale pre-rewrite bytes. This is the guard against the
+// TSM weighted-avg POST bug where sum/count sub-requests silently received the
+// original avg query and produced a flat line of 1.
+func TestSetRequestValues_SyncsRequestBodyCache(t *testing.T) {
+	const origBody = "query=avg%28up%29&start=1000&end=2000&step=15"
+	r, _ := http.NewRequest(http.MethodPost, "http://example.com/api/v1/query_range",
+		io.NopCloser(bytes.NewBufferString(origBody)))
+	r.Header.Set(headers.NameContentType, headers.ValueXFormURLEncoded)
+
+	// Attach resources with the original body already cached, simulating the
+	// state after the outer ServeHTTP has parsed the request.
+	rsc := &request.Resources{RequestBody: []byte(origBody)}
+	r = request.SetResources(r, rsc)
+
+	// Rewrite query param (mirrors what RewriteForWeightedAvg does).
+	v, _, _ := GetRequestValues(r)
+	v.Set("query", "sum(up)")
+	SetRequestValues(r, v)
+
+	// rsc.RequestBody must reflect the rewritten params.
+	got := request.GetResources(r)
+	if got == nil {
+		t.Fatal("expected non-nil resources after SetRequestValues")
+	}
+	gotVals, err := url.ParseQuery(string(got.RequestBody))
+	if err != nil {
+		t.Fatalf("RequestBody is not valid query-encoded: %v", err)
+	}
+	if q := gotVals.Get("query"); q != "sum(up)" {
+		t.Errorf("RequestBody query param: got %q, want %q", q, "sum(up)")
+	}
+	if s := gotVals.Get("start"); s != "1000" {
+		t.Errorf("RequestBody start param: got %q, want %q", s, "1000")
 	}
 }
 

--- a/pkg/proxy/params/params_test.go
+++ b/pkg/proxy/params/params_test.go
@@ -212,6 +212,41 @@ func TestSetRequestValues_SyncsRequestBodyCache(t *testing.T) {
 	if s := gotVals.Get("start"); s != "1000" {
 		t.Errorf("RequestBody start param: got %q, want %q", s, "1000")
 	}
+
+	// A later GetRequestValues call must not reuse the stale PostForm parsed
+	// before SetRequestValues rewrote the body.
+	gotParsed, _, _ := GetRequestValues(r)
+	if q := gotParsed.Get("query"); q != "sum(up)" {
+		t.Errorf("reparsed query param: got %q, want %q", q, "sum(up)")
+	}
+}
+
+func TestSetRequestValues_ClearsParsedFormCache(t *testing.T) {
+	const origBody = "query=avg%28up%29&start=1000&end=2000&step=15"
+	r, _ := http.NewRequest(http.MethodPost, "http://example.com/api/v1/query_range",
+		io.NopCloser(bytes.NewBufferString(origBody)))
+	r.Header.Set(headers.NameContentType, headers.ValueXFormURLEncoded)
+	r = request.SetResources(r, &request.Resources{RequestBody: []byte(origBody)})
+
+	v, _, _ := GetRequestValues(r)
+	if q := v.Get("query"); q != "avg(up)" {
+		t.Fatalf("initial query param: got %q, want %q", q, "avg(up)")
+	}
+	if r.PostForm == nil {
+		t.Fatal("expected form cache to be populated")
+	}
+
+	v.Set("query", "count(up)")
+	SetRequestValues(r, v)
+	if r.Form != nil || r.PostForm != nil || r.MultipartForm != nil {
+		t.Fatalf("expected parsed form caches cleared, got Form=%v PostForm=%v MultipartForm=%v",
+			r.Form, r.PostForm, r.MultipartForm)
+	}
+
+	got, _, _ := GetRequestValues(r)
+	if q := got.Get("query"); q != "count(up)" {
+		t.Errorf("reparsed query param: got %q, want %q", q, "count(up)")
+	}
 }
 
 // TestSetRequestValues_POSTJSONURLSync verifies that SetRequestValues for POST


### PR DESCRIPTION
## Description
<!-- Describe changes and the problem solved -->
This corrects a defect in ALB Time Series Merge for Prometheus on `avg` outer aggregators. To avoid an improperly weighted average, we clone the original request twice for the proxy call, replacing one's `avg` with `sum` and the other's with `count`, and then perform the average internally per-timestamp against the results.

The defect surfaces when the request is POST. The cloned requests were pointing to a shallow copy / pointer of a context item, causing both requests to issue `count` requests to the backends, causing the average value to always be `1` for every timestamp.

This updates `prometheus.RewriteForWeightedAvg` to deep copy the resources context, and `params.SetRequestValues` to update the deep-copied resource's cached body to stay in sync with the outbound body.

Tests added for both.

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [x] Bug fix
- - [x] Test coverage

## AI Disclosure
<!-- [x] exactly one option below -->
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
