### PR TITLE
fix: [proxy/engines] dpc chunk test wallclock dependency

### DIFF
--- a/pkg/proxy/engines/deltaproxycache_chunk_test.go
+++ b/pkg/proxy/engines/deltaproxycache_chunk_test.go
@@ -29,32 +29,6 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 )
 
-// DeltaProxyCacheRequest rejects requests whose extent ends before
-// now - (step * TimeseriesRetention) by routing them straight through
-// DoProxy (engine=HTTPProxy, status=proxy-only). With default
-// TimeseriesRetention=1024 and step=1h that window is ~42.67d, measured
-// against real wallclock. The two helpers below anchor each test's
-// reference 'now' to a recent chunk bucket so the queries stay inside
-// that window regardless of when the test runs, while preserving the
-// in-bucket vs cross-bucket topologies the tests need to exercise.
-//
-// chunkSize = step * cache/options/defaults.DefaultTimeseriesChunkFactor (420).
-
-func chunkBucketAnchor(step time.Duration) time.Time {
-	chunkSize := step * 420
-	// midpoint of the most-recently-completed chunk bucket; queries within
-	// ±200h of this point stay inside one bucket.
-	return time.Now().Add(-chunkSize).Truncate(chunkSize).Add(chunkSize / 2)
-}
-
-func chunkBucketStraddle(step time.Duration) time.Time {
-	chunkSize := step * 420
-	// 11h after a chunk-bucket boundary; the Q1 (-30h..-12h) and
-	// Q2 (-10h..-8h) extents used by the cross-bucket tests fall on
-	// opposite sides of the boundary just before 'now'.
-	return time.Now().Add(-chunkSize).Truncate(chunkSize).Add(11 * time.Hour)
-}
-
 func TestDeltaProxyCacheRequestMissThenHitChunksChunks(t *testing.T) {
 	ts, w, r, rsc, err := setupTestHarnessDPC()
 	rsc.CacheConfig.UseCacheChunking = true
@@ -631,15 +605,12 @@ func TestDeltaProxyCacheRequestRangeMissChunks(t *testing.T) {
 	rsc.CacheConfig.Provider = "test"
 
 	o.FastForwardDisable = true
+	o.TimeseriesRetention = 1 << 20 // pin against wallclock drift on fixed fixture
 
 	step := time.Duration(3600) * time.Second
 
-	// anchor 'now' to the midpoint of a recently-completed 17.5d chunk bucket
-	// so all three queries land in the same bucket while staying inside the
-	// DPC eviction retention window (step * TimeseriesRetention = 42.67d at
-	// defaults). A fixed calendar date would eventually drift outside that
-	// window relative to wallclock and trip the proxy-only bypass.
-	now := chunkBucketAnchor(step)
+	// fixed to keep all three queries in the same 17.5d chunk bucket; see the _CrossBucket test
+	now := time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
 	end := now.Add(-time.Duration(12) * time.Hour)
 
 	extr := timeseries.Extent{Start: end.Add(-time.Duration(18) * time.Hour), End: end}
@@ -783,14 +754,12 @@ func TestDeltaProxyCacheRequestRangeMissChunks_CrossBucket(t *testing.T) {
 	o := rsc.BackendOptions
 	rsc.CacheConfig.Provider = "test"
 	o.FastForwardDisable = true
+	o.TimeseriesRetention = 1 << 20 // pin against wallclock drift on fixed fixture
 
 	step := time.Duration(3600) * time.Second
 
-	// position 'now' 11h after a chunk-bucket boundary so the Q1 kmiss write
-	// (now-30h..now-12h) lands in the prior bucket and the Q2 high-end read
-	// (now-10h..now-8h) lands in the next bucket, exercising the cross-bucket
-	// recovery path while staying inside DPC eviction retention.
-	now := chunkBucketStraddle(step)
+	// kmiss write in bucket ending 2026-04-20T00:00Z; high-end read in next bucket
+	now := time.Date(2026, 4, 20, 11, 0, 0, 0, time.UTC)
 	end := now.Add(-time.Duration(12) * time.Hour)
 
 	extr := timeseries.Extent{Start: end.Add(-time.Duration(18) * time.Hour), End: end}
@@ -868,9 +837,10 @@ func TestDeltaProxyCacheRequestRangeMissChunks_CrossBucketPreservesPriorChunks(t
 	o := rsc.BackendOptions
 	rsc.CacheConfig.Provider = "test"
 	o.FastForwardDisable = true
+	o.TimeseriesRetention = 1 << 20 // pin against wallclock drift on fixed fixture
 
 	step := time.Duration(3600) * time.Second
-	now := chunkBucketStraddle(step)
+	now := time.Date(2026, 4, 20, 11, 0, 0, 0, time.UTC)
 
 	runQuery := func(start, end time.Time) *http.Response {
 		u := r.URL

--- a/pkg/proxy/engines/deltaproxycache_chunk_test.go
+++ b/pkg/proxy/engines/deltaproxycache_chunk_test.go
@@ -29,6 +29,32 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 )
 
+// DeltaProxyCacheRequest rejects requests whose extent ends before
+// now - (step * TimeseriesRetention) by routing them straight through
+// DoProxy (engine=HTTPProxy, status=proxy-only). With default
+// TimeseriesRetention=1024 and step=1h that window is ~42.67d, measured
+// against real wallclock. The two helpers below anchor each test's
+// reference 'now' to a recent chunk bucket so the queries stay inside
+// that window regardless of when the test runs, while preserving the
+// in-bucket vs cross-bucket topologies the tests need to exercise.
+//
+// chunkSize = step * cache/options/defaults.DefaultTimeseriesChunkFactor (420).
+
+func chunkBucketAnchor(step time.Duration) time.Time {
+	chunkSize := step * 420
+	// midpoint of the most-recently-completed chunk bucket; queries within
+	// ±200h of this point stay inside one bucket.
+	return time.Now().Add(-chunkSize).Truncate(chunkSize).Add(chunkSize / 2)
+}
+
+func chunkBucketStraddle(step time.Duration) time.Time {
+	chunkSize := step * 420
+	// 11h after a chunk-bucket boundary; the Q1 (-30h..-12h) and
+	// Q2 (-10h..-8h) extents used by the cross-bucket tests fall on
+	// opposite sides of the boundary just before 'now'.
+	return time.Now().Add(-chunkSize).Truncate(chunkSize).Add(11 * time.Hour)
+}
+
 func TestDeltaProxyCacheRequestMissThenHitChunksChunks(t *testing.T) {
 	ts, w, r, rsc, err := setupTestHarnessDPC()
 	rsc.CacheConfig.UseCacheChunking = true
@@ -608,8 +634,12 @@ func TestDeltaProxyCacheRequestRangeMissChunks(t *testing.T) {
 
 	step := time.Duration(3600) * time.Second
 
-	// fixed to keep all three queries in the same 17.5d chunk bucket; see the _CrossBucket test
-	now := time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
+	// anchor 'now' to the midpoint of a recently-completed 17.5d chunk bucket
+	// so all three queries land in the same bucket while staying inside the
+	// DPC eviction retention window (step * TimeseriesRetention = 42.67d at
+	// defaults). A fixed calendar date would eventually drift outside that
+	// window relative to wallclock and trip the proxy-only bypass.
+	now := chunkBucketAnchor(step)
 	end := now.Add(-time.Duration(12) * time.Hour)
 
 	extr := timeseries.Extent{Start: end.Add(-time.Duration(18) * time.Hour), End: end}
@@ -756,8 +786,11 @@ func TestDeltaProxyCacheRequestRangeMissChunks_CrossBucket(t *testing.T) {
 
 	step := time.Duration(3600) * time.Second
 
-	// kmiss write in bucket ending 2026-04-20T00:00Z; high-end read in next bucket
-	now := time.Date(2026, 4, 20, 11, 0, 0, 0, time.UTC)
+	// position 'now' 11h after a chunk-bucket boundary so the Q1 kmiss write
+	// (now-30h..now-12h) lands in the prior bucket and the Q2 high-end read
+	// (now-10h..now-8h) lands in the next bucket, exercising the cross-bucket
+	// recovery path while staying inside DPC eviction retention.
+	now := chunkBucketStraddle(step)
 	end := now.Add(-time.Duration(12) * time.Hour)
 
 	extr := timeseries.Extent{Start: end.Add(-time.Duration(18) * time.Hour), End: end}
@@ -837,7 +870,7 @@ func TestDeltaProxyCacheRequestRangeMissChunks_CrossBucketPreservesPriorChunks(t
 	o.FastForwardDisable = true
 
 	step := time.Duration(3600) * time.Second
-	now := time.Date(2026, 4, 20, 11, 0, 0, 0, time.UTC)
+	now := chunkBucketStraddle(step)
 
 	runQuery := func(start, end time.Time) *http.Response {
 		u := r.URL


### PR DESCRIPTION
## Description

Three chunk tests in `pkg/proxy/engines/deltaproxycache_chunk_test.go` hardcode `now := time.Date(2026, 4, ...)` and fail once real wallclock moves past `step * TimeseriesRetention` (1h * 1024 = ~42.67d) beyond the fixture date. `TestDeltaProxyCacheRequestRangeMissChunks` started failing locally around 2026-05-25, the two `_CrossBucket` siblings would have followed a few days later.

The trigger is the `EvictionMethodOldest` branch in [deltaproxycache.go:238-251](pkg/proxy/engines/deltaproxycache.go) -- `OldestRetainedTimestamp` is computed from `time.Now()`, so a fixed-calendar `trq.Extent.End` eventually slides before it and DPC short-circuits to `DoProxy` (engine=HTTPProxy, status=proxy-only). The fixture comment about the "17.5d chunk bucket" was about a different thing (chunk size = step * `DefaultTimeseriesChunkFactor`); it isn't what was tripping the test.

First commit is intentionally empty so CI captures the failure on a clean branch off main, leaving a permanent record of the time bomb. Second commit replaces the hardcoded dates with two helpers anchored to `time.Now()`:

- `chunkBucketAnchor(step)` for the single-bucket case (`TestDeltaProxyCacheRequestRangeMissChunks`) -- midpoint of a recently-completed chunk bucket
- `chunkBucketStraddle(step)` for the cross-bucket cases -- 11h after a recent chunk-bucket boundary so Q1 (-30h..-12h) and Q2 (-10h..-8h) fall on opposite sides

Both helpers stay well inside the retention window so future wallclock drift can't reintroduce the same failure.

## Type of Change

- - [x] Bug fix

## AI Disclosure

- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.