### PR TITLE
fix: [listener] correct active-connections gauge under connections_limit

### DIFF
--- a/pkg/proxy/listener/listener.go
+++ b/pkg/proxy/listener/listener.go
@@ -66,13 +66,17 @@ type Listener struct {
 }
 
 type observedConnection struct {
-	*net.TCPConn
+	net.Conn
 }
 
 func (o *observedConnection) Close() error {
-	err := o.TCPConn.Close()
-	metrics.ProxyActiveConnections.Dec()
-	metrics.ProxyConnectionClosed.Inc()
+	err := o.Conn.Close()
+	// Only the first successful Close adjusts the gauge; a subsequent Close
+	// returns an error (net/http may close the same conn more than once).
+	if err == nil {
+		metrics.ProxyActiveConnections.Dec()
+		metrics.ProxyConnectionClosed.Inc()
+	}
 	return err
 }
 
@@ -88,12 +92,15 @@ func (l *Listener) Accept() (net.Conn, error) {
 
 	metrics.ProxyActiveConnections.Inc()
 	metrics.ProxyConnectionAccepted.Inc()
-	// this is necessary for HTTP/2 to work
-	if t, ok := c.(*net.TCPConn); ok {
-		return &observedConnection{t}, nil
+	// *tls.Conn is left unwrapped so http.Server can type-assert it for
+	// HTTP/2 (ALPN); every other conn -- including *net.TCPConn and the
+	// netutil.LimitListener wrapper -- is wrapped so Close decrements
+	// ProxyActiveConnections.
+	if _, ok := c.(*tls.Conn); ok {
+		return c, nil
 	}
 
-	return c, nil
+	return &observedConnection{Conn: c}, nil
 }
 
 // CertSwapper returns the CertSwapper reference from the Listener

--- a/pkg/proxy/listener/listener.go
+++ b/pkg/proxy/listener/listener.go
@@ -70,14 +70,14 @@ type observedConnection struct {
 }
 
 func (o *observedConnection) Close() error {
-	err := o.Conn.Close()
+	if err := o.Conn.Close(); err != nil {
+		return err
+	}
 	// Only the first successful Close adjusts the gauge; a subsequent Close
 	// returns an error (net/http may close the same conn more than once).
-	if err == nil {
-		metrics.ProxyActiveConnections.Dec()
-		metrics.ProxyConnectionClosed.Inc()
-	}
-	return err
+	metrics.ProxyActiveConnections.Dec()
+	metrics.ProxyConnectionClosed.Inc()
+	return nil
 }
 
 // Accept implements Listener.Accept

--- a/pkg/proxy/listener/listener_test.go
+++ b/pkg/proxy/listener/listener_test.go
@@ -29,11 +29,13 @@ import (
 	"testing"
 	"time"
 
+	dto "github.com/prometheus/client_model/go"
 	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
 	"github.com/trickstercache/trickster/v2/pkg/config"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/level"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
+	"github.com/trickstercache/trickster/v2/pkg/observability/metrics"
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing"
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing/exporters/stdout"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/errors"
@@ -42,6 +44,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
 	testutil "github.com/trickstercache/trickster/v2/pkg/testutil"
 	tlstest "github.com/trickstercache/trickster/v2/pkg/testutil/tls"
+	"golang.org/x/net/netutil"
 )
 
 func testListener() net.Listener {
@@ -347,10 +350,77 @@ func TestCloseObservedConnection(t *testing.T) {
 		t.Error("invalid connection type")
 	}
 	oconn := &observedConnection{
-		TCPConn: tconn,
+		Conn: tconn,
 	}
 	err = oconn.Close()
 	if err != nil {
 		t.Error(err)
+	}
+}
+
+func TestObservedConnectionIdempotentClose(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(testutil.BasicHTTPHandler))
+	defer s.Close()
+	address := s.URL[7:]
+	conn, err := net.Dial("tcp", address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tconn, ok := conn.(*net.TCPConn)
+	if !ok {
+		t.Fatal("invalid connection type")
+	}
+	oconn := &observedConnection{
+		Conn: tconn,
+	}
+
+	metrics.ProxyActiveConnections.Set(10.0)
+
+	// First Close succeeds and decrements the gauge exactly once.
+	if err := oconn.Close(); err != nil {
+		t.Errorf("first Close: unexpected error: %v", err)
+	}
+
+	// Subsequent Closes return an error because the conn is already closed;
+	// that error is what prevents the gauge from being decremented again.
+	for i := 0; i < 5; i++ {
+		if err := oconn.Close(); err == nil {
+			t.Error("expected an error closing an already-closed connection")
+		}
+	}
+
+	var m dto.Metric
+	metrics.ProxyActiveConnections.Write(&m)
+	finalVal := m.GetGauge().GetValue()
+
+	if finalVal != 9.0 {
+		t.Errorf("expected ProxyActiveConnections metric to be 9.0 after idempotent close, got %f", finalVal)
+	}
+}
+
+func TestAcceptWrapsLimitListenerConn(t *testing.T) {
+	// With connections_limit set, the listener is wrapped by a
+	// netutil.LimitListener whose conns are not *net.TCPConn. Accept must
+	// still wrap them so Close decrements the active-connections gauge.
+	raw, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+	l := &Listener{Listener: netutil.LimitListener(raw, 10)}
+
+	go func() {
+		if c, derr := net.Dial("tcp", raw.Addr().String()); derr == nil {
+			c.Close()
+		}
+	}()
+
+	conn, err := l.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if _, ok := conn.(*observedConnection); !ok {
+		t.Errorf("Accept did not wrap LimitListener conn: got %T, want *observedConnection", conn)
 	}
 }


### PR DESCRIPTION
## Description
Keeps the `trickster_proxy_active_connections` gauge accurate when `frontend.connections_limit` is set.

**Root cause**
`Listener.Accept()` only wrapped `*net.TCPConn` in `observedConnection`. When `connections_limit > 0` the listener is wrapped by `netutil.LimitListener`, whose accepted conns are `*netutil.limitListenerConn` — not `*net.TCPConn`. Those conns were returned unwrapped, so their `Close()` never decremented `ProxyActiveConnections`: the gauge climbed monotonically and stopped reflecting the real connection count.

A related issue: `net/http` can call `Close()` on the same conn more than once, which previously double-decremented the gauge and drifted it negative under load.

**Fix**
- `Accept()` now wraps every accepted conn except `*tls.Conn` (left bare so `http.Server` can negotiate HTTP/2 via ALPN). `observedConnection` embeds `net.Conn` instead of `*net.TCPConn`.
- `observedConnection.Close()` decrements the gauge only on the first successful close; a repeat close returns an error, which guards the decrement — replacing the previous `sync.Once` per @crandles's review.

**Tests**
- `TestObservedConnectionIdempotentClose` asserts a repeated close returns an error and the gauge nets a single decrement.
- `TestAcceptWrapsLimitListenerConn` asserts `Accept` wraps a `LimitListener` conn.

## Type of Change
- [x] Bug fix
- [x] Test coverage

## AI Disclosure
- [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
