### PR TITLE
fix: [alb/healthcheck] nested alb pools report `nc` instead of available

### DIFF
--- a/integration/alb_nested_test.go
+++ b/integration/alb_nested_test.go
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #996: an ALB whose pool contains another ALB ("nested") was reported
+// on the /trickster/health page as "nc:[alb-inner]" because the inner ALB has
+// no health check registered. The user could not tell whether traffic was
+// actually flowing. This test pins both behaviors:
+//   - alb-inner appears in alb-outer's availablePoolMembers (not unchecked)
+//   - traffic through alb-outer reaches alb-inner's leaf members
+func TestALBNestedPoolAvailable(t *testing.T) {
+	const promRange = `{"status":"success","data":{"resultType":"matrix","result":[` +
+		`{"metric":{"__name__":"up","job":"prometheus"},"values":[%s]}` +
+		`]}}`
+	const buildInfo = `{"status":"success","data":{"version":"2.0"}}`
+
+	mkRange := func(start, end, step int64) string {
+		var b strings.Builder
+		first := true
+		for ts := start; ts <= end; ts += step {
+			if !first {
+				b.WriteString(",")
+			}
+			first = false
+			fmt.Fprintf(&b, `[%d,"1"]`, ts)
+		}
+		return fmt.Sprintf(promRange, b.String())
+	}
+
+	var aHits, bHits atomic.Int64
+	mk := func(hits *atomic.Int64) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			if r.URL.Path == "/api/v1/status/buildinfo" {
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, buildInfo)
+				return
+			}
+			_ = r.ParseForm()
+			start, _ := parseInt(r.Form.Get("start"))
+			end, _ := parseInt(r.Form.Get("end"))
+			step, _ := parseInt(r.Form.Get("step"))
+			if step == 0 {
+				step = 15
+			}
+			hits.Add(1)
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, mkRange(start, end, step))
+		}))
+	}
+	leafA := mk(&aHits)
+	t.Cleanup(leafA.Close)
+	leafB := mk(&bHits)
+	t.Cleanup(leafB.Close)
+
+	const (
+		frontPort   = 18960
+		metricsPort = 18961
+		mgmtPort    = 18962
+	)
+
+	yaml := fmt.Sprintf(`
+frontend:
+  listen_port: %d
+metrics:
+  listen_port: %d
+mgmt:
+  listen_port: %d
+logging:
+  log_level: error
+caches:
+  mem1:
+    provider: memory
+backends:
+  prom-a:
+    provider: prometheus
+    origin_url: %s
+    cache_name: mem1
+    healthcheck:
+      path: /api/v1/status/buildinfo
+      query: ""
+      interval: 100ms
+      timeout: 500ms
+      failure_threshold: 1
+      recovery_threshold: 1
+  prom-b:
+    provider: prometheus
+    origin_url: %s
+    cache_name: mem1
+    healthcheck:
+      path: /api/v1/status/buildinfo
+      query: ""
+      interval: 100ms
+      timeout: 500ms
+      failure_threshold: 1
+      recovery_threshold: 1
+  alb-inner:
+    provider: alb
+    alb:
+      mechanism: rr
+      pool:
+        - prom-a
+        - prom-b
+  alb-outer:
+    provider: alb
+    alb:
+      mechanism: tsm
+      output_format: prometheus
+      pool:
+        - alb-inner
+`, frontPort, metricsPort, mgmtPort, leafA.URL, leafB.URL)
+
+	cfgPath := filepath.Join(t.TempDir(), "trickster.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(yaml), 0644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go startTrickster(t, ctx, expectedStartError{}, "-config", cfgPath)
+
+	metricsAddr := fmt.Sprintf("127.0.0.1:%d", metricsPort)
+	waitForTrickster(t, metricsAddr)
+
+	healthURL := "http://" + metricsAddr + "/trickster/health"
+	requireHealthState(t, healthURL, "prom-a", "available", 10*time.Second)
+	requireHealthState(t, healthURL, "prom-b", "available", 10*time.Second)
+
+	requireALBMemberState(t, healthURL, "alb-outer", "alb-inner", "available", 10*time.Second)
+	requireALBMemberNotIn(t, healthURL, "alb-outer", "alb-inner", "unchecked")
+
+	now := time.Now()
+	end := now.Truncate(15 * time.Second)
+	start := end.Add(-2 * time.Minute)
+	params := url.Values{
+		"query": {fmt.Sprintf("up + 0*%d", now.UnixNano())},
+		"start": {fmt.Sprintf("%d", start.Unix())},
+		"end":   {fmt.Sprintf("%d", end.Unix())},
+		"step":  {"15"},
+	}
+	u := fmt.Sprintf("http://127.0.0.1:%d/alb-outer/api/v1/query_range?%s",
+		frontPort, params.Encode())
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		r, err := http.Get(u)
+		if !assert.NoError(c, err) {
+			return
+		}
+		b, _ := io.ReadAll(r.Body)
+		r.Body.Close()
+		assert.Equal(c, http.StatusOK, r.StatusCode, "body=%s", string(b))
+		assert.Greater(c, aHits.Load()+bHits.Load(), int64(0),
+			"waiting for nested alb to fan traffic to a leaf")
+	}, 10*time.Second, 200*time.Millisecond,
+		"alb-outer never routed traffic through alb-inner to leaf upstreams")
+}
+
+// requireALBMemberNotIn asserts the named member does not appear in the given
+// bucket on the named ALB. bucket is one of "available", "unavailable",
+// "unchecked", "initializing".
+func requireALBMemberNotIn(t *testing.T, healthURL, alb, member, bucket string) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, healthURL, nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	type entry struct {
+		Name                    string   `json:"name"`
+		AvailablePoolMembers    []string `json:"availablePoolMembers"`
+		UnavailablePoolMembers  []string `json:"unavailablePoolMembers"`
+		UncheckedPoolMembers    []string `json:"uncheckedPoolMembers"`
+		InitializingPoolMembers []string `json:"initializingPoolMembers"`
+	}
+	var hs struct {
+		Available   []entry `json:"available"`
+		Unavailable []entry `json:"unavailable"`
+	}
+	require.NoError(t, json.Unmarshal(b, &hs), "health payload was not JSON: %s", string(b))
+	all := append([]entry{}, hs.Available...)
+	all = append(all, hs.Unavailable...)
+	for _, e := range all {
+		if e.Name != alb {
+			continue
+		}
+		var pool []string
+		switch bucket {
+		case "available":
+			pool = e.AvailablePoolMembers
+		case "unavailable":
+			pool = e.UnavailablePoolMembers
+		case "unchecked":
+			pool = e.UncheckedPoolMembers
+		case "initializing":
+			pool = e.InitializingPoolMembers
+		}
+		require.NotContains(t, pool, member,
+			"member %q must not appear in ALB %q %sPoolMembers (body=%s)",
+			member, alb, bucket, string(b))
+		return
+	}
+	t.Fatalf("ALB %q not present in health page (body=%s)", alb, string(b))
+}

