### PR TITLE
fix: [integration] nonce histogram fidelity query to avoid cache hit

### DIFF
--- a/integration/prometheus_test.go
+++ b/integration/prometheus_test.go
@@ -388,7 +388,8 @@ func TestPrometheus(t *testing.T) {
 	})
 
 	t.Run("native histogram round-trip fidelity", func(t *testing.T) {
-		params := url.Values{"query": {"prometheus_http_request_duration_seconds"}}
+		query := fmt.Sprintf("prometheus_http_request_duration_seconds + 0*%d", time.Now().UnixNano())
+		params := url.Values{"query": {query}}
 
 		// Query directly against Prometheus
 		prDirect, _ := queryTricksterProm(t, "127.0.0.1:9090", "", "/api/v1/query", params)


### PR DESCRIPTION
## Description

Fixes #999.

`TestPrometheus/native_histogram_round-trip_fidelity` reused the same query string as the earlier `native_histogram_instant_query` subtest, so it hit the cache populated by that earlier run and compared a stale series count against a fresh direct-Prometheus query.

Fix: utilize a unique query to force a cache miss.

## Type of Change

- - [x] Bug fix

## AI Disclosure

- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.