--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -35,7 +35,14 @@ func (b Backends) StartHealthChecks(knownStatuses healthcheck.StatusLookup) (hea
 	hc := healthcheck.New()
 	for k, c := range b {
 		bo := c.Configuration()
-		if IsVirtual(bo.Provider) || k == "frontend" {
+		if k == "frontend" {
+			continue
+		}
+		if IsVirtual(bo.Provider) {
+			// Virtual backends have no upstream to probe; register a synthetic
+			// passing status so nested ALBs surface in the health page and in
+			// outer pools' availablePoolMembers (issue #996).
+			hc.RegisterVirtual(k, bo.Provider)
 			continue
 		}
 		hco := bo.HealthCheck

--- a/pkg/backends/backends_virtual_test.go
+++ b/pkg/backends/backends_virtual_test.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package backends
+
+import (
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
+	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
+	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
+)
+
+// Issue #996: a virtual backend (ALB, Rule) used as a pool member of another
+// ALB must surface in the health checker's status registry so the /health
+// endpoint can report the nested ALB as an available pool member instead of
+// "nc" (uncheckedPoolMembers). Today StartHealthChecks skips virtuals
+// entirely, so st[name] is nil at the health builder.
+func TestStartHealthChecksRegistersVirtualBackends(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider string
+	}{
+		{"alb-inner", providers.ALB},
+		{"rule-inner", providers.Rule},
+	}
+	for _, c := range cases {
+		t.Run(c.provider, func(t *testing.T) {
+			o := bo.New()
+			o.Provider = c.provider
+			cl, err := New(c.name, o, nil, lm.NewRouter(), nil)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			b := Backends{c.name: cl}
+			hc, err := b.StartHealthChecks(nil)
+			if err != nil {
+				t.Fatalf("StartHealthChecks: %v", err)
+			}
+			st, ok := hc.Statuses()[c.name]
+			if !ok || st == nil {
+				t.Fatalf("expected statuses to contain virtual backend %q", c.name)
+			}
+			if got := st.Get(); got != healthcheck.StatusPassing {
+				t.Errorf("expected StatusPassing (%d) got %d", healthcheck.StatusPassing, got)
+			}
+		})
+	}
+}

--- a/pkg/backends/healthcheck/healthcheck.go
+++ b/pkg/backends/healthcheck/healthcheck.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"slices"
 	"sync"
+	"time"
 
 	ho "github.com/trickstercache/trickster/v2/pkg/backends/healthcheck/options"
 )
@@ -30,6 +31,10 @@ import (
 type HealthChecker interface {
 	// Register a health check Target
 	Register(name string, description string, options *ho.Options, client *http.Client) (*Status, error)
+	// RegisterVirtual records a synthetic always-passing Status for a virtual
+	// backend (rule, alb) that has no upstream to probe. Without this,
+	// nested ALBs render as "nc" on the health page (issue #996).
+	RegisterVirtual(name, description string) *Status
 	// Remove a health check Target
 	Unregister(name string)
 	// Resolve status of named Target
@@ -112,6 +117,14 @@ func (hc *healthChecker) Register(name, description string, o *ho.Options,
 		t.Start(context.Background())
 	}
 	return t.status, nil
+}
+
+func (hc *healthChecker) RegisterVirtual(name, description string) *Status {
+	s := NewStatus(name, description, "", StatusPassing, time.Time{}, nil)
+	hc.mtx.Lock()
+	hc.statuses[name] = s
+	hc.mtx.Unlock()
+	return s
 }
 
 func (hc *healthChecker) Unregister(name string) {

--- a/pkg/proxy/handlers/health/health.go
+++ b/pkg/proxy/handlers/health/health.go
@@ -246,6 +246,15 @@ func updateStatusText(now func() time.Time, hc healthcheck.HealthChecker, hd *he
 	var al, ul, il, ql int
 
 	for k, v := range st {
+		// Virtual backends (alb, rule) carry a synthetic status only so they
+		// surface in outer ALB pool reporting; they have their own per-ALB
+		// section below and would duplicate as plain entries here.
+		if b, ok := backends[k]; ok && b != nil && b.Configuration() != nil {
+			p := b.Configuration().Provider
+			if p == providers.ALB || p == providers.Rule {
+				continue
+			}
+		}
 		switch v.Get() {
 		case healthcheck.StatusPassing:
 			a[al] = k

--- a/pkg/proxy/handlers/health/health_test.go
+++ b/pkg/proxy/handlers/health/health_test.go
@@ -73,6 +73,12 @@ func (m *mockHealthChecker) Register(name string, description string, options *h
 	return &healthcheck.Status{}, nil
 }
 
+func (m *mockHealthChecker) RegisterVirtual(name, description string) *healthcheck.Status {
+	s := healthcheck.NewStatus(name, description, "", healthcheck.StatusPassing, time.Time{}, nil)
+	m.targets[name] = mockTarget{description: description, status: s}
+	return s
+}
+
 func (m *mockHealthChecker) Unregister(name string) {
 	delete(m.targets, name)
 }


### PR DESCRIPTION
## Description

Fixes #996.

A nested ALB used as a pool member of another ALB was rendered as `nc:[alb-inner]` (uncheckedPoolMembers) on the `/trickster/health` page even when traffic was being routed through it. Operators couldn't tell whether the nested ALB was actually live or silently dropped.

Virtual backends (alb, rule) now register a synthetic always-passing health status, so they appear in the parent ALB's `availablePoolMembers`.

## Type of Change

- - [x] Bug fix

## AI Disclosure

- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
