### PR TITLE
test: extend unit test coverage

### DIFF
--- a/.github/workflows/ci-build-tests.yml
+++ b/.github/workflows/ci-build-tests.yml
@@ -100,7 +100,6 @@ jobs:
           make data-race-test
           echo "::endgroup::"
           make data-race-test-inspect
-      - run: sed -i -e '/^.*_gen\.go:.*$/d' .coverprofile
       - run: go build -o /dev/null ./cmd/trickster
       - name: Send coverage
         if: github.repository_owner == 'trickstercache' # Skip for forked repositories
@@ -131,7 +130,6 @@ jobs:
         run: make integration-cover
       - name: Run integration tests (with race detection enabled)
         run: make -C integration data-race-test
-      - run: sed -i -e '/^.*_gen\.go:.*$/d' integration/.integration.coverprofile
       - name: Send integration coverage
         if: github.repository_owner == 'trickstercache'
         uses: shogo82148/actions-goveralls@v1

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,8 @@ GO_TEST_PATH ?= $(shell $(GO) list ./... | grep -v v2/integration)
 gotest:
 	$(GO) test -timeout=5m -v ${GO_TEST_FLAGS} $(GO_TEST_PATH)
 	@./hack/filter-coverprofile.sh .coverprofile
+	@echo
+	@./hack/coverprofile-summary.sh
 
 .PHONY: data-race-test
 data-race-test:

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ GO_TEST_PATH ?= $(shell $(GO) list ./... | grep -v v2/integration)
 .PHONY: gotest
 gotest:
 	$(GO) test -timeout=5m -v ${GO_TEST_FLAGS} $(GO_TEST_PATH)
+	@./hack/filter-coverprofile.sh .coverprofile
 
 .PHONY: data-race-test
 data-race-test:

--- a/hack/coverprofile-summary.sh
+++ b/hack/coverprofile-summary.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018 The Trickster Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# coverprofile-summary.sh prints covered statements, total statements, and
+# coverage percent from a Go coverage profile.
+
+set -euo pipefail
+
+PROFILE="${1:-.coverprofile}"
+
+if [ ! -f "${PROFILE}" ]; then
+  echo "coverprofile ${PROFILE} does not exist, please check path"
+  exit 1
+fi
+
+awk '
+  NR == 1 {
+    if ($0 !~ /^mode: /) {
+      printf "invalid coverprofile: missing mode line\n" > "/dev/stderr"
+      exit 1
+    }
+    next
+  }
+  {
+    statements = $2
+    count = $3
+    total += statements
+    if (count > 0) {
+      covered += statements
+    }
+  }
+  END {
+    if (total == 0) {
+      printf "covered statements: 0\n"
+      printf "total statements: 0\n"
+      printf "coverage percent: 0.00%%\n"
+      exit
+    }
+    printf "covered statements: %d\n", covered
+    printf "total statements: %d\n", total
+    printf "coverage percent: %.2f%%\n", (covered / total) * 100
+  }
+' "${PROFILE}"

--- a/hack/filter-coverprofile.sh
+++ b/hack/filter-coverprofile.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018 The Trickster Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# filter-coverprofile.sh removes entries from a Go coverage profile that
+# should not count toward coverage metrics (generated code, entrypoints,
+# and example code).
+
+set -euo pipefail
+
+PROFILE="${1:?usage: $0 <coverprofile>}"
+
+# nothing to do if the profile wasn't generated (e.g., coverage disabled)
+[ -f "${PROFILE}" ] || exit 0
+
+EXCLUDE_PATTERNS=(
+  '_gen\.go:'
+  '^github\.com/trickstercache/trickster/v2/cmd/'
+  '^github\.com/trickstercache/trickster/v2/examples/'
+  '^github\.com/trickstercache/trickster/v2/pkg/testutil/'
+)
+
+pattern="$(IFS='|'; echo "${EXCLUDE_PATTERNS[*]}")"
+
+tmp="$(mktemp)"
+grep -Ev "${pattern}" "${PROFILE}" > "${tmp}" || true
+mv "${tmp}" "${PROFILE}"

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -12,12 +12,14 @@ developer-delete:
 
 test:
 	$(GO) test -v --failfast
+	@../hack/filter-coverprofile.sh .integration.coverprofile
 
 data-race-test:
 	$(GO) test -v --failfast --race
 
 cover:
 	$(GO) test -v --failfast -coverpkg=../... -coverprofile=.integration.coverprofile
+	@../hack/filter-coverprofile.sh .integration.coverprofile
 	$(GO) tool cover -func=.integration.coverprofile | tail -1
 
 cover-html: cover

--- a/pkg/backends/alb/client_test.go
+++ b/pkg/backends/alb/client_test.go
@@ -17,11 +17,16 @@
 package alb
 
 import (
+	goerrors "errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends"
 	"github.com/trickstercache/trickster/v2/pkg/backends/alb/errors"
 	"github.com/trickstercache/trickster/v2/pkg/backends/alb/mech/tsm"
+	"github.com/trickstercache/trickster/v2/pkg/backends/alb/mech/ur"
+	uropt "github.com/trickstercache/trickster/v2/pkg/backends/alb/mech/ur/options"
 	"github.com/trickstercache/trickster/v2/pkg/backends/alb/names"
 	ao "github.com/trickstercache/trickster/v2/pkg/backends/alb/options"
 	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
@@ -29,6 +34,8 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/backends/prometheus"
 	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
 	"github.com/trickstercache/trickster/v2/pkg/backends/providers/registry/types"
+	pkgerrors "github.com/trickstercache/trickster/v2/pkg/errors"
+	"github.com/trickstercache/trickster/v2/pkg/util/sets"
 )
 
 const invalidPoolMemberCheck = "invalid pool member name [invalid] provided for alb [test]"
@@ -169,5 +176,275 @@ func TestValidateAndStartPool(t *testing.T) {
 	err = cl.ValidateAndStartPool(b, hcs)
 	if err != nil {
 		t.Error(err)
+	}
+}
+
+func TestNewClientCaptureDefaults(t *testing.T) {
+	o := bo.New()
+	o.MaxCaptureBytes = 123
+	o.MaxFanoutCaptureBytes = 456
+	o.ALBOptions = ao.New()
+	o.ALBOptions.MechanismName = names.MechanismRR
+
+	cl, err := NewClient("test", o, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if o.ALBOptions.MaxCaptureBytes != 123 || o.ALBOptions.MaxFanoutCaptureBytes != 456 {
+		t.Fatalf("expected ALB capture defaults to inherit backend values, got %d/%d",
+			o.ALBOptions.MaxCaptureBytes, o.ALBOptions.MaxFanoutCaptureBytes)
+	}
+	if cl == nil {
+		t.Fatal("expected client")
+	}
+}
+
+func TestStopPoolsAndStopPool(t *testing.T) {
+	o := bo.New()
+	o.ALBOptions = ao.New()
+	o.ALBOptions.MechanismName = names.MechanismRR
+	o.ALBOptions.Pool = []string{"test"}
+
+	cl, err := NewClient("test", o, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := backends.Backends{"test": cl}
+	if err := StopPools(b); err != nil {
+		t.Fatalf("StopPools: %v", err)
+	}
+	cl.(*Client).StopPool()
+}
+
+func TestClientValidateErrors(t *testing.T) {
+	o := bo.New()
+	cl, err := NewClient("test", o, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := cl.(*Client)
+
+	if err := c.Validate(sets.NewStringSet()); err != pkgerrors.ErrInvalidOptions {
+		t.Fatalf("Validate() = %v, want ErrInvalidOptions", err)
+	}
+
+	o.ALBOptions = ao.New()
+	o.ALBOptions.MechanismName = "missing"
+	if err := c.Validate(sets.NewStringSet()); err == nil {
+		t.Fatal("expected invalid mechanism error")
+	}
+}
+
+func TestValidateAndStartPoolUnprobedMembersResetFloor(t *testing.T) {
+	memberOpts := bo.New()
+	memberOpts.Provider = providers.ReverseProxyShort
+	memberOpts.OriginURL = "http://example.com"
+	memberOpts.HealthCheck.Interval = 0
+
+	member, err := backends.New("member", memberOpts, nil, http.NotFoundHandler(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	albOpts := bo.New()
+	albOpts.ALBOptions = ao.New()
+	albOpts.ALBOptions.MechanismName = names.MechanismRR
+	albOpts.ALBOptions.HealthyFloor = int(healthcheck.StatusPassing)
+	albOpts.ALBOptions.Pool = []string{"member"}
+
+	albClient, err := NewClient("edge", albOpts, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cl := albClient.(*Client)
+
+	err = cl.ValidateAndStartPool(backends.Backends{
+		"edge":   cl,
+		"member": member,
+	}, healthcheck.StatusLookup{"member": &healthcheck.Status{}})
+	if err != nil {
+		t.Fatalf("ValidateAndStartPool: %v", err)
+	}
+	cl.StopPool()
+}
+
+func TestValidateAndStartPoolAdmitsFailingFloor(t *testing.T) {
+	memberOpts := bo.New()
+	memberOpts.Provider = providers.ReverseProxyShort
+	memberOpts.OriginURL = "http://example.com"
+	member, err := backends.New("member", memberOpts, nil, http.NotFoundHandler(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	albOpts := bo.New()
+	albOpts.ALBOptions = ao.New()
+	albOpts.ALBOptions.MechanismName = names.MechanismRR
+	albOpts.ALBOptions.HealthyFloor = int(healthcheck.StatusFailing)
+	albOpts.ALBOptions.Pool = []string{"member"}
+
+	albClient, err := NewClient("edge", albOpts, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cl := albClient.(*Client)
+
+	err = cl.ValidateAndStartPool(backends.Backends{
+		"edge":   cl,
+		"member": member,
+	}, healthcheck.StatusLookup{"member": &healthcheck.Status{}})
+	if err != nil {
+		t.Fatalf("ValidateAndStartPool: %v", err)
+	}
+	cl.StopPool()
+}
+
+func TestValidateAndStartUserRouter(t *testing.T) {
+	defaultHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	memberOpts := bo.New()
+	memberOpts.Provider = providers.ReverseProxyShort
+	memberOpts.OriginURL = "http://example.com"
+	member, err := backends.New("tenant-a", memberOpts, nil, defaultHandler, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("default backend", func(t *testing.T) {
+		albOpts := bo.New()
+		albOpts.ALBOptions = ao.New()
+		albOpts.ALBOptions.MechanismName = names.MechanismUR
+		albOpts.ALBOptions.UserRouter = &uropt.Options{
+			DefaultBackend:   "tenant-a",
+			TargetProvider:   providers.ReverseProxyShort,
+			Users: uropt.UserMappingOptionsByUser{
+				"alice": {ToBackend: "tenant-a", ToUser: "alice"},
+			},
+		}
+
+		albClient, err := NewClient("ur-edge", albOpts, nil, nil, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cl := albClient.(*Client)
+		h, ok := cl.handler.(*ur.Handler)
+		if !ok {
+			t.Fatalf("handler type = %T, want *ur.Handler", cl.handler)
+		}
+
+		err = cl.validateAndStartUserRouter(backends.Backends{
+			"tenant-a": member,
+		}, healthcheck.StatusLookup{"tenant-a": &healthcheck.Status{}})
+		if err != nil {
+			t.Fatalf("validateAndStartUserRouter: %v", err)
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "http://example/", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("unauthenticated UR request status = %d, want 200 via default backend", w.Code)
+		}
+	})
+
+	t.Run("no route unauthorized", func(t *testing.T) {
+		albOpts := bo.New()
+		albOpts.ALBOptions = ao.New()
+		albOpts.ALBOptions.MechanismName = names.MechanismUR
+		albOpts.ALBOptions.UserRouter = &uropt.Options{
+			TargetProvider:    providers.ReverseProxyShort,
+			NoRouteStatusCode: http.StatusUnauthorized,
+		}
+
+		albClient, err := NewClient("ur-edge", albOpts, nil, nil, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cl := albClient.(*Client)
+		h := cl.handler.(*ur.Handler)
+
+		if err := cl.validateAndStartUserRouter(backends.Backends{}, nil); err != nil {
+			t.Fatalf("validateAndStartUserRouter: %v", err)
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "http://example/", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("unauthenticated UR request status = %d, want 401", w.Code)
+		}
+	})
+}
+
+func TestValidateAndStartUserRouterErrors(t *testing.T) {
+	albOpts := bo.New()
+	albOpts.ALBOptions = ao.New()
+	albOpts.ALBOptions.MechanismName = names.MechanismUR
+	albOpts.ALBOptions.UserRouter = &uropt.Options{
+		DefaultBackend: "missing",
+		TargetProvider: providers.ReverseProxyShort,
+	}
+
+	albClient, err := NewClient("ur-edge", albOpts, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cl := albClient.(*Client)
+
+	err = cl.validateAndStartUserRouter(backends.Backends{}, nil)
+	if err == nil {
+		t.Fatal("expected invalid default backend error")
+	}
+
+	albOpts.ALBOptions.UserRouter = &uropt.Options{
+		TargetProvider: providers.ReverseProxyShort,
+		Users: uropt.UserMappingOptionsByUser{
+			"alice": {ToBackend: "missing"},
+		},
+	}
+	albClient, err = NewClient("ur-edge", albOpts, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cl = albClient.(*Client)
+	err = cl.validateAndStartUserRouter(backends.Backends{}, nil)
+	if err == nil {
+		t.Fatal("expected invalid user backend error")
+	}
+
+	albOpts.ALBOptions.UserRouter = &uropt.Options{
+		TargetProvider: providers.ReverseProxyShort,
+		Users: uropt.UserMappingOptionsByUser{
+			"alice": {ToBackend: "tenant-a", ToCredential: "secret"},
+		},
+	}
+	albClient, err = NewClient("ur-edge", albOpts, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cl = albClient.(*Client)
+	memberOpts := bo.New()
+	memberOpts.Provider = providers.ReverseProxyShort
+	memberOpts.OriginURL = "http://example.com"
+	member, err := backends.New("tenant-a", memberOpts, nil, http.NotFoundHandler(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cl.validateAndStartUserRouter(backends.Backends{"tenant-a": member}, nil)
+	var credErr *errors.InvalidALBOptionsError
+	if !goerrors.As(err, &credErr) {
+		t.Fatalf("validateAndStartUserRouter() = %v, want InvalidALBOptionsError", err)
+	}
+	want := errors.NewErrInvalidUserRouterCreds("ur-edge")
+	if err.Error() != want.Error() {
+		t.Fatalf("validateAndStartUserRouter() = %v, want %v", err, want)
+	}
+}
+
+func TestObserveOnlyOpts(t *testing.T) {
+	opts := observeOnlyOpts()
+	if opts == nil || !opts.ObserveOnly {
+		t.Fatalf("observeOnlyOpts() = %+v", opts)
 	}
 }

--- a/pkg/backends/alb/mech/tsm/helpers_test.go
+++ b/pkg/backends/alb/mech/tsm/helpers_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/trickstercache/trickster/v2/pkg/backends/alb/mech/fanout"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
 )
@@ -237,5 +238,22 @@ func TestMergeMultiValuedHeaders(t *testing.T) {
 					tc.name, tc.winner.Get(headers.NameSetCookie))
 			}
 		})
+	}
+}
+
+func TestAllFanoutFailed(t *testing.T) {
+	t.Parallel()
+
+	if allFanoutFailed(nil) {
+		t.Fatal("nil results should not be all failed")
+	}
+	if allFanoutFailed([]fanout.Result{}) {
+		t.Fatal("empty results should not be all failed")
+	}
+	if !allFanoutFailed([]fanout.Result{{Failed: true}, {Failed: true}}) {
+		t.Fatal("expected all failed when every slot failed")
+	}
+	if allFanoutFailed([]fanout.Result{{Failed: true}, {Failed: false}}) {
+		t.Fatal("expected not all failed when one slot succeeded")
 	}
 }

--- a/pkg/backends/alb/mech/tsm/time_series_merge_ctor_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_ctor_test.go
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tsm
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	alberr "github.com/trickstercache/trickster/v2/pkg/backends/alb/errors"
+	"github.com/trickstercache/trickster/v2/pkg/backends/alb/mech/rr"
+	"github.com/trickstercache/trickster/v2/pkg/backends/alb/mech/types"
+	"github.com/trickstercache/trickster/v2/pkg/backends/alb/options"
+	"github.com/trickstercache/trickster/v2/pkg/backends/prometheus"
+	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
+	rt "github.com/trickstercache/trickster/v2/pkg/backends/providers/registry/types"
+	"github.com/trickstercache/trickster/v2/pkg/testutil/albpool"
+)
+
+func TestRegistryEntry(t *testing.T) {
+	t.Parallel()
+	entry := RegistryEntry()
+	if entry.Name != Name || entry.ShortName != ShortName {
+		t.Fatalf("RegistryEntry = %+v, want Name=%q ShortName=%q", entry, Name, ShortName)
+	}
+	if entry.New == nil {
+		t.Fatal("RegistryEntry.New is nil")
+	}
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid output format", func(t *testing.T) {
+		t.Parallel()
+		_, err := New(&options.Options{OutputFormat: "not-a-provider"}, nil)
+		if !errors.Is(err, alberr.ErrInvalidTimeSeriesMergeProvider) {
+			t.Fatalf("New() error = %v, want ErrInvalidTimeSeriesMergeProvider", err)
+		}
+	})
+
+	t.Run("missing factory", func(t *testing.T) {
+		t.Parallel()
+		_, err := New(&options.Options{OutputFormat: providers.Prometheus}, rt.Lookup{})
+		if !errors.Is(err, alberr.ErrInvalidTimeSeriesMergeProvider) {
+			t.Fatalf("New() error = %v, want ErrInvalidTimeSeriesMergeProvider", err)
+		}
+	})
+
+	t.Run("valid prometheus provider", func(t *testing.T) {
+		t.Parallel()
+		m, err := New(
+			&options.Options{OutputFormat: providers.Prometheus},
+			rt.Lookup{providers.Prometheus: prometheus.NewClient},
+		)
+		if err != nil {
+			t.Fatalf("New() unexpected error: %v", err)
+		}
+		if m == nil {
+			t.Fatal("New() returned nil mechanism")
+		}
+		if m.Name() != ShortName {
+			t.Fatalf("Name() = %q, want %q", m.Name(), ShortName)
+		}
+	})
+}
+
+func TestHandlerStopPool(t *testing.T) {
+	t.Parallel()
+
+	h := &handler{}
+	p, _, _ := albpool.NewHealthy([]http.Handler{http.NotFoundHandler()})
+	defer p.Stop()
+	h.SetPool(p)
+	h.StopPool()
+}
+
+func TestHandlerSetPoolPropagatesNonmergeHandler(t *testing.T) {
+	t.Parallel()
+
+	nmh, err := rr.New(nil, nil)
+	if err != nil {
+		t.Fatalf("rr.New: %v", err)
+	}
+	nmpm, ok := nmh.(types.PoolMechanism)
+	if !ok {
+		t.Fatal("rr mechanism should implement PoolMechanism")
+	}
+	h := &handler{nonmergeHandler: nmpm}
+	p, _, _ := albpool.NewHealthy([]http.Handler{http.NotFoundHandler()})
+	defer p.Stop()
+	h.SetPool(p)
+	if nmpm.Pool() != p {
+		t.Fatal("SetPool did not propagate pool to nonmergeHandler")
+	}
+}

--- a/pkg/backends/alb/mech/tsm/time_series_merge_serve_weighted_avg_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_serve_weighted_avg_test.go
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tsm
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/backends"
+	"github.com/trickstercache/trickster/v2/pkg/backends/alb/pool"
+	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/params"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
+	"github.com/trickstercache/trickster/v2/pkg/testutil/albpool"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/epoch"
+)
+
+type weightedAvgStubBackend struct {
+	stripKeysStubBackend
+}
+
+func (b *weightedAvgStubBackend) ClassifyMerge(query string) (int, bool, string) {
+	if strings.HasPrefix(query, "avg(") {
+		return int(dataset.MergeStrategySum), true, ""
+	}
+	return int(dataset.MergeStrategyDedup), false, ""
+}
+
+func (b *weightedAvgStubBackend) RewriteForWeightedAvg(r *http.Request, query string) (*http.Request, *http.Request) {
+	sumReq, err := request.Clone(r)
+	if err != nil {
+		return r, r
+	}
+	countReq, err := request.Clone(r)
+	if err != nil {
+		return sumReq, sumReq
+	}
+	sumQP := url.Values{"query": {strings.Replace(query, "avg(", "sum(", 1)}}
+	countQP := url.Values{"query": {strings.Replace(query, "avg(", "count(", 1)}}
+	params.SetRequestValues(sumReq, sumQP)
+	params.SetRequestValues(countReq, countQP)
+	return sumReq, countReq
+}
+
+type weightedAvgMemberSpec struct {
+	sumValue   string
+	countValue string
+}
+
+func weightedAvgDataSet(value string) *dataset.DataSet {
+	return &dataset.DataSet{
+		Results: dataset.Results{{
+			SeriesList: dataset.SeriesList{{
+				Header: dataset.SeriesHeader{Name: "requests", Tags: dataset.Tags{}},
+				Points: dataset.Points{{
+					Epoch:  epoch.Epoch(100),
+					Size:   32,
+					Values: []any{value},
+				}},
+			}},
+		}},
+	}
+}
+
+func weightedAvgRespondFunc(w http.ResponseWriter, _ *http.Request, accum *merge.Accumulator, statusCode int) {
+	headers.StripMergeHeaders(w.Header())
+	if statusCode == 0 {
+		statusCode = http.StatusOK
+	}
+	ds, _ := accum.GetTSData().(*dataset.DataSet)
+	w.WriteHeader(statusCode)
+	if ds == nil || len(ds.Results) == 0 || len(ds.Results[0].SeriesList) == 0 {
+		_, _ = w.Write([]byte("MERGED:empty|warnings=" + strings.Join(dsWarnings(ds), ",")))
+		return
+	}
+	var sb strings.Builder
+	sb.WriteString("MERGED:")
+	for _, p := range ds.Results[0].SeriesList[0].Points {
+		sb.WriteString(strconv.FormatInt(int64(p.Epoch), 10))
+		sb.WriteByte('=')
+		if len(p.Values) > 0 {
+			sb.WriteString(formatAny(p.Values[0]))
+		}
+		sb.WriteByte(';')
+	}
+	sb.WriteString("|warnings=")
+	sb.WriteString(strings.Join(dsWarnings(ds), ","))
+	_, _ = w.Write([]byte(sb.String()))
+}
+
+func dsWarnings(ds *dataset.DataSet) []string {
+	if ds == nil {
+		return nil
+	}
+	return ds.Warnings
+}
+
+func formatAny(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	default:
+		return ""
+	}
+}
+
+func weightedAvgMemberHandler(spec weightedAvgMemberSpec) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		qp, _, _ := params.GetRequestValues(r)
+		query := qp.Get("query")
+		var val string
+		switch {
+		case strings.HasPrefix(query, "sum("):
+			val = spec.sumValue
+		case strings.HasPrefix(query, "count("):
+			val = spec.countValue
+		default:
+			http.Error(w, "unexpected query", http.StatusInternalServerError)
+			return
+		}
+		rsc := request.GetResources(r)
+		if rsc != nil {
+			rsc.TS = weightedAvgDataSet(val)
+			rsc.MergeFunc = merge.TimeseriesMergeFuncWithStrategy(nil, rsc.TSMergeStrategy)
+			rsc.MergeRespondFunc = weightedAvgRespondFunc
+		}
+		w.Header().Set(headers.NameTricksterResult, "engine=none")
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func weightedAvgEmptySideHandler(failCount bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		qp, _, _ := params.GetRequestValues(r)
+		query := qp.Get("query")
+		isCount := strings.HasPrefix(query, "count(")
+		rsc := request.GetResources(r)
+		if rsc != nil {
+			rsc.MergeRespondFunc = weightedAvgRespondFunc
+			if failCount == isCount {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			val := "10"
+			if isCount {
+				val = "2"
+			}
+			rsc.TS = weightedAvgDataSet(val)
+			rsc.MergeFunc = merge.TimeseriesMergeFuncWithStrategy(nil, rsc.TSMergeStrategy)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func newWeightedAvgTarget(h http.Handler) *pool.Target {
+	st := &healthcheck.Status{}
+	st.Set(healthcheck.StatusPassing)
+	be := &weightedAvgStubBackend{}
+	return pool.NewTarget(h, st, be)
+}
+
+func newWeightedAvgPool(handlers []http.Handler) pool.Pool {
+	targets := make(pool.Targets, len(handlers))
+	for i, h := range handlers {
+		targets[i] = newWeightedAvgTarget(h)
+	}
+	p := pool.New(targets, -1)
+	p.RefreshHealthy()
+	return p
+}
+
+func newWeightedAvgRequest(t *testing.T, query string) *http.Request {
+	t.Helper()
+	r := albpool.NewParentGET(t)
+	r.URL.RawQuery = "query=" + url.QueryEscape(query)
+	rsc := request.NewResources(nil, nil, nil, nil, nil, nil)
+	rsc.TimeRangeQuery = &timeseries.TimeRangeQuery{Statement: query}
+	return request.SetResources(r, rsc)
+}
+
+func TestServeWeightedAvg(t *testing.T) {
+	logger.SetLogger(testLogger)
+
+	t.Run("two_members_finalize_weighted_average", func(t *testing.T) {
+		p := newWeightedAvgPool([]http.Handler{
+			weightedAvgMemberHandler(weightedAvgMemberSpec{sumValue: "60", countValue: "3"}),
+			weightedAvgMemberHandler(weightedAvgMemberSpec{sumValue: "40", countValue: "1"}),
+		})
+		defer p.Stop()
+		albpool.WaitHealthy(t, p, 2)
+
+		h := &handler{mergePaths: []string{"/"}}
+		h.SetPool(p)
+
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newWeightedAvgRequest(t, "avg(requests)"))
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status: want 200 got %d body=%q", w.Code, w.Body.String())
+		}
+		body := w.Body.String()
+		if !strings.Contains(body, "100=25") {
+			t.Fatalf("body: want weighted avg 100=25, got %q", body)
+		}
+	})
+
+	t.Run("count_fanout_empty_warns_unfinalized_sums", func(t *testing.T) {
+		p := newWeightedAvgPool([]http.Handler{
+			weightedAvgEmptySideHandler(true),
+			weightedAvgEmptySideHandler(true),
+		})
+		defer p.Stop()
+		albpool.WaitHealthy(t, p, 2)
+
+		h := &handler{mergePaths: []string{"/"}}
+		h.SetPool(p)
+
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newWeightedAvgRequest(t, "avg(requests)"))
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status: want 200 got %d body=%q", w.Code, w.Body.String())
+		}
+		body := w.Body.String()
+		if !strings.Contains(body, "100=20") {
+			t.Fatalf("body: want unfinalized merged sum 100=20, got %q", body)
+		}
+		if !strings.Contains(body, "count fanout returned no usable responses") {
+			t.Fatalf("body: want count-fanout warning, got %q", body)
+		}
+	})
+
+	t.Run("sum_fanout_empty_promotes_count_with_warning", func(t *testing.T) {
+		p := newWeightedAvgPool([]http.Handler{
+			weightedAvgEmptySideHandler(false),
+			weightedAvgEmptySideHandler(false),
+		})
+		defer p.Stop()
+		albpool.WaitHealthy(t, p, 2)
+
+		h := &handler{mergePaths: []string{"/"}}
+		h.SetPool(p)
+
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newWeightedAvgRequest(t, "avg(requests)"))
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status: want 200 got %d body=%q", w.Code, w.Body.String())
+		}
+		body := w.Body.String()
+		if !strings.Contains(body, "100=4") {
+			t.Fatalf("body: want promoted merged count 100=4, got %q", body)
+		}
+		if !strings.Contains(body, "sum fanout returned no usable responses") {
+			t.Fatalf("body: want sum-fanout warning, got %q", body)
+		}
+	})
+
+	t.Run("mixed_sum_status_marks_phit", func(t *testing.T) {
+		okHandler := weightedAvgMemberHandler(weightedAvgMemberSpec{sumValue: "10", countValue: "2"})
+		errHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			qp, _, _ := params.GetRequestValues(r)
+			if strings.HasPrefix(qp.Get("query"), "sum(") {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			weightedAvgMemberHandler(weightedAvgMemberSpec{sumValue: "0", countValue: "0"}).
+				ServeHTTP(w, r)
+		})
+
+		p := newWeightedAvgPool([]http.Handler{okHandler, errHandler})
+		defer p.Stop()
+		albpool.WaitHealthy(t, p, 2)
+
+		h := &handler{mergePaths: []string{"/"}}
+		h.SetPool(p)
+
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newWeightedAvgRequest(t, "avg(requests)"))
+
+		if status := w.Header().Get(headers.NameTricksterResult); !strings.Contains(status, "phit") {
+			t.Fatalf("%s: want phit marker, got %q", headers.NameTricksterResult, status)
+		}
+	})
+
+	t.Run("instant_query_from_form_param", func(t *testing.T) {
+		p := newWeightedAvgPool([]http.Handler{
+			weightedAvgMemberHandler(weightedAvgMemberSpec{sumValue: "20", countValue: "2"}),
+		})
+		defer p.Stop()
+		albpool.WaitHealthy(t, p, 1)
+
+		h := &handler{mergePaths: []string{"/"}}
+		h.SetPool(p)
+
+		r := albpool.NewParentGET(t)
+		r.URL.RawQuery = "query=" + url.QueryEscape("avg(requests)")
+		rsc := request.NewResources(nil, nil, nil, nil, nil, nil)
+		r = request.SetResources(r, rsc)
+
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status: want 200 got %d body=%q", w.Code, w.Body.String())
+		}
+		if !strings.Contains(w.Body.String(), "100=10") {
+			t.Fatalf("body: want weighted avg 100=10, got %q", w.Body.String())
+		}
+	})
+}
+
+// Compile-time check that the stub satisfies TSMMergeProvider.
+var _ backends.TSMMergeProvider = (*weightedAvgStubBackend)(nil)

--- a/pkg/backends/alb/mech/ur/options/options_test.go
+++ b/pkg/backends/alb/mech/ur/options/options_test.go
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package options
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
+	"gopkg.in/yaml.v2"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	o := New()
+	if o.NoRouteStatusCode != http.StatusUnauthorized {
+		t.Fatalf("NoRouteStatusCode = %d, want 401", o.NoRouteStatusCode)
+	}
+}
+
+func TestInitialize(t *testing.T) {
+	t.Parallel()
+
+	o := &Options{}
+	if err := o.Initialize("edge-alb"); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if o.NoRouteStatusCode != http.StatusUnauthorized {
+		t.Fatalf("NoRouteStatusCode = %d, want default 401", o.NoRouteStatusCode)
+	}
+
+	o = &Options{NoRouteStatusCode: http.StatusNotFound}
+	if err := o.Initialize("edge-alb"); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if o.NoRouteStatusCode != http.StatusNotFound {
+		t.Fatalf("NoRouteStatusCode = %d, want 404", o.NoRouteStatusCode)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	backendTypes := map[string]string{
+		"tenant-a": providers.ReverseProxyShort,
+	}
+
+	o := New()
+	o.DefaultBackend = "tenant-a"
+	if err := o.Initialize("edge"); err != nil {
+		t.Fatal(err)
+	}
+	if err := o.Validate(backendTypes); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	o = New()
+	o.DefaultBackend = "missing"
+	if err := o.Initialize("edge"); err != nil {
+		t.Fatal(err)
+	}
+	err := o.Validate(backendTypes)
+	if err == nil {
+		t.Fatal("expected invalid default backend error")
+	}
+	var ie *InvalidUserRouterOptionsError
+	if !errors.As(err, &ie) {
+		t.Fatalf("Validate() = %T, want InvalidUserRouterOptionsError", err)
+	}
+
+	o = New()
+	o.Users = UserMappingOptionsByUser{
+		"alice": {ToBackend: "missing"},
+	}
+	if err := o.Initialize("edge"); err != nil {
+		t.Fatal(err)
+	}
+	if err := o.Validate(backendTypes); err == nil {
+		t.Fatal("expected invalid user backend error")
+	}
+
+	o = New()
+	o.NoRouteStatusCode = 99
+	if err := o.Initialize("edge"); err != nil {
+		t.Fatal(err)
+	}
+	if err := o.Validate(backendTypes); err == nil {
+		t.Fatal("expected invalid no_route_status_code error")
+	}
+}
+
+func TestClone(t *testing.T) {
+	t.Parallel()
+
+	o := New()
+	o.DefaultBackend = "tenant-a"
+	o.Users = UserMappingOptionsByUser{
+		"alice": {ToBackend: "tenant-a", ToUser: "alice"},
+	}
+	cl := o.Clone()
+	if cl == o {
+		t.Fatal("Clone returned same pointer")
+	}
+	if cl.Users["alice"] == o.Users["alice"] {
+		t.Fatal("expected cloned user mapping")
+	}
+	cl.Users["alice"].ToUser = "bob"
+	if o.Users["alice"].ToUser != "alice" {
+		t.Fatal("clone should not share user mapping pointer")
+	}
+}
+
+func TestNewErrInvalidUserRouterOptions(t *testing.T) {
+	t.Parallel()
+
+	err := NewErrInvalidUserRouterOptions("edge")
+	var ie *InvalidUserRouterOptionsError
+	if !errors.As(err, &ie) {
+		t.Fatalf("error type = %T, want InvalidUserRouterOptionsError", err)
+	}
+}
+
+func TestUnmarshalYAML(t *testing.T) {
+	t.Parallel()
+
+	const raw = `
+backends:
+  edge:
+    user_router:
+      default_backend: tenant-a
+      no_route_status_code: 404
+      users:
+        alice:
+          to_backend: tenant-a
+          to_user: alice
+`
+
+	type backendDoc struct {
+		Backends map[string]struct {
+			UserRouter *Options `yaml:"user_router"`
+		} `yaml:"backends"`
+	}
+	var doc backendDoc
+	if err := yaml.Unmarshal([]byte(raw), &doc); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	o := doc.Backends["edge"].UserRouter
+	if o == nil {
+		t.Fatal("expected user router options")
+	}
+	if o.DefaultBackend != "tenant-a" {
+		t.Fatalf("DefaultBackend = %q", o.DefaultBackend)
+	}
+	if o.NoRouteStatusCode != http.StatusNotFound {
+		t.Fatalf("NoRouteStatusCode = %d, want 404", o.NoRouteStatusCode)
+	}
+	if o.Users["alice"].ToUser != "alice" {
+		t.Fatalf("unexpected user mapping: %+v", o.Users["alice"])
+	}
+}

--- a/pkg/backends/clickhouse/model/unmarshal_test.go
+++ b/pkg/backends/clickhouse/model/unmarshal_test.go
@@ -17,9 +17,12 @@
 package model
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/epoch"
 )
 
 func TestStripSize(t *testing.T) {
@@ -47,5 +50,171 @@ func TestUnmarshalTimeseries(t *testing.T) {
 	if len(ds.ExtentList) != 1 || !ds.ExtentList[0].Start.Equal(el[0].Start) ||
 		!ds.ExtentList[0].End.Equal(el[0].End) {
 		t.Error("unexpected extents: ", ds.ExtentList)
+	}
+}
+
+func TestUnmarshalTimeseriesReaderErrors(t *testing.T) {
+	_, err := UnmarshalTimeseriesReader(strings.NewReader("only-one-row"), testTRQ.Clone())
+	if err != timeseries.ErrInvalidBody {
+		t.Fatalf("UnmarshalTimeseriesReader() = %v, want ErrInvalidBody", err)
+	}
+}
+
+func TestTypeToFieldDataType(t *testing.T) {
+	tests := map[string]timeseries.FieldDataType{
+		"String":    timeseries.String,
+		"UUID":      timeseries.String,
+		"FixedString(16)": timeseries.String,
+		"Int64":     timeseries.Int64,
+		"UInt64":    timeseries.Uint64,
+		"Float64":   timeseries.Float64,
+		"Decimal128(18)": timeseries.Float64,
+		"DateTime":  timeseries.DateTimeSQL,
+		"DateTime64(3)": timeseries.DateTimeSQL,
+		"Date":      timeseries.DateSQL,
+		"Nothing":   timeseries.Null,
+		"UnknownType": timeseries.Unknown,
+	}
+	for input, want := range tests {
+		if got := typeToFieldDataType(input); got != want {
+			t.Errorf("typeToFieldDataType(%q) = %v, want %v", input, got, want)
+		}
+	}
+}
+
+func TestLoadFieldDef(t *testing.T) {
+	trq := testTRQ.Clone()
+
+	fd := loadFieldDef("", "String", 0, trq)
+	if fd.OutputPosition != -1 {
+		t.Fatalf("empty field OutputPosition = %d, want -1", fd.OutputPosition)
+	}
+
+	fd = loadFieldDef("t", "DateTime", 0, trq)
+	if fd.Role != timeseries.RoleTimestamp || fd.DataType != timeseries.DateTimeSQL {
+		t.Fatalf("DateTime timestamp field = %+v", fd)
+	}
+
+	fd = loadFieldDef("t", "Date", 0, trq)
+	if fd.DataType != timeseries.DateSQL {
+		t.Fatalf("Date timestamp DataType = %v, want DateSQL", fd.DataType)
+	}
+
+	fd = loadFieldDef("hostname", "String", 1, trq)
+	if fd.Role != timeseries.RoleTag {
+		t.Fatalf("tag field role = %v, want RoleTag", fd.Role)
+	}
+
+	trq.TimestampDefinition.DataType = timeseries.DateTimeUnixMilli
+	fd = loadFieldDef("t", "UnknownType", 0, trq)
+	if fd.DataType != timeseries.DateTimeUnixMilli {
+		t.Fatalf("custom timestamp DataType = %v, want DateTimeUnixMilli", fd.DataType)
+	}
+}
+
+func TestBuildFieldDefinitionsInvalidRows(t *testing.T) {
+	rows := [][]string{
+		{"a", "b", "c"},
+		{"String", "String"},
+	}
+	_, err := buildFieldDefinitions(rows, testTRQ.Clone())
+	if err != timeseries.ErrInvalidBody {
+		t.Fatalf("buildFieldDefinitions() = %v, want ErrInvalidBody", err)
+	}
+}
+
+func TestParseTimeField(t *testing.T) {
+	tfd := timeseries.FieldDefinition{DataType: timeseries.DateTimeSQL}
+	ep, err := parseTimeField("2020-01-01 12:00:00", tfd)
+	if err != nil {
+		t.Fatalf("parseTimeField DateTimeSQL: %v", err)
+	}
+	if ep == 0 {
+		t.Fatal("expected non-zero epoch")
+	}
+
+	tfd = timeseries.FieldDefinition{DataType: timeseries.DateSQL}
+	ep, err = parseTimeField("2020-01-01", tfd)
+	if err != nil {
+		t.Fatalf("parseTimeField DateSQL: %v", err)
+	}
+	if ep == 0 {
+		t.Fatal("expected non-zero epoch")
+	}
+
+	tfd = timeseries.FieldDefinition{DataType: timeseries.Uint64}
+	ep, err = parseTimeField("1577836800", tfd)
+	if err != nil {
+		t.Fatalf("parseTimeField seconds: %v", err)
+	}
+	want := epoch.Epoch(int64(1577836800) * 1000000000)
+	if ep != want {
+		t.Fatalf("seconds epoch = %v, want %v", ep, want)
+	}
+
+	ep, err = parseTimeField("1577836800000", tfd)
+	if err != nil {
+		t.Fatalf("parseTimeField milliseconds: %v", err)
+	}
+	want = epoch.Epoch(int64(1577836800000) * 1000000)
+	if ep != want {
+		t.Fatalf("milliseconds epoch = %v, want %v", ep, want)
+	}
+
+	ep, err = parseTimeField("1577836800000000", tfd)
+	if err != nil {
+		t.Fatalf("parseTimeField microseconds: %v", err)
+	}
+	want = epoch.Epoch(int64(1577836800000000) * 1000)
+	if ep != want {
+		t.Fatalf("microseconds epoch = %v, want %v", ep, want)
+	}
+
+	ep, err = parseTimeField("1577836800000000000", tfd)
+	if err != nil {
+		t.Fatalf("parseTimeField nanoseconds: %v", err)
+	}
+	want = epoch.Epoch(1577836800000000000)
+	if ep != want {
+		t.Fatalf("nanoseconds epoch = %v, want %v", ep, want)
+	}
+
+	tfd = timeseries.FieldDefinition{DataType: timeseries.TimeSQL}
+	ep, err = parseTimeField("12:00:00", tfd)
+	if err != nil {
+		t.Fatalf("parseTimeField TimeSQL: %v", err)
+	}
+	if ep == 0 {
+		t.Fatal("expected non-zero epoch for TimeSQL")
+	}
+
+	tfd = timeseries.FieldDefinition{DataType: timeseries.Uint64}
+	_, err = parseTimeField("not-a-time", tfd)
+	if err != timeseries.ErrInvalidTimeFormat {
+		t.Fatalf("parseTimeField invalid = %v, want ErrInvalidTimeFormat", err)
+	}
+}
+
+func TestParseClickHouseTimestamp(t *testing.T) {
+	for i := 1; i <= 9; i++ {
+		frac := strings.Repeat("0", i)
+		input := "2020-01-01 12:00:00." + frac
+		if _, err := parseClickHouseTimestamp("", input); err != nil {
+			t.Fatalf("parseClickHouseTimestamp(%q) = %v", input, err)
+		}
+	}
+
+	for _, input := range []string{
+		"2020-01-01 12:00:00",
+		"2020-01-01 12:00:00.",
+	} {
+		if _, err := parseClickHouseTimestamp("", input); err != nil {
+			t.Fatalf("parseClickHouseTimestamp(%q) = %v", input, err)
+		}
+	}
+
+	longFrac := "2020-01-01 12:00:00." + strings.Repeat("1", 12)
+	if _, err := parseClickHouseTimestamp("", longFrac); err != nil {
+		t.Fatalf("parseClickHouseTimestamp long fraction = %v", err)
 	}
 }

--- a/pkg/backends/healthcheck/options/options_validate_test.go
+++ b/pkg/backends/healthcheck/options/options_validate_test.go
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package options
+
+import (
+	"testing"
+	"time"
+
+	ct "github.com/trickstercache/trickster/v2/pkg/config/types"
+)
+
+func TestValidateSuccess(t *testing.T) {
+	t.Parallel()
+
+	o := &Options{
+		Verb:              "GET",
+		Scheme:            "https",
+		Host:              "hc.example.com",
+		Path:              "/health",
+		Timeout:           2 * time.Second,
+		ExpectedCodes:     []int{200, 204},
+		FailureThreshold:  1,
+		RecoveryThreshold: 2,
+	}
+	ok, err := o.Validate()
+	if !ok || err != nil {
+		t.Fatalf("Validate() = (%v, %v)", ok, err)
+	}
+}
+
+func TestValidateErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		o    *Options
+	}{
+		{
+			name: "invalid verb",
+			o:    &Options{Verb: "NOT_A_METHOD"},
+		},
+		{
+			name: "invalid scheme",
+			o:    &Options{Scheme: "ftp"},
+		},
+		{
+			name: "timeout too low",
+			o:    &Options{Timeout: MinProbeWait - 1},
+		},
+		{
+			name: "timeout too high",
+			o:    &Options{Timeout: MaxProbeWait + time.Second},
+		},
+		{
+			name: "invalid expected code",
+			o:    &Options{ExpectedCodes: []int{99}},
+		},
+		{
+			name: "host without scheme",
+			o:    &Options{Host: "hc.example.com"},
+		},
+		{
+			name: "negative failure threshold",
+			o:    &Options{FailureThreshold: -1},
+		},
+		{
+			name: "negative recovery threshold",
+			o:    &Options{RecoveryThreshold: -1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ok, err := tt.o.Validate()
+			if ok || err == nil {
+				t.Fatalf("Validate() = (%v, %v), want error", ok, err)
+			}
+		})
+	}
+}
+
+func TestCloneCopiesSlicesAndMaps(t *testing.T) {
+	t.Parallel()
+
+	o := &Options{
+		Verb:            "GET",
+		ExpectedCodes:   []int{200},
+		Headers:         ct.EnvStringMap{"X-Test": "1"},
+		ExpectedHeaders: map[string]string{"Content-Type": "text/plain"},
+	}
+	cl := o.Clone()
+	if cl == o {
+		t.Fatal("Clone returned same pointer")
+	}
+	cl.ExpectedCodes[0] = 500
+	if o.ExpectedCodes[0] != 200 {
+		t.Fatal("ExpectedCodes should be copied")
+	}
+	cl.Headers["X-Test"] = "2"
+	if o.Headers["X-Test"] != "1" {
+		t.Fatal("Headers should be copied")
+	}
+	cl.ExpectedHeaders["Content-Type"] = "application/json"
+	if o.ExpectedHeaders["Content-Type"] != "text/plain" {
+		t.Fatal("ExpectedHeaders should be copied")
+	}
+}

--- a/pkg/backends/influxdb/flux/flux_parser_test.go
+++ b/pkg/backends/influxdb/flux/flux_parser_test.go
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package flux
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefaultJSONRequestBody(t *testing.T) {
+	t.Parallel()
+
+	rb := DefaultJSONRequestBody()
+	if rb.Type != LangFlux || rb.Dialect.Delimiter != "," {
+		t.Fatalf("unexpected defaults: %+v", rb)
+	}
+	if len(DefaultAnnotations()) != 3 {
+		t.Fatalf("annotations = %v", DefaultAnnotations())
+	}
+}
+
+func TestVndfluxToJSON(t *testing.T) {
+	t.Parallel()
+
+	rb := vndfluxToJSON([]byte("from(\"bucket\")"))
+	if rb.Query != `from("bucket")` || rb.Type != LangFlux {
+		t.Fatalf("unexpected body: %+v", rb)
+	}
+}
+
+func TestParseStep(t *testing.T) {
+	t.Parallel()
+
+	d, err := parseStep(`|> aggregateWindow(every: 1m, fn: mean)`)
+	if err != nil || d != time.Minute {
+		t.Fatalf("parseStep = (%v, %v)", d, err)
+	}
+
+	_, err = parseStep("|> aggregateWindow(fn: mean)")
+	if err != ErrTimeRangeParsingFailed {
+		t.Fatalf("parseStep error = %v", err)
+	}
+}
+
+func TestParseRange(t *testing.T) {
+	t.Parallel()
+
+	e, err := parseRange(`|> range(start: 1672531200, stop: 1673136000)`)
+	if err != nil {
+		t.Fatalf("parseRange: %v", err)
+	}
+	if e.Start.Unix() != 1672531200 || e.End.Unix() != 1673136000 {
+		t.Fatalf("extent = %+v", e)
+	}
+
+	_, err = parseRange("|> range(start: bad, stop: 1)")
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestTryParseTimeField(t *testing.T) {
+	t.Parallel()
+
+	tm, err := tryParseRelativeDuration("-7d")
+	if err != nil || tm.IsZero() {
+		t.Fatalf("relative duration = (%v, %v)", tm, err)
+	}
+
+	tm, err = tryParseAbsoluteTime("2023-01-01T00:00:00Z")
+	if err != nil || tm.Unix() != 1672531200 {
+		t.Fatalf("absolute time = (%v, %v)", tm, err)
+	}
+
+	tm, err = tryParseUnixTimestamp("1672531200")
+	if err != nil || tm.Unix() != 1672531200 {
+		t.Fatalf("unix timestamp = (%v, %v)", tm, err)
+	}
+
+	_, err = tryParseTimeField("not-a-time")
+	if err != ErrTimeRangeParsingFailed {
+		t.Fatalf("tryParseTimeField = %v", err)
+	}
+}
+
+func TestTokenizeRangeLine(t *testing.T) {
+	t.Parallel()
+
+	line := `from("bucket") |> range(start: -7d, stop: -6d)`
+	start := len(`from("bucket") `)
+	out := tokenizeRangeLine(line, start)
+	if out != `from("bucket") |> range(<TIMERANGE_TOKEN>)` {
+		t.Fatalf("tokenizeRangeLine = %q", out)
+	}
+}
+
+func TestParseQueryErrors(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, err := ParseQuery(`from("bucket")
+|> aggregateWindow(every: not-a-duration, fn: mean)`)
+	if err == nil {
+		t.Fatal("expected parse step error")
+	}
+
+	_, e, _, err := ParseQuery(`from("bucket")
+|> range(start: 1, stop: 2)`)
+	if err != nil || e.Start.Unix() != 1 {
+		t.Fatalf("ParseQuery unix range = (%+v, %v)", e, err)
+	}
+}
+
+func TestParseQueryRelativeRange(t *testing.T) {
+	t.Parallel()
+
+	_, e, d, err := ParseQuery(testFluxQuery1)
+	if err != nil {
+		t.Fatalf("ParseQuery: %v", err)
+	}
+	if d != time.Minute {
+		t.Fatalf("step = %v", d)
+	}
+	if e.End.Before(e.Start) {
+		t.Fatalf("expected ordered extent, got %+v", e)
+	}
+}

--- a/pkg/backends/options/options_lookup_test.go
+++ b/pkg/backends/options/options_lookup_test.go
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package options
+
+import (
+	"testing"
+	"time"
+
+	ho "github.com/trickstercache/trickster/v2/pkg/backends/healthcheck/options"
+	ao "github.com/trickstercache/trickster/v2/pkg/backends/alb/options"
+	uropt "github.com/trickstercache/trickster/v2/pkg/backends/alb/mech/ur/options"
+	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
+	ro "github.com/trickstercache/trickster/v2/pkg/backends/rule/options"
+	"github.com/trickstercache/trickster/v2/pkg/cache/negative"
+	co "github.com/trickstercache/trickster/v2/pkg/cache/options"
+	tro "github.com/trickstercache/trickster/v2/pkg/observability/tracing/options"
+	autho "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/options"
+	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
+	rwopts "github.com/trickstercache/trickster/v2/pkg/proxy/request/rewriter/options"
+)
+
+func TestLookupValidateAndInitialize(t *testing.T) {
+	t.Parallel()
+
+	member := New()
+	member.Name = "member"
+	member.Provider = providers.ReverseProxyShort
+	member.OriginURL = "http://example.com"
+	member.TracingConfigName = ""
+
+	alb := New()
+	alb.Name = "edge"
+	alb.Provider = providers.ALB
+	alb.ALBOptions = ao.New()
+	alb.ALBOptions.MechanismName = "rr"
+	alb.ALBOptions.UserRouter = &uropt.Options{
+		DefaultBackend: "member",
+	}
+
+	l := Lookup{"member": member, "edge": alb}
+	if err := l.Validate(); err != nil {
+		t.Fatalf("Lookup.Validate: %v", err)
+	}
+	if alb.ALBOptions.UserRouter.TargetProvider != providers.ReverseProxyShort {
+		t.Fatalf("UserRouter.TargetProvider = %q, want %q",
+			alb.ALBOptions.UserRouter.TargetProvider, providers.ReverseProxyShort)
+	}
+
+	if err := l.Initialize(); err != nil {
+		t.Fatalf("Lookup.Initialize: %v", err)
+	}
+	if member.Name != "member" {
+		t.Fatalf("member.Name = %q", member.Name)
+	}
+}
+
+func TestLookupValidateRejectsInvalidOriginURL(t *testing.T) {
+	t.Parallel()
+
+	o := New()
+	o.Provider = providers.Prometheus
+	o.OriginURL = "://bad-url"
+	l := Lookup{"bad": o}
+	_, err := o.Validate()
+	if err == nil {
+		t.Fatal("expected invalid origin_url error")
+	}
+	if err := l.Validate(); err == nil {
+		t.Fatal("expected Lookup.Validate to propagate origin_url error")
+	}
+}
+
+func TestValidateConfigMappingsSuccessPaths(t *testing.T) {
+	t.Parallel()
+
+	o := New()
+	o.Name = "backend"
+	o.Provider = providers.Prometheus
+	o.OriginURL = "http://example.com"
+	o.AuthenticatorName = "auth"
+	o.ReqRewriterName = "rw"
+	o.TracingConfigName = "trace"
+	o.NegativeCacheName = "neg"
+	o.Paths = po.List{{
+		Path:              "/secure",
+		AuthenticatorName: "auth",
+		ReqRewriterName:   "rw",
+	}}
+
+	l := Lookup{"backend": o}
+	err := l.ValidateConfigMappings(
+		co.Lookup{"default": nil},
+		negative.Lookups{"neg": {404: time.Second}},
+		ro.Lookup{},
+		rwopts.Lookup{"rw": nil},
+		autho.Lookup{"auth": autho.New()},
+		tro.Lookup{"trace": tro.New()},
+	)
+	if err != nil {
+		t.Fatalf("ValidateConfigMappings: %v", err)
+	}
+	if o.AuthOptions == nil {
+		t.Fatal("expected AuthOptions to be wired")
+	}
+	if len(o.NegativeCache) == 0 {
+		t.Fatal("expected NegativeCache map to be populated")
+	}
+}
+
+func TestValidateConfigMappingsALBAndCycles(t *testing.T) {
+	t.Parallel()
+
+	member := New()
+	member.Name = "member"
+	member.Provider = providers.ReverseProxyShort
+	member.OriginURL = "http://example.com"
+	member.TracingConfigName = ""
+	member.NegativeCacheName = ""
+
+	edge := New()
+	edge.Name = "edge"
+	edge.Provider = providers.ALB
+	edge.TracingConfigName = ""
+	edge.NegativeCacheName = ""
+	edge.ALBOptions = ao.New()
+	edge.ALBOptions.MechanismName = "rr"
+	edge.ALBOptions.Pool = []string{"member"}
+
+	l := Lookup{"member": member, "edge": edge}
+	err := l.ValidateConfigMappings(co.Lookup{"default": nil}, negative.Lookups{},
+		ro.Lookup{}, rwopts.Lookup{}, autho.Lookup{}, tro.Lookup{})
+	if err != nil {
+		t.Fatalf("ValidateConfigMappings for ALB pool: %v", err)
+	}
+
+	edge.ALBOptions.Pool = []string{"edge"}
+	err = l.ValidateConfigMappings(co.Lookup{"default": nil}, negative.Lookups{},
+		ro.Lookup{}, rwopts.Lookup{}, autho.Lookup{}, tro.Lookup{})
+	if err == nil {
+		t.Fatal("expected cycle validation error")
+	}
+}
+
+func TestValidateConfigMappingsInvalidReferences(t *testing.T) {
+	t.Parallel()
+
+	o := New()
+	o.Name = "backend"
+	o.Provider = providers.Prometheus
+	o.OriginURL = "http://example.com"
+	o.AuthenticatorName = "missing"
+	l := Lookup{"backend": o}
+
+	err := l.ValidateConfigMappings(co.Lookup{"default": nil}, negative.Lookups{},
+		ro.Lookup{}, rwopts.Lookup{}, autho.Lookup{}, tro.Lookup{})
+	if err == nil {
+		t.Fatal("expected invalid authenticator error")
+	}
+
+	o.AuthenticatorName = ""
+	o.Paths = po.List{{Path: "/x", AuthenticatorName: "missing"}}
+	err = l.ValidateConfigMappings(co.Lookup{"default": nil}, negative.Lookups{},
+		ro.Lookup{}, rwopts.Lookup{}, autho.Lookup{}, tro.Lookup{})
+	if err == nil {
+		t.Fatal("expected invalid path authenticator error")
+	}
+
+	o.Paths = nil
+	o.Provider = providers.ALB
+	o.ALBOptions = nil
+	err = l.ValidateConfigMappings(co.Lookup{"default": nil}, negative.Lookups{},
+		ro.Lookup{}, rwopts.Lookup{}, autho.Lookup{}, tro.Lookup{})
+	if err == nil {
+		t.Fatal("expected invalid ALB options error")
+	}
+}
+
+func TestOptionsValidateHealthCheckError(t *testing.T) {
+	t.Parallel()
+
+	o := New()
+	o.Name = "backend"
+	o.Provider = providers.Prometheus
+	o.OriginURL = "http://example.com"
+	o.HealthCheck = &ho.Options{Verb: "NOT_A_METHOD"}
+
+	_, err := o.Validate()
+	if err == nil {
+		t.Fatal("expected healthcheck validation error")
+	}
+}

--- a/pkg/backends/rule/options/options_test.go
+++ b/pkg/backends/rule/options/options_test.go
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package options
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	o := New()
+	if o.InputDelimiter != " " {
+		t.Fatalf("InputDelimiter = %q, want %q", o.InputDelimiter, " ")
+	}
+	if o.InputIndex != -1 {
+		t.Fatalf("InputIndex = %d, want -1", o.InputIndex)
+	}
+	if o.MaxRuleExecutions != DefaultMaxRuleExecutions {
+		t.Fatalf("MaxRuleExecutions = %d, want %d", o.MaxRuleExecutions, DefaultMaxRuleExecutions)
+	}
+	if o.InputType != "string" {
+		t.Fatalf("InputType = %q, want string", o.InputType)
+	}
+}
+
+func TestInitialize(t *testing.T) {
+	t.Parallel()
+
+	o := &Options{
+		MaxRuleExecutions: 0,
+		InputDelimiter:    "",
+		InputType:         "STRING",
+		InputEncoding:     "BASE64",
+		Operation:         "EQ",
+	}
+	if err := o.Initialize(""); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if o.MaxRuleExecutions != DefaultMaxRuleExecutions {
+		t.Fatalf("MaxRuleExecutions = %d, want default", o.MaxRuleExecutions)
+	}
+	if o.InputDelimiter != " " {
+		t.Fatalf("InputDelimiter = %q, want space", o.InputDelimiter)
+	}
+	if o.InputType != "string" || o.InputEncoding != "base64" || o.Operation != "eq" {
+		t.Fatalf("expected lowercase normalization, got type=%q encoding=%q op=%q",
+			o.InputType, o.InputEncoding, o.Operation)
+	}
+}
+
+func TestClone(t *testing.T) {
+	t.Parallel()
+
+	o := New()
+	o.NextRoute = "next"
+	o.CaseOptions = CaseOptionsList{
+		{Matches: []string{"a", "b"}, NextRoute: "case-a"},
+		nil,
+	}
+	cl := o.Clone()
+	if cl == o {
+		t.Fatal("Clone returned same pointer")
+	}
+	if cl.NextRoute != "next" {
+		t.Fatalf("NextRoute = %q", cl.NextRoute)
+	}
+	if len(cl.CaseOptions) != 2 {
+		t.Fatalf("CaseOptions len = %d", len(cl.CaseOptions))
+	}
+	if cl.CaseOptions[0] == o.CaseOptions[0] {
+		t.Fatal("expected cloned case options")
+	}
+	cl.CaseOptions[0].Matches[0] = "changed"
+	if o.CaseOptions[0].Matches[0] != "a" {
+		t.Fatal("clone should not share slice backing")
+	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"", "none"} {
+		o := New()
+		o.Name = name
+		ok, err := o.Validate()
+		if ok || err != ErrInvalidName {
+			t.Fatalf("Validate(%q) = (%v, %v), want (false, ErrInvalidName)", name, ok, err)
+		}
+	}
+
+	o := New()
+	o.Name = "valid-rule"
+	ok, err := o.Validate()
+	if !ok || err != nil {
+		t.Fatalf("Validate(valid-rule) = (%v, %v)", ok, err)
+	}
+}
+
+func TestLookupInitializeAndValidate(t *testing.T) {
+	t.Parallel()
+
+	l := Lookup{
+		"rule-a": {
+			InputSource: "path",
+			Operation:   "EQ",
+		},
+	}
+	if err := l.Initialize(); err != nil {
+		t.Fatalf("Lookup.Initialize: %v", err)
+	}
+	if l["rule-a"].Name != "rule-a" {
+		t.Fatalf("Name = %q, want rule-a", l["rule-a"].Name)
+	}
+	if err := l.Validate(); err != nil {
+		t.Fatalf("Lookup.Validate: %v", err)
+	}
+
+	l["bad"] = nil
+	if err := l.Initialize(); err == nil {
+		t.Fatal("expected empty rule error from Initialize")
+	}
+	if err := l.Validate(); err == nil {
+		t.Fatal("expected empty rule error from Validate")
+	}
+
+	l = Lookup{"": New()}
+	if err := l.Validate(); err != ErrInvalidName {
+		t.Fatalf("Validate empty name = %v, want ErrInvalidName", err)
+	}
+}
+
+func TestUnmarshalYAML(t *testing.T) {
+	t.Parallel()
+
+	const raw = `
+rules:
+  route-by-path:
+    next_route: default
+    input_source: path
+    input_type: STRING
+    input_encoding: BASE64
+    operation: EQ
+    cases:
+      - matches: ["/api"]
+        next_route: api-backend
+`
+
+	type rulesDoc struct {
+		Rules Lookup `yaml:"rules"`
+	}
+	var doc rulesDoc
+	if err := yaml.Unmarshal([]byte(raw), &doc); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	o := doc.Rules["route-by-path"]
+	if o == nil {
+		t.Fatal("expected route-by-path rule")
+	}
+	if err := o.Initialize(""); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if o.NextRoute != "default" || o.InputSource != "path" {
+		t.Fatalf("unexpected rule options: %+v", o)
+	}
+	if o.InputType != "string" || o.InputEncoding != "base64" || o.Operation != "eq" {
+		t.Fatalf("expected normalized values, got type=%q encoding=%q op=%q",
+			o.InputType, o.InputEncoding, o.Operation)
+	}
+	if len(o.CaseOptions) != 1 || o.CaseOptions[0].NextRoute != "api-backend" {
+		t.Fatalf("unexpected cases: %+v", o.CaseOptions)
+	}
+}

--- a/pkg/cache/options/options_extended_test.go
+++ b/pkg/cache/options/options_extended_test.go
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package options
+
+import (
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/cache/providers"
+	"github.com/trickstercache/trickster/v2/pkg/util/sets"
+	"gopkg.in/yaml.v2"
+)
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	o := New()
+	o.Name = ""
+	if ok, err := o.Validate(); ok || err != ErrInvalidName {
+		t.Fatalf("Validate() = (%v, %v), want invalid name", ok, err)
+	}
+
+	o = New()
+	o.Name = "default"
+	o.Index.MaxSizeBytes = 100
+	o.Index.MaxSizeBackoffBytes = 200
+	if ok, err := o.Validate(); ok || err != errMaxSizeBackoffBytesTooBig {
+		t.Fatalf("Validate backoff bytes = (%v, %v)", ok, err)
+	}
+
+	o = New()
+	o.Name = "default"
+	o.Index.MaxSizeObjects = 10
+	o.Index.MaxSizeBackoffObjects = 20
+	if ok, err := o.Validate(); ok || err != errMaxSizeBackoffObjectsTooBig {
+		t.Fatalf("Validate backoff objects = (%v, %v)", ok, err)
+	}
+
+	o = New()
+	o.Name = "default"
+	if ok, err := o.Validate(); !ok || err != nil {
+		t.Fatalf("Validate(default) = (%v, %v)", ok, err)
+	}
+}
+
+func TestLookupValidate(t *testing.T) {
+	t.Parallel()
+
+	l := Lookup{"default": New()}
+	if err := l.Validate(); err != nil {
+		t.Fatalf("Lookup.Validate: %v", err)
+	}
+
+	l = Lookup{"": New()}
+	if err := l.Validate(); err != ErrInvalidName {
+		t.Fatalf("Lookup.Validate() = %v, want ErrInvalidName", err)
+	}
+}
+
+func TestEqualProviderBranches(t *testing.T) {
+	t.Parallel()
+
+	o := New()
+	o.Provider = providers.Redis
+	o.ProviderID = providers.RedisID
+	if !o.Equal(o.Clone()) {
+		t.Fatal("redis options should be equal to clone")
+	}
+
+	o2 := o.Clone()
+	o2.Redis.Endpoint = "different:6379"
+	if o.Equal(o2) {
+		t.Fatal("expected redis endpoint difference to make options unequal")
+	}
+
+	fs := New()
+	fs.Provider = providers.Filesystem
+	fs.ProviderID = providers.FilesystemID
+	if !fs.Equal(fs.Clone()) {
+		t.Fatal("filesystem options should be equal to clone")
+	}
+}
+
+func TestInitializeProviderBranchesAndWarnings(t *testing.T) {
+	t.Parallel()
+
+	o := New()
+	o.Provider = "filesystem"
+	l := Lookup{"default": o}
+	if _, err := l.Initialize(sets.New([]string{"default"})); err != nil {
+		t.Fatalf("Initialize filesystem: %v", err)
+	}
+	if o.ProviderID != providers.FilesystemID || o.Redis != nil || o.Filesystem == nil {
+		t.Fatalf("unexpected provider wiring: %+v", o)
+	}
+
+	o = New()
+	o.Provider = "redis"
+	o.Redis.ClientType = "standard"
+	o.Redis.Endpoint = ""
+	o.Redis.Endpoints = []string{"127.0.0.1:6379"}
+	l = Lookup{"default": o}
+	warnings, err := l.Initialize(sets.New([]string{"default"}))
+	if err != nil {
+		t.Fatalf("Initialize redis: %v", err)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %v, want standard/endpoints warning", warnings)
+	}
+
+	o = New()
+	o.Provider = "redis"
+	o.Redis.ClientType = "sentinel"
+	o.Redis.Endpoint = "127.0.0.1:6379"
+	o.Redis.Endpoints = nil
+	l = Lookup{"default": o}
+	warnings, err = l.Initialize(sets.New([]string{"default"}))
+	if err != nil {
+		t.Fatalf("Initialize sentinel: %v", err)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %v, want sentinel/endpoint warning", warnings)
+	}
+}
+
+func TestInitializeRemovesInactiveCaches(t *testing.T) {
+	t.Parallel()
+
+	l := Lookup{
+		"active":   New(),
+		"inactive": New(),
+	}
+	if _, err := l.Initialize(sets.New([]string{"active"})); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if _, ok := l["inactive"]; ok {
+		t.Fatal("expected inactive cache to be removed")
+	}
+}
+
+func TestClearProviderOptionsAndUnmarshalYAML(t *testing.T) {
+	t.Parallel()
+
+	o := New()
+	o.ClearProviderOptions()
+	if o.Index != nil || o.Redis != nil || o.Memory != nil {
+		t.Fatal("expected provider options to be cleared")
+	}
+
+	const raw = `
+caches:
+  default:
+    provider: memory
+    timeseries_chunk_factor: 4
+`
+	type doc struct {
+		Caches Lookup `yaml:"caches"`
+	}
+	var d doc
+	if err := yaml.Unmarshal([]byte(raw), &d); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	c := d.Caches["default"]
+	if c == nil || c.TimeseriesChunkFactor != 4 {
+		t.Fatalf("unexpected cache options: %+v", c)
+	}
+}

--- a/pkg/cache/redis/options/options_extended_test.go
+++ b/pkg/cache/redis/options/options_extended_test.go
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package options
+
+import (
+	"testing"
+	"time"
+
+	ct "github.com/trickstercache/trickster/v2/pkg/config/types"
+	"gopkg.in/yaml.v2"
+)
+
+func TestEqual(t *testing.T) {
+	t.Parallel()
+
+	o := New()
+	if !o.Equal(o) {
+		t.Fatal("expected options equal to self")
+	}
+	if o.Equal(nil) {
+		t.Fatal("expected false for nil comparison")
+	}
+
+	o2 := &Options{
+		ClientType: DefaultRedisClientType,
+		Protocol:   DefaultRedisProtocol,
+		Endpoint:   DefaultRedisEndpoint,
+		Endpoints:  []string{DefaultRedisEndpoint},
+	}
+	o2.Endpoint = "other:6379"
+	if o.Equal(o2) {
+		t.Fatal("expected endpoint difference to make options unequal")
+	}
+
+	o3 := &Options{
+		ClientType:      DefaultRedisClientType,
+		Protocol:        DefaultRedisProtocol,
+		Endpoint:        DefaultRedisEndpoint,
+		Endpoints:       []string{DefaultRedisEndpoint},
+		Password:        ct.EnvString("secret"),
+		MinRetryBackoff: time.Second,
+		UseTLS:          true,
+	}
+	if !o3.Equal(o3) {
+		t.Fatal("expected custom options to be equal to self")
+	}
+}
+
+func TestEqualStringSlices(t *testing.T) {
+	t.Parallel()
+
+	if !equalStringSlices([]string{"a", "b"}, []string{"a", "b"}) {
+		t.Fatal("expected equal slices")
+	}
+	if equalStringSlices([]string{"a"}, []string{"a", "b"}) {
+		t.Fatal("expected unequal slice lengths")
+	}
+	if equalStringSlices([]string{"a"}, []string{"b"}) {
+		t.Fatal("expected unequal slice values")
+	}
+}
+
+func TestUnmarshalYAML(t *testing.T) {
+	t.Parallel()
+
+	const raw = `
+caches:
+  default:
+    redis:
+      client_type: sentinel
+      endpoint: redis:6379
+      password: secret
+`
+	type doc struct {
+		Caches map[string]struct {
+			Redis *Options `yaml:"redis"`
+		} `yaml:"caches"`
+	}
+	var d doc
+	if err := yaml.Unmarshal([]byte(raw), &d); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	o := d.Caches["default"].Redis
+	if o == nil || o.ClientType != "sentinel" || o.Password != "secret" {
+		t.Fatalf("unexpected redis options: %+v", o)
+	}
+}

--- a/pkg/config/validate/validate_unit_test.go
+++ b/pkg/config/validate/validate_unit_test.go
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package validate
+
+import (
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/config"
+	"github.com/trickstercache/trickster/v2/pkg/errors"
+	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
+	co "github.com/trickstercache/trickster/v2/pkg/cache/options"
+	lo "github.com/trickstercache/trickster/v2/pkg/observability/logging/options"
+	mo "github.com/trickstercache/trickster/v2/pkg/observability/metrics/options"
+	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
+)
+
+func TestValidateNilConfig(t *testing.T) {
+	t.Parallel()
+
+	if err := Validate(nil); err != errors.ErrInvalidOptions {
+		t.Fatalf("Validate(nil) = %v, want ErrInvalidOptions", err)
+	}
+}
+
+func TestValidateSubsectionsNilOrEmpty(t *testing.T) {
+	t.Parallel()
+
+	if err := Rewriters(nil); err != nil {
+		t.Fatalf("Rewriters(nil) = %v", err)
+	}
+	if err := Rules(nil); err != nil {
+		t.Fatalf("Rules(nil) = %v", err)
+	}
+	if err := Caches(nil); err != nil {
+		t.Fatalf("Caches(nil) = %v", err)
+	}
+	if err := Tracers(nil); err != nil {
+		t.Fatalf("Tracers(nil) = %v", err)
+	}
+	if err := Authenticators(nil); err != nil {
+		t.Fatalf("Authenticators(nil) = %v", err)
+	}
+	if err := NegativeCaches(nil); err != nil {
+		t.Fatalf("NegativeCaches(nil) = %v", err)
+	}
+}
+
+func TestBackendsRequiresEntries(t *testing.T) {
+	t.Parallel()
+
+	c := config.NewConfig()
+	c.Backends = bo.Lookup{}
+	if err := Backends(c); err != errors.ErrNoValidBackends {
+		t.Fatalf("Backends(empty) = %v", err)
+	}
+
+	c.Backends = bo.Lookup{
+		"default": {
+			Name:                "default",
+			Provider:            providers.Prometheus,
+			OriginURL:           "http://example.com:9090",
+			CacheName:           "default",
+			TracingConfigName:   "",
+			NegativeCacheName:     "",
+		},
+	}
+	c.Caches = co.Lookup{"default": co.New()}
+	if err := Backends(c); err != nil {
+		t.Fatalf("Backends(valid) = %v", err)
+	}
+}
+
+func TestValidateMinimalConfig(t *testing.T) {
+	t.Parallel()
+
+	c := config.NewConfig()
+	c.Logging = &lo.Options{LogLevel: "info"}
+	c.Metrics = &mo.Options{}
+	c.Caches = co.Lookup{"default": co.New()}
+	c.Backends = bo.Lookup{
+		"default": {
+			Name:                "default",
+			Provider:            providers.Prometheus,
+			OriginURL:           "http://example.com:9090",
+			CacheName:           "default",
+			TracingConfigName:   "",
+			NegativeCacheName:     "",
+		},
+	}
+	if err := Validate(c); err != nil {
+		t.Fatalf("Validate(minimal) = %v", err)
+	}
+}
+
+func TestValidateLoadedConfig(t *testing.T) {
+	t.Parallel()
+
+	c, err := config.Load([]string{"-config", "../../../testdata/test.multiple_backends.conf"})
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	if err := Validate(c); err != nil {
+		t.Fatalf("Validate(full config) = %v", err)
+	}
+}

--- a/pkg/observability/logging/logging_extended_test.go
+++ b/pkg/observability/logging/logging_extended_test.go
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logging
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/level"
+)
+
+type stringerVal struct{ s string }
+
+func (s stringerVal) String() string { return s.s }
+
+func TestNoopLogger(t *testing.T) {
+	t.Parallel()
+
+	l := NoopLogger()
+	l.Info("ignored", Pairs{"k": "v"})
+	if l.Level() != level.Info {
+		t.Fatalf("Level() = %s, want info", l.Level())
+	}
+}
+
+func TestLoggerWriteAndFiltering(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	l := StreamLogger(buf, level.Warn)
+	l.SetLogAsynchronous(false)
+
+	l.Info("hidden", nil)
+	l.Warn("visible", Pairs{"key": "value"})
+	if !strings.Contains(buf.String(), "visible") {
+		t.Fatalf("output = %q", buf.String())
+	}
+	if strings.Contains(buf.String(), "hidden") {
+		t.Fatal("info message should be filtered at warn level")
+	}
+
+	n, err := l.(*logger).Write([]byte("direct write\n"))
+	if err != nil || n == 0 {
+		t.Fatalf("Write() = (%d, %v)", n, err)
+	}
+	if !strings.Contains(buf.String(), "direct write") {
+		t.Fatal("expected direct write output")
+	}
+}
+
+func TestLoggerOnceAndSynchronousHelpers(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	l := StreamLogger(buf, level.Debug)
+	l.SetLogAsynchronous(false)
+
+	if !l.DebugOnce("once-key", "debug once", nil) {
+		t.Fatal("expected first DebugOnce to log")
+	}
+	if l.DebugOnce("once-key", "debug once", nil) {
+		t.Fatal("expected second DebugOnce to be suppressed")
+	}
+	if !l.HasDebuggedOnce("once-key") {
+		t.Fatal("expected HasDebuggedOnce true")
+	}
+
+	l.LogSynchronous(level.Error, "sync error", Pairs{
+		"err":   errors.New("boom"),
+		"label": stringerVal{s: "has space"},
+		"plain": "x",
+	})
+	out := buf.String()
+	if !strings.Contains(out, "sync error") || !strings.Contains(out, "boom") {
+		t.Fatalf("output = %q", out)
+	}
+	if !strings.Contains(out, `"has space"`) {
+		t.Fatalf("expected quoted stringer value in %q", out)
+	}
+}
+
+func TestLoggerAsyncMode(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	l := StreamLogger(buf, level.Info)
+	l.SetLogAsynchronous(true)
+	l.Info("async entry", nil)
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for buf.Len() == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if buf.Len() == 0 {
+		t.Fatal("expected async log output")
+	}
+}
+
+func TestQuoteAsNeeded(t *testing.T) {
+	t.Parallel()
+
+	if quoteAsNeeded("plain") != "plain" {
+		t.Fatal("expected unquoted plain value")
+	}
+	if quoteAsNeeded(`has space`) != `"has space"` {
+		t.Fatalf("quoteAsNeeded = %q", quoteAsNeeded(`has space`))
+	}
+}
+
+func TestGetCallerSkipsLoggingFrames(t *testing.T) {
+	t.Parallel()
+
+	if got := getCaller(0); got != "" {
+		t.Fatalf("caller = %q, want empty when invoked from logging tests", got)
+	}
+}
+
+func TestLoggerCloseWithoutCloser(t *testing.T) {
+	t.Parallel()
+
+	l := ConsoleLogger(level.Info)
+	l.Close()
+}
+
+func TestLogWithTrimmedEvent(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	l := StreamLogger(buf, level.Info)
+	l.SetLogAsynchronous(false)
+	l.Info("  spaced event  ", Pairs{"k": fmt.Sprintf("%v", 1)})
+	if !strings.Contains(buf.String(), `event="spaced event"`) {
+		t.Fatalf("output = %q", buf.String())
+	}
+}
+
+func TestStreamLoggerWithCloser(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	sl := StreamLogger(w, level.Error)
+	sl.SetLogAsynchronous(false)
+	sl.ErrorSynchronous("sync", nil)
+	if w.Body.Len() == 0 {
+		t.Fatal("expected synchronous error output")
+	}
+	sl.Close()
+}

--- a/pkg/observability/tracing/options/options_extended_test.go
+++ b/pkg/observability/tracing/options/options_extended_test.go
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package options
+
+import (
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestSanitizeSampleRate(t *testing.T) {
+	t.Parallel()
+
+	o := &Options{}
+	o.SanitizeSampleRate()
+	if o.SampleRate == nil || *o.SampleRate != 1.0 {
+		t.Fatalf("SampleRate = %v", o.SampleRate)
+	}
+
+	rate := -1.0
+	o = &Options{SampleRate: &rate}
+	o.SanitizeSampleRate()
+	if *o.SampleRate != 0.0 {
+		t.Fatalf("SampleRate = %v", *o.SampleRate)
+	}
+
+	rate = 0.5
+	o = &Options{SampleRate: &rate}
+	o.SanitizeSampleRate()
+	if *o.SampleRate != 0.5 {
+		t.Fatalf("SampleRate = %v", *o.SampleRate)
+	}
+}
+
+func TestProcessTracingOptionsDefaults(t *testing.T) {
+	t.Parallel()
+
+	o := &Options{}
+	ProcessTracingOptions(Lookup{"trace": o})
+	if o.ServiceName != DefaultTracerServiceName {
+		t.Fatalf("ServiceName = %q", o.ServiceName)
+	}
+	if o.Provider != DefaultTracerProvider {
+		t.Fatalf("Provider = %q", o.Provider)
+	}
+	if o.SampleRate == nil || *o.SampleRate != 1.0 {
+		t.Fatalf("SampleRate = %v", o.SampleRate)
+	}
+}
+
+func TestCloneCopiesNestedFields(t *testing.T) {
+	t.Parallel()
+
+	rate := 0.25
+	base := New()
+	o := &Options{
+		Endpoint:     "collector:4317",
+		Timeout:      2 * time.Second,
+		SampleRate:   &rate,
+		Tags:         map[string]string{"env": "test"},
+		OmitTagsList: []string{"drop-me"},
+		StdOutOptions: base.StdOutOptions,
+	}
+	cl := o.Clone()
+	if cl == o {
+		t.Fatal("expected distinct clone")
+	}
+	cl.Tags["env"] = "changed"
+	if o.Tags["env"] != "test" {
+		t.Fatal("clone should not share tags map")
+	}
+}
+
+func TestLookupValidate(t *testing.T) {
+	t.Parallel()
+
+	l := Lookup{"default": New()}
+	if err := l.Validate(); err != nil {
+		t.Fatalf("Lookup.Validate: %v", err)
+	}
+	if l["default"].Name != "default" {
+		t.Fatalf("Name = %q", l["default"].Name)
+	}
+}
+
+func TestUnmarshalYAML(t *testing.T) {
+	t.Parallel()
+
+	const raw = `
+tracing:
+  default:
+    provider: stdout
+    service_name: trickster-test
+    sample_rate: 0.5
+    omit_tags: [internal]
+`
+	type doc struct {
+		Tracing Lookup `yaml:"tracing"`
+	}
+	var d doc
+	if err := yaml.Unmarshal([]byte(raw), &d); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	o := d.Tracing["default"]
+	if o == nil || o.ServiceName != "trickster-test" {
+		t.Fatalf("unexpected tracing options: %+v", o)
+	}
+	if o.SampleRate == nil || *o.SampleRate != 0.5 {
+		t.Fatalf("SampleRate = %v", o.SampleRate)
+	}
+}

--- a/pkg/proxy/authenticator/cred/cred.go
+++ b/pkg/proxy/authenticator/cred/cred.go
@@ -29,6 +29,8 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+const cryptSaltAlphabet = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
 var ErrUnauthorized = errors.New("unauthorized")
 
 // VerifyPassword verifies a password against a stored hash
@@ -153,7 +155,7 @@ func verifySHACryptHash(
 	if len(parts) < 4 {
 		return errors.New("invalid SHA-Crypt hash format")
 	}
-	if parts[1] != strings.TrimPrefix(magicPrefix, "$") {
+	if parts[1] != strings.TrimSuffix(strings.TrimPrefix(magicPrefix, "$"), "$") {
 		return errors.New("hash magic prefix mismatch")
 	}
 	var salt string
@@ -308,7 +310,6 @@ func computeAndCompareSHACrypt(password, salt string, rounds int, expectedHash s
 
 // apr1Base64Encode encodes the MD5 hash using Apache's base64 variant (Hash64)
 func apr1Base64Encode(data []byte) string {
-	const alphabet = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 	hashSize := (len(data) * 8) / 6
 	if (len(data)*8)%6 != 0 {
 		hashSize++
@@ -320,23 +321,23 @@ func apr1Base64Encode(data []byte) string {
 		switch len(src) {
 		default:
 			// Process 3 bytes -> 4 characters
-			dst[0] = alphabet[src[0]&0x3f]
-			dst[1] = alphabet[((src[0]>>6)|(src[1]<<2))&0x3f]
-			dst[2] = alphabet[((src[1]>>4)|(src[2]<<4))&0x3f]
-			dst[3] = alphabet[(src[2]>>2)&0x3f]
+			dst[0] = cryptSaltAlphabet[src[0]&0x3f]
+			dst[1] = cryptSaltAlphabet[((src[0]>>6)|(src[1]<<2))&0x3f]
+			dst[2] = cryptSaltAlphabet[((src[1]>>4)|(src[2]<<4))&0x3f]
+			dst[3] = cryptSaltAlphabet[(src[2]>>2)&0x3f]
 			src = src[3:]
 			dst = dst[4:]
 		case 2:
 			// Process 2 bytes -> 3 characters
-			dst[0] = alphabet[src[0]&0x3f]
-			dst[1] = alphabet[((src[0]>>6)|(src[1]<<2))&0x3f]
-			dst[2] = alphabet[(src[1]>>4)&0x3f]
+			dst[0] = cryptSaltAlphabet[src[0]&0x3f]
+			dst[1] = cryptSaltAlphabet[((src[0]>>6)|(src[1]<<2))&0x3f]
+			dst[2] = cryptSaltAlphabet[(src[1]>>4)&0x3f]
 			src = src[2:]
 			dst = dst[3:]
 		case 1:
 			// Process 1 byte -> 2 characters
-			dst[0] = alphabet[src[0]&0x3f]
-			dst[1] = alphabet[(src[0]>>6)&0x3f]
+			dst[0] = cryptSaltAlphabet[src[0]&0x3f]
+			dst[1] = cryptSaltAlphabet[(src[0]>>6)&0x3f]
 			src = src[1:]
 			dst = dst[2:]
 		}

--- a/pkg/proxy/authenticator/cred/cred_test.go
+++ b/pkg/proxy/authenticator/cred/cred_test.go
@@ -1,0 +1,431 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cred
+
+import (
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"hash"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+func randomBytes(t *testing.T, n int) []byte {
+	t.Helper()
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	return b
+}
+
+func randomPassword(t *testing.T) string {
+	t.Helper()
+	return base64.RawStdEncoding.EncodeToString(randomBytes(t, 16))
+}
+
+func randomSalt(t *testing.T, n int) string {
+	t.Helper()
+	b := randomBytes(t, n)
+	for i, v := range b {
+		b[i] = cryptSaltAlphabet[int(v)%len(cryptSaltAlphabet)]
+	}
+	return string(b)
+}
+
+func generateMD5CryptHash(password, magicPrefix, salt string) string {
+	pwBytes := []byte(password)
+	saltBytes := []byte(salt)
+	pwLen := len(pwBytes)
+	b := md5.New()
+	b.Write(pwBytes)
+	b.Write(saltBytes)
+	b.Write(pwBytes)
+	bsum := b.Sum(nil)
+	a := md5.New()
+	a.Write(pwBytes)
+	a.Write([]byte(magicPrefix))
+	a.Write(saltBytes)
+	cnt := pwLen
+	for ; cnt > 16; cnt -= 16 {
+		a.Write(bsum)
+	}
+	a.Write(bsum[0:cnt])
+	for cnt = pwLen; cnt > 0; cnt >>= 1 {
+		if (cnt & 1) == 0 {
+			a.Write(pwBytes[0:1])
+		} else {
+			a.Write([]byte{0})
+		}
+	}
+	asum := a.Sum(nil)
+	csum := asum
+	for round := range 1000 {
+		c := md5.New()
+		if (round & 1) != 0 {
+			c.Write(pwBytes)
+		} else {
+			c.Write(csum)
+		}
+		if (round % 3) != 0 {
+			c.Write(saltBytes)
+		}
+		if (round % 7) != 0 {
+			c.Write(pwBytes)
+		}
+		if (round & 1) == 0 {
+			c.Write(pwBytes)
+		} else {
+			c.Write(csum)
+		}
+		csum = c.Sum(nil)
+	}
+	reordered := []byte{
+		csum[12], csum[6], csum[0],
+		csum[13], csum[7], csum[1],
+		csum[14], csum[8], csum[2],
+		csum[15], csum[9], csum[3],
+		csum[5], csum[10], csum[4],
+		csum[11],
+	}
+	magic := strings.TrimPrefix(magicPrefix, "$")
+	magic = strings.TrimSuffix(magic, "$")
+	return fmt.Sprintf("$%s$%s$%s", magic, salt, apr1Base64Encode(reordered))
+}
+
+func generateSHACryptHash(
+	password, magicPrefix, salt string,
+	rounds int,
+	hashFunc func() hash.Hash,
+	hashSize int,
+) string {
+	key := []byte(password)
+	saltBytes := []byte(salt)
+	keyLen := len(key)
+	saltLen := len(saltBytes)
+	if saltLen > 16 {
+		saltBytes = saltBytes[:16]
+		saltLen = 16
+	}
+	b := hashFunc()
+	b.Write(key)
+	b.Write(saltBytes)
+	b.Write(key)
+	bsum := b.Sum(nil)
+	a := hashFunc()
+	a.Write(key)
+	a.Write(saltBytes)
+	cnt := keyLen
+	for ; cnt > hashSize; cnt -= hashSize {
+		a.Write(bsum)
+	}
+	a.Write(bsum[0:cnt])
+	for cnt = keyLen; cnt > 0; cnt >>= 1 {
+		if (cnt & 1) != 0 {
+			a.Write(bsum)
+		} else {
+			a.Write(key)
+		}
+	}
+	asum := a.Sum(nil)
+	p := hashFunc()
+	for range keyLen {
+		p.Write(key)
+	}
+	psum := p.Sum(nil)
+	pseq := make([]byte, 0, keyLen)
+	for cnt = keyLen; cnt > hashSize; cnt -= hashSize {
+		pseq = append(pseq, psum...)
+	}
+	pseq = append(pseq, psum[0:cnt]...)
+	s := hashFunc()
+	for range 16 + int(asum[0]) {
+		s.Write(saltBytes)
+	}
+	ssum := s.Sum(nil)
+	sseq := make([]byte, 0, saltLen)
+	for cnt = saltLen; cnt > hashSize; cnt -= hashSize {
+		sseq = append(sseq, ssum...)
+	}
+	sseq = append(sseq, ssum[0:cnt]...)
+	csum := asum
+	for round := range rounds {
+		c := hashFunc()
+		if (round & 1) != 0 {
+			c.Write(pseq)
+		} else {
+			c.Write(csum)
+		}
+		if (round % 3) != 0 {
+			c.Write(sseq)
+		}
+		if (round % 7) != 0 {
+			c.Write(pseq)
+		}
+		if (round & 1) != 0 {
+			c.Write(csum)
+		} else {
+			c.Write(pseq)
+		}
+		csum = c.Sum(nil)
+	}
+	var reordered []byte
+	if hashSize == 32 {
+		reordered = []byte{
+			csum[20], csum[10], csum[0],
+			csum[11], csum[1], csum[21],
+			csum[2], csum[22], csum[12],
+			csum[23], csum[13], csum[3],
+			csum[14], csum[4], csum[24],
+			csum[5], csum[25], csum[15],
+			csum[26], csum[16], csum[6],
+			csum[17], csum[7], csum[27],
+			csum[8], csum[28], csum[18],
+			csum[29], csum[19], csum[9],
+			csum[30], csum[31],
+		}
+	} else {
+		reordered = []byte{
+			csum[42], csum[21], csum[0],
+			csum[1], csum[43], csum[22],
+			csum[23], csum[2], csum[44],
+			csum[45], csum[24], csum[3],
+			csum[4], csum[46], csum[25],
+			csum[26], csum[5], csum[47],
+			csum[48], csum[27], csum[6],
+			csum[7], csum[49], csum[28],
+			csum[29], csum[8], csum[50],
+			csum[51], csum[30], csum[9],
+			csum[10], csum[52], csum[31],
+			csum[32], csum[11], csum[53],
+			csum[54], csum[33], csum[12],
+			csum[13], csum[55], csum[34],
+			csum[35], csum[14], csum[56],
+			csum[57], csum[36], csum[15],
+			csum[16], csum[58], csum[37],
+			csum[38], csum[17], csum[59],
+			csum[60], csum[39], csum[18],
+			csum[19], csum[61], csum[40],
+			csum[41], csum[20], csum[62],
+			csum[63],
+		}
+	}
+	magic := strings.TrimSuffix(strings.TrimPrefix(magicPrefix, "$"), "$")
+	encoded := apr1Base64Encode(reordered)
+	if rounds != 5000 {
+		return fmt.Sprintf("$%s$rounds=%d$%s$%s", magic, rounds, salt, encoded)
+	}
+	return fmt.Sprintf("$%s$%s$%s", magic, salt, encoded)
+}
+
+func generateBcryptHash(t *testing.T, password string) string {
+	t.Helper()
+	h, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("bcrypt.GenerateFromPassword: %v", err)
+	}
+	return string(h)
+}
+
+type credentialCase struct {
+	name     string
+	generate func(t *testing.T, password string) string
+}
+
+func TestVerifyPassword_SupportedFormats(t *testing.T) {
+	t.Parallel()
+
+	cases := []credentialCase{
+		{
+			name: "plaintext",
+			generate: func(_ *testing.T, password string) string {
+				return password
+			},
+		},
+		{
+			name: "md5-crypt",
+			generate: func(_ *testing.T, password string) string {
+				return generateMD5CryptHash(password, "$1$", randomSalt(t, 8))
+			},
+		},
+		{
+			name: "apr1",
+			generate: func(_ *testing.T, password string) string {
+				return generateMD5CryptHash(password, "$apr1$", randomSalt(t, 8))
+			},
+		},
+		{
+			name: "sha256-crypt",
+			generate: func(_ *testing.T, password string) string {
+				return generateSHACryptHash(password, "$5$", randomSalt(t, 8), 5000, sha256.New, 32)
+			},
+		},
+		{
+			name: "sha256-crypt-with-rounds",
+			generate: func(_ *testing.T, password string) string {
+				return generateSHACryptHash(password, "$5$", randomSalt(t, 8), 8000, sha256.New, 32)
+			},
+		},
+		{
+			name: "sha512-crypt",
+			generate: func(_ *testing.T, password string) string {
+				return generateSHACryptHash(password, "$6$", randomSalt(t, 8), 5000, sha512.New, 64)
+			},
+		},
+		{
+			name: "bcrypt",
+			generate: func(t *testing.T, password string) string {
+				return generateBcryptHash(t, password)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			password := randomPassword(t)
+			hash := tc.generate(t, password)
+
+			if err := VerifyPassword(hash, password); err != nil {
+				t.Fatalf("VerifyPassword(valid): %v", err)
+			}
+
+			wrong := randomPassword(t)
+			for wrong == password {
+				wrong = randomPassword(t)
+			}
+			if err := VerifyPassword(hash, wrong); err == nil {
+				t.Fatal("expected error for wrong password")
+			}
+		})
+	}
+}
+
+func TestVerifyPassword_ErrUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	hash := randomPassword(t)
+	wrong := randomPassword(t)
+	for wrong == hash {
+		wrong = randomPassword(t)
+	}
+
+	if err := VerifyPassword(hash, wrong); !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("expected ErrUnauthorized, got %v", err)
+	}
+}
+
+func TestVerifyPassword_BcryptWrongPassword(t *testing.T) {
+	t.Parallel()
+
+	password := randomPassword(t)
+	hash := generateBcryptHash(t, password)
+	wrong := randomPassword(t)
+	for wrong == password {
+		wrong = randomPassword(t)
+	}
+
+	err := VerifyPassword(hash, wrong)
+	if err == nil {
+		t.Fatal("expected bcrypt mismatch error")
+	}
+	if errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("expected bcrypt error, got ErrUnauthorized")
+	}
+}
+
+func TestVerifyPassword_InvalidHashFormats(t *testing.T) {
+	t.Parallel()
+
+	password := randomPassword(t)
+	cases := []struct {
+		name string
+		hash string
+	}{
+		{name: "md5-too-few-parts", hash: "$1$onlysalt"},
+		{name: "sha256-too-few-parts", hash: "$5$onlysalt"},
+		{name: "sha256-bad-rounds", hash: "$5$rounds=abc$" + randomSalt(t, 8) + "$deadbeef"},
+		{name: "sha256-missing-hash-with-rounds", hash: "$5$rounds=5000$" + randomSalt(t, 8)},
+		{name: "sha512-missing-hash", hash: "$6$" + randomSalt(t, 8)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if err := VerifyPassword(tc.hash, password); err == nil {
+				t.Fatal("expected error for invalid hash format")
+			}
+		})
+	}
+}
+
+func TestVerifyPassword_SHACryptCustomRounds(t *testing.T) {
+	t.Parallel()
+
+	password := randomPassword(t)
+	hash := generateSHACryptHash(password, "$5$", randomSalt(t, 8), 8000, sha256.New, 32)
+	if err := VerifyPassword(hash, password); err != nil {
+		t.Fatalf("VerifyPassword(custom rounds): %v", err)
+	}
+}
+
+func TestApr1Base64Encode(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		input    []byte
+		expected string
+	}{
+		{
+			name:     "three-bytes",
+			input:    []byte{0x00, 0x00, 0x00},
+			expected: "....",
+		},
+		{
+			name:     "two-bytes",
+			input:    []byte{0x00, 0x00},
+			expected: "...",
+		},
+		{
+			name:     "one-byte",
+			input:    []byte{0x00},
+			expected: "..",
+		},
+		{
+			name:     "five-bytes",
+			input:    []byte{0x01, 0x02, 0x03, 0x04, 0x05},
+			expected: "/6k.2I.",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := apr1Base64Encode(tc.input); got != tc.expected {
+				t.Fatalf("apr1Base64Encode() = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/proxy/authenticator/loaders/csv/csv_test.go
+++ b/pkg/proxy/authenticator/loaders/csv/csv_test.go
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package csv
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/types"
+)
+
+func TestLoadCSVWithHeader(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "users.csv")
+	content := "username,password\n alice , secret \n bob,hash\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	users, err := LoadCSV(path, types.CSV)
+	if err != nil {
+		t.Fatalf("LoadCSV: %v", err)
+	}
+	if users["alice"] != "secret" || users["bob"] != "hash" {
+		t.Fatalf("users = %+v", users)
+	}
+}
+
+func TestLoadCSVNoHeader(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "users.csv")
+	if err := os.WriteFile(path, []byte("alice,secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	users, err := LoadCSV(path, types.CSVNoHeader)
+	if err != nil {
+		t.Fatalf("LoadCSV: %v", err)
+	}
+	if users["alice"] != "secret" {
+		t.Fatalf("users = %+v", users)
+	}
+}
+
+func TestLoadCSVSkipsHeaderRow(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "users.csv")
+	content := "username,password\nbob,hash\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	users, err := LoadCSV(path, types.CSV)
+	if err != nil {
+		t.Fatalf("LoadCSV: %v", err)
+	}
+	if len(users) != 1 || users["bob"] != "hash" {
+		t.Fatalf("users = %+v", users)
+	}
+}
+
+func TestLoadCSVOpenError(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadCSV(filepath.Join(t.TempDir(), "missing.csv"), types.CSV)
+	if err == nil {
+		t.Fatal("expected open error")
+	}
+}
+
+func TestLoadCSVMalformedFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "bad.csv")
+	if err := os.WriteFile(path, []byte("\"unclosed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadCSV(path, types.CSVNoHeader)
+	if err == nil {
+		t.Fatal("expected csv parse error")
+	}
+}

--- a/pkg/proxy/authenticator/providers/basic/basic_test.go
+++ b/pkg/proxy/authenticator/providers/basic/basic_test.go
@@ -19,13 +19,17 @@ package basic
 import (
 	"fmt"
 	"maps"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
 	ct "github.com/trickstercache/trickster/v2/pkg/config/types"
+	pkgerrors "github.com/trickstercache/trickster/v2/pkg/errors"
+	authopt "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/types"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -226,5 +230,175 @@ func TestAddUsers_MergeLogic(t *testing.T) {
 	_, err = a.Authenticate(req)
 	if err != nil {
 		t.Error(err)
+	}
+}
+
+func TestNewPtr(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewPtr(nil)
+	if err != pkgerrors.ErrInvalidOptions {
+		t.Fatalf("NewPtr(nil) = %v, want ErrInvalidOptions", err)
+	}
+
+	opts := authopt.New()
+	opts.Name = "default-realm"
+	opts.Users = ct.EnvStringMap{testUser1: bcryptHash(testUser1p)}
+	a, err := NewPtr(map[string]any{"options": opts})
+	if err != nil {
+		t.Fatalf("NewPtr: %v", err)
+	}
+	if a.realm != "default-realm" {
+		t.Fatalf("realm = %q", a.realm)
+	}
+
+	opts = authopt.New()
+	opts.ProviderData = map[string]any{
+		showLoginFormField: true,
+		realmField:         "Protected Area",
+	}
+	opts.Users = ct.EnvStringMap{testUser1: bcryptHash(testUser1p)}
+	a, err = NewPtr(map[string]any{"options": opts})
+	if err != nil {
+		t.Fatalf("NewPtr with login form: %v", err)
+	}
+	if !a.showLoginForm || a.realm != "Protected Area" {
+		t.Fatalf("showLoginForm=%v realm=%q", a.showLoginForm, a.realm)
+	}
+}
+
+func TestAuthenticateObserveOnly(t *testing.T) {
+	t.Parallel()
+
+	a := &Authenticator{observeOnly: true}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.SetBasicAuth(testUser1, testUser1p)
+	ar, err := a.Authenticate(req)
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if ar.Status != types.AuthObserved || ar.Username != testUser1 {
+		t.Fatalf("AuthResult = %+v", ar)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	ar, err = a.Authenticate(req)
+	if err != nil {
+		t.Fatalf("Authenticate without creds: %v", err)
+	}
+	if ar.Status != types.AuthObserved || ar.Username != "" {
+		t.Fatalf("AuthResult = %+v", ar)
+	}
+}
+
+func TestAuthenticateLoginFormFailureHeaders(t *testing.T) {
+	t.Parallel()
+
+	a := &Authenticator{showLoginForm: true, realm: "Test Realm"}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	ar, err := a.Authenticate(req)
+	if err == nil {
+		t.Fatal("expected auth failure")
+	}
+	if ar == nil || ar.ResponseHeaders[headers.NameWWWAuthenticate] != `Basic realm="Test Realm"` {
+		t.Fatalf("ResponseHeaders = %+v", ar)
+	}
+}
+
+func TestCloneAndSanitize(t *testing.T) {
+	t.Parallel()
+
+	a := &Authenticator{
+		users:         types.CredentialsManifest{testUser1: bcryptHash(testUser1p)},
+		showLoginForm: true,
+		realm:         "realm",
+		proxyPreserve: false,
+	}
+	cl := a.ClonePtr()
+	if cl == a {
+		t.Fatal("ClonePtr should produce independent copy")
+	}
+	cl.users[testUser1] = "changed"
+	if a.users[testUser1] == "changed" {
+		t.Fatal("ClonePtr should not share users map")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(headers.NameAuthorization, "Basic abc")
+	a.Sanitize(req)
+	if req.Header.Get(headers.NameAuthorization) != "" {
+		t.Fatal("expected Authorization header to be removed")
+	}
+
+	a.proxyPreserve = true
+	req.Header.Set(headers.NameAuthorization, "Basic abc")
+	a.Sanitize(req)
+	if req.Header.Get(headers.NameAuthorization) == "" {
+		t.Fatal("expected Authorization header to be preserved")
+	}
+}
+
+func TestCustomCredentialFuncs(t *testing.T) {
+	t.Parallel()
+
+	a := &Authenticator{}
+	a.SetExtractCredentialsFunc(func(_ *http.Request) (string, string, error) {
+		return testUser1, testUser1p, nil
+	})
+	a.AddUser(testUser1, bcryptHash(testUser1p))
+
+	u, p, err := a.ExtractCredentials(httptest.NewRequest(http.MethodGet, "/", nil))
+	if err != nil || u != testUser1 || p != testUser1p {
+		t.Fatalf("ExtractCredentials = (%q, %q, %v)", u, p, err)
+	}
+
+	a.SetSetCredentialsFunc(func(r *http.Request, user, credential string) error {
+		r.Header.Set("X-Auth-User", user)
+		r.Header.Set("X-Auth-Pass", credential)
+		return nil
+	})
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	if err := a.SetCredentials(req, testUser1, testUser1p); err != nil {
+		t.Fatalf("SetCredentials: %v", err)
+	}
+	if req.Header.Get("X-Auth-User") != testUser1 {
+		t.Fatalf("X-Auth-User = %q", req.Header.Get("X-Auth-User"))
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	if err := (&Authenticator{}).SetCredentials(req, testUser1, testUser1p); err != nil {
+		t.Fatalf("SetCredentials default: %v", err)
+	}
+	u, p, ok := req.BasicAuth()
+	if !ok || u != testUser1 || p != testUser1p {
+		t.Fatalf("BasicAuth = (%q, %q, %v)", u, p, ok)
+	}
+}
+
+func TestCloneAndRegistryEntry(t *testing.T) {
+	t.Parallel()
+
+	a := &Authenticator{realm: "realm"}
+	if _, ok := a.Clone().(*Authenticator); !ok {
+		t.Fatal("Clone should return *Authenticator")
+	}
+	if RegistryEntry().Provider != ID {
+		t.Fatalf("RegistryEntry provider = %q", RegistryEntry().Provider)
+	}
+	if _, err := New(map[string]any{"options": authopt.New()}); err != nil {
+		t.Fatalf("New: %v", err)
+	}
+}
+
+func TestProxyPreserveAndObserveOnlyFlags(t *testing.T) {
+	t.Parallel()
+
+	a := &Authenticator{proxyPreserve: true}
+	if !a.ProxyPreserve() {
+		t.Fatal("expected ProxyPreserve true")
+	}
+	a.SetObserveOnly(true)
+	if !a.IsObserveOnly() {
+		t.Fatal("expected observe-only true")
 	}
 }

--- a/pkg/proxy/handlers/health/health_status_test.go
+++ b/pkg/proxy/handlers/health/health_status_test.go
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package health
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/backends"
+	"github.com/trickstercache/trickster/v2/pkg/backends/alb"
+	uropt "github.com/trickstercache/trickster/v2/pkg/backends/alb/mech/ur/options"
+	ao "github.com/trickstercache/trickster/v2/pkg/backends/alb/options"
+	"github.com/trickstercache/trickster/v2/pkg/backends/alb/names"
+	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
+	ho "github.com/trickstercache/trickster/v2/pkg/backends/healthcheck/options"
+	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
+	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+)
+
+type stubHealthChecker struct {
+	statuses healthcheck.StatusLookup
+	subCh    chan bool
+}
+
+func (s *stubHealthChecker) Register(string, string, *ho.Options, *http.Client) (*healthcheck.Status, error) {
+	return &healthcheck.Status{}, nil
+}
+func (s *stubHealthChecker) RegisterVirtual(string, string) *healthcheck.Status {
+	return &healthcheck.Status{}
+}
+func (s *stubHealthChecker) Unregister(string) {}
+func (s *stubHealthChecker) Status(string) *healthcheck.Status { return nil }
+func (s *stubHealthChecker) Statuses() healthcheck.StatusLookup { return s.statuses }
+func (s *stubHealthChecker) Shutdown() {
+	if s.subCh != nil {
+		s.subCh <- true
+	}
+}
+func (s *stubHealthChecker) Subscribe(ch chan bool) { s.subCh = ch }
+
+type configBackend struct {
+	mockBackend
+	cfg *bo.Options
+}
+
+func (b *configBackend) Configuration() *bo.Options { return b.cfg }
+
+func fixedNow() func() time.Time {
+	tm := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	return func() time.Time { return tm }
+}
+
+func TestStatusHandlerNilHealthChecker(t *testing.T) {
+	if got := StatusHandler(time.Now, nil, nil); got != nil {
+		t.Fatal("expected nil handler for nil health checker")
+	}
+}
+
+func TestHealthStatusFormats(t *testing.T) {
+	t.Parallel()
+
+	bs := backendStatus{
+		Name:                    "alb1",
+		Provider:                providers.ALB,
+		Mechanism:               names.MechanismRR,
+		AvailablePoolMembers:    []string{"a"},
+		UnavailablePoolMembers:  []string{"b"},
+		UncheckedPoolMembers:    []string{"c"},
+		InitializingPoolMembers: []string{"d"},
+	}
+	hs := &healthStatus{
+		Title:      title,
+		UpdateTime: "2024-06-01 12:00:00UTC",
+		Unavailable: []backendStatus{{
+			Name:      "down",
+			Provider:  providers.Prometheus,
+			DownSince: "2024-06-01 11:00:00UTC",
+			Detail:    "connection refused",
+		}},
+		Available:    []backendStatus{bs, {Name: "up", Provider: providers.Prometheus}},
+		Initializing: []backendStatus{{Name: "init", Provider: providers.Prometheus}},
+		Unchecked:    []backendStatus{{Name: "nc", Provider: providers.Prometheus}},
+	}
+
+	if hs.String() == "" {
+		t.Fatal("String() should delegate to Tabular")
+	}
+	if !strings.Contains(hs.JSON(), `"title":"Trickster Backend Health Status"`) {
+		t.Fatalf("JSON() unexpected: %s", hs.JSON())
+	}
+	if !strings.Contains(hs.YAML(), "title:") {
+		t.Fatalf("YAML() unexpected: %s", hs.YAML())
+	}
+
+	tab := hs.Tabular()
+	for _, want := range []string{
+		"down", "available", "unavailable since",
+		"initializing", "not configured for automated health checks",
+		"alb (rr)", "a:[a]", "u:[b]", "nc:[c]",
+	} {
+		if !strings.Contains(tab, want) {
+			t.Errorf("Tabular() missing %q in:\n%s", want, tab)
+		}
+	}
+}
+
+func TestUpdateStatusTextBackendsAndALB(t *testing.T) {
+	t.Parallel()
+
+	now := fixedNow()
+	passing := healthcheck.NewStatus("member-up", providers.Prometheus, "", healthcheck.StatusPassing, time.Time{}, nil)
+	failing := healthcheck.NewStatus("member-down", providers.Prometheus, "", healthcheck.StatusFailing, now().Add(-time.Hour), nil)
+	failing.SetDetail("timeout")
+	unchecked := healthcheck.NewStatus("member-nc", providers.Prometheus, "", healthcheck.StatusUnchecked, time.Time{}, nil)
+	init := healthcheck.NewStatus("member-init", providers.Prometheus, "", healthcheck.StatusInitializing, time.Time{}, nil)
+
+	rpOpts := bo.New()
+	rpOpts.Provider = providers.ReverseProxyShort
+	rpOpts.OriginURL = "http://example.com"
+	rpOpts.HealthCheck = &ho.Options{Interval: time.Minute}
+
+	noProbeOpts := bo.New()
+	noProbeOpts.Provider = providers.ReverseProxyShort
+	noProbeOpts.OriginURL = "http://example.com"
+	noProbeOpts.HealthCheck = &ho.Options{Interval: 0}
+
+	albOpts := bo.New()
+	albOpts.Provider = providers.ALB
+	albOpts.ALBOptions = ao.New()
+	albOpts.ALBOptions.MechanismName = names.MechanismRR
+	albOpts.ALBOptions.Pool = []string{"member-up", "member-down", "member-nc", "member-init"}
+
+	albClient, err := alb.NewClient("edge", albOpts, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	hc := &stubHealthChecker{statuses: healthcheck.StatusLookup{
+		"rp-up":      passing,
+		"rp-down":    failing,
+		"member-up":  passing,
+		"member-down": failing,
+		"member-nc":  unchecked,
+		"member-init": init,
+	}}
+	hd := &healthDetail{}
+	bes := backends.Backends{
+		"rp-up":   &configBackend{mockBackend: mockBackend{name: "rp-up"}, cfg: rpOpts},
+		"rp-down": &configBackend{mockBackend: mockBackend{name: "rp-down"}, cfg: rpOpts},
+		"no-probe": &configBackend{mockBackend: mockBackend{name: "no-probe"}, cfg: noProbeOpts},
+		"edge":    albClient,
+		"virtual-alb": &configBackend{
+			mockBackend: mockBackend{name: "virtual-alb"},
+			cfg:         &bo.Options{Provider: providers.ALB},
+		},
+	}
+
+	updateStatusText(now, hc, hd, bes)
+	d := hd.detail.Load()
+	if d == nil {
+		t.Fatal("expected detail to be stored")
+	}
+	if !strings.Contains(d.text, "member-up") || !strings.Contains(d.text, "member-down") {
+		t.Fatalf("ALB pool detail missing members: %s", d.text)
+	}
+	if !strings.Contains(d.text, "no-probe") {
+		t.Fatalf("expected unchecked backend without probe interval: %s", d.text)
+	}
+	if strings.Contains(d.json, "virtual-alb") {
+		t.Fatalf("virtual ALB should not appear as plain backend entry: %s", d.json)
+	}
+	if !strings.Contains(d.json, `"name":"edge"`) {
+		t.Fatalf("expected ALB section for edge: %s", d.json)
+	}
+}
+
+func TestUpdateStatusTextUserRouterPool(t *testing.T) {
+	t.Parallel()
+
+	now := fixedNow()
+	member := healthcheck.NewStatus("tenant-a", providers.ReverseProxyShort, "", healthcheck.StatusPassing, time.Time{}, nil)
+
+	albOpts := bo.New()
+	albOpts.Provider = providers.ALB
+	albOpts.ALBOptions = ao.New()
+	albOpts.ALBOptions.MechanismName = names.MechanismUR
+	albOpts.ALBOptions.UserRouter = &uropt.Options{
+		DefaultBackend: "tenant-a",
+		Users: uropt.UserMappingOptionsByUser{
+			"alice": {ToBackend: "tenant-a"},
+		},
+	}
+
+	albClient, err := alb.NewClient("ur-edge", albOpts, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	hc := &stubHealthChecker{statuses: healthcheck.StatusLookup{"tenant-a": member}}
+	hd := &healthDetail{}
+	updateStatusText(now, hc, hd, backends.Backends{"ur-edge": albClient})
+
+	d := hd.detail.Load()
+	if !strings.Contains(d.text, "ur-edge") || !strings.Contains(d.text, "tenant-a") {
+		t.Fatalf("expected user-router pool member in output: %s", d.text)
+	}
+}
+
+func TestStatusHandlerContentNegotiation(t *testing.T) {
+	hc := &stubHealthChecker{statuses: healthcheck.StatusLookup{
+		"backend": healthcheck.NewStatus("backend", providers.Prometheus, "", healthcheck.StatusPassing, time.Time{}, nil),
+	}}
+	handler := StatusHandler(fixedNow(), hc, nil)
+	if handler == nil {
+		t.Fatal("expected handler")
+	}
+
+	t.Run("yaml query param", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/?yaml", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if ct := w.Header().Get(headers.NameContentType); ct != headers.ValueTextYAML {
+			t.Fatalf("content-type = %q, want yaml", ct)
+		}
+		if !strings.HasPrefix(w.Body.String(), "title:") {
+			t.Fatalf("expected yaml body, got %q", w.Body.String())
+		}
+	})
+
+	t.Run("not modified", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set(headers.NameIfModifiedSince, fixedNow()().Format(time.RFC1123))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusNotModified {
+			t.Fatalf("status = %d, want 304", w.Code)
+		}
+	})
+
+	t.Run("plaintext default", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if !strings.Contains(w.Body.String(), "Trickster Backend Health Status") {
+			t.Fatalf("expected plaintext tabular body, got %q", w.Body.String())
+		}
+	})
+}
+
+func TestStatusHelpers(t *testing.T) {
+	t.Parallel()
+
+	if got := statusToString(healthcheck.StatusPassing, false); got != "available" {
+		t.Fatalf("passing = %q", got)
+	}
+	if got := statusToString(healthcheck.StatusFailing, true); got != "unavailable since" {
+		t.Fatalf("failing since = %q", got)
+	}
+	if got := formatProvider(backendStatus{Provider: providers.ALB, Mechanism: names.MechanismTSM}); got != "alb (tsm)" {
+		t.Fatalf("formatProvider = %q", got)
+	}
+	if got := cleanupDescription(providers.ReverseProxyCache); got != providers.ReverseProxyCacheShort {
+		t.Fatalf("cleanupDescription = %q", got)
+	}
+}

--- a/pkg/proxy/handlers/trickster/purge/purge_handlers_test.go
+++ b/pkg/proxy/handlers/trickster/purge/purge_handlers_test.go
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package purge
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/backends"
+	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
+)
+
+func TestKeyHandler(t *testing.T) {
+	t.Parallel()
+
+	const pathPrefix = "/trickster/purge/key/"
+	cache := newMemCache()
+	bes := backends.Backends{
+		"backend-a": &fakeBackend{
+			cfg:   &bo.Options{Name: "backend-a"},
+			cache: cache,
+		},
+	}
+	h := KeyHandler(pathPrefix, bes)
+
+	t.Run("success", func(t *testing.T) {
+		key := "object-key"
+		if err := cache.Store(key, []byte("v"), 0); err != nil {
+			t.Fatal(err)
+		}
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, pathPrefix+"backend-a/"+key, nil)
+		h(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+		}
+		if _, _, err := cache.Retrieve(key); err == nil {
+			t.Fatal("expected key to be purged")
+		}
+	})
+
+	t.Run("not found path", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, pathPrefix+"backend-a", nil)
+		h(w, r)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("status = %d", w.Code)
+		}
+	})
+
+	t.Run("missing backend", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, pathPrefix+"missing/key", nil)
+		h(w, r)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("missing cache", func(t *testing.T) {
+		bes := backends.Backends{
+			"no-cache": &fakeBackend{cfg: &bo.Options{Name: "no-cache"}, cache: nil},
+		}
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, pathPrefix+"no-cache/key", nil)
+		KeyHandler(pathPrefix, bes)(w, r)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+		}
+	})
+}
+
+func TestPathHandlerValidation(t *testing.T) {
+	t.Parallel()
+
+	const pathPrefix = "/trickster/purge/path/"
+	bes := backends.Backends{
+		"a": &fakeBackend{
+			cfg:   &bo.Options{Name: "a", CacheKeyPrefix: "pfx"},
+			cache: newMemCache(),
+		},
+	}
+
+	t.Run("usage error", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, pathPrefix+"/only-path", nil)
+		PathHandler(pathPrefix, &bes)(w, r)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, pathPrefix, nil)
+		PathHandler(pathPrefix, &bes)(w, r)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("status = %d", w.Code)
+		}
+	})
+
+	t.Run("missing backend", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, pathPrefix+"missing/path", nil)
+		PathHandler(pathPrefix, &bes)(w, r)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+		}
+	})
+}

--- a/pkg/proxy/request/rewriter/options/options_extended_test.go
+++ b/pkg/proxy/request/rewriter/options/options_extended_test.go
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package options
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	o := &Options{Name: ""}
+	if ok, err := o.Validate(); ok || err != ErrInvalidName {
+		t.Fatalf("Validate() = (%v, %v)", ok, err)
+	}
+
+	o = &Options{Name: "rewrite-host"}
+	if ok, err := o.Validate(); !ok || err != nil {
+		t.Fatalf("Validate() = (%v, %v)", ok, err)
+	}
+}
+
+func TestLookupValidate(t *testing.T) {
+	t.Parallel()
+
+	l := Lookup{
+		"rewrite-host": {Instructions: RewriteList{{"set", "Host", "example.com"}}},
+		"skip-nil":     nil,
+	}
+	if err := l.Validate(); err != nil {
+		t.Fatalf("Lookup.Validate: %v", err)
+	}
+	if l["rewrite-host"].Name != "rewrite-host" {
+		t.Fatalf("Name = %q", l["rewrite-host"].Name)
+	}
+
+	l = Lookup{"": &Options{}}
+	if err := l.Validate(); err != ErrInvalidName {
+		t.Fatalf("Lookup.Validate() = %v", err)
+	}
+}
+
+func TestCloneAndInitialize(t *testing.T) {
+	t.Parallel()
+
+	o := &Options{
+		Instructions: RewriteList{
+			{"set", "Host", "example.com"},
+			{"set", "X-Test", "1"},
+		},
+	}
+	cl := o.Clone()
+	if len(cl.Instructions) != 2 || cl.Instructions[0][2] != "example.com" {
+		t.Fatalf("clone instructions = %+v", cl.Instructions)
+	}
+	cl.Instructions[0][2] = "changed"
+	if o.Instructions[0][2] != "example.com" {
+		t.Fatal("clone should not share instruction slice")
+	}
+
+	if err := o.Initialize("ignored"); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+}
+
+func TestUnmarshalYAML(t *testing.T) {
+	t.Parallel()
+
+	const raw = `
+request_rewriters:
+  rewrite-host:
+    instructions:
+      - [set, Host, example.com]
+`
+	type doc struct {
+		Rewriters Lookup `yaml:"request_rewriters"`
+	}
+	var d doc
+	if err := yaml.Unmarshal([]byte(raw), &d); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	o := d.Rewriters["rewrite-host"]
+	if o == nil || len(o.Instructions) != 1 || o.Instructions[0][2] != "example.com" {
+		t.Fatalf("unexpected rewriter: %+v", o)
+	}
+}

--- a/pkg/proxy/response/merge/timeseries_respond_test.go
+++ b/pkg/proxy/response/merge/timeseries_respond_test.go
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package merge
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
+)
+
+func TestTimeseriesMergeFuncErrors(t *testing.T) {
+	t.Parallel()
+
+	accum := NewAccumulator()
+	mf := TimeseriesMergeFunc(func([]byte, *timeseries.TimeRangeQuery) (timeseries.Timeseries, error) {
+		return nil, errors.New("unmarshal failed")
+	})
+	err := mf(accum, []byte("bad"), 0)
+	require.Error(t, err)
+
+	err = mf(accum, 42, 0)
+	require.ErrorContains(t, err, "unexpected data type")
+}
+
+func TestTimeseriesMergeFuncFromBytes(t *testing.T) {
+	t.Parallel()
+
+	ds := makeTestDataSet(0, "up", nil, []int64{100}, []string{"1"})
+	accum := NewAccumulator()
+	fromBytes := TimeseriesMergeFuncFromBytes(func([]byte, *timeseries.TimeRangeQuery) (timeseries.Timeseries, error) {
+		return ds, nil
+	})
+	require.NoError(t, fromBytes(accum, []byte("payload"), 0))
+	require.NotNil(t, accum.GetTSData())
+}
+
+func TestTimeseriesRespondFunc(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil data returns bad gateway", func(t *testing.T) {
+		rf := TimeseriesRespondFunc(func(timeseries.Timeseries, *timeseries.RequestOptions, int, io.Writer) error {
+			return nil
+		}, nil)
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		rf(w, r, NewAccumulator(), 0)
+		require.Equal(t, http.StatusBadGateway, w.Code)
+	})
+
+	t.Run("writes merged data", func(t *testing.T) {
+		accum := NewAccumulator()
+		ds := makeTestDataSet(0, "up", nil, []int64{100}, []string{"1"})
+		require.NoError(t, TimeseriesMergeFunc(nil)(accum, ds, 0))
+
+		var called bool
+		rf := TimeseriesRespondFunc(func(_ timeseries.Timeseries, _ *timeseries.RequestOptions, status int, w io.Writer) error {
+			called = true
+			require.Equal(t, http.StatusOK, status)
+			_, err := w.Write([]byte("ok"))
+			return err
+		}, nil)
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		rf(w, r, accum, 0)
+		require.True(t, called)
+		require.Equal(t, http.StatusOK, w.Code)
+	})
+}
+
+func TestTimeseriesRespondFuncWithStrategy(t *testing.T) {
+	t.Parallel()
+
+	accum := NewAccumulator()
+	ds1 := makeTestDataSet(0, "latency", nil, []int64{100}, []string{"10"})
+	ds2 := makeTestDataSet(0, "latency", nil, []int64{100}, []string{"30"})
+	mf := TimeseriesMergeFuncWithStrategy(nil, int(dataset.MergeStrategyAvg))
+	require.NoError(t, mf(accum, ds1, 0))
+	require.NoError(t, mf(accum, ds2, 1))
+
+	var finalized string
+	rf := TimeseriesRespondFuncWithStrategy(
+		func(ts timeseries.Timeseries, _ *timeseries.RequestOptions, _ int, _ io.Writer) error {
+			ds := ts.(*dataset.DataSet)
+			finalized = ds.Results[0].SeriesList[0].Points[0].Values[0].(string)
+			return nil
+		},
+		nil,
+		int(dataset.MergeStrategyAvg),
+	)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	rf(w, r, accum, 0)
+	require.Equal(t, "20", finalized)
+}

--- a/pkg/timeseries/dataset/csv/csv_test.go
+++ b/pkg/timeseries/dataset/csv/csv_test.go
@@ -1,0 +1,467 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package csv
+
+import (
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/epoch"
+)
+
+func testFieldParser(_ [][]string, _ *timeseries.TimeRangeQuery) (timeseries.SeriesFields, error) {
+	return timeseries.SeriesFields{
+		Timestamp: timeseries.FieldDefinition{
+			Name:           "time",
+			OutputPosition: 2,
+			DataType:       timeseries.Int64,
+			Role:           timeseries.RoleTimestamp,
+		},
+		Tags: timeseries.FieldDefinitions{
+			{
+				Name:           "host",
+				OutputPosition: 1,
+				DataType:       timeseries.String,
+				Role:           timeseries.RoleTag,
+			},
+		},
+		Values: timeseries.FieldDefinitions{
+			{
+				Name:           "value",
+				OutputPosition: 3,
+				DataType:       timeseries.Float64,
+				Role:           timeseries.RoleValue,
+			},
+			{
+				Name:           "count",
+				OutputPosition: 4,
+				DataType:       timeseries.Int64,
+				Role:           timeseries.RoleValue,
+			},
+		},
+		ResultNameCol: 0,
+	}, nil
+}
+
+func testDataTypeParser(string) timeseries.FieldDataType {
+	return timeseries.Unknown
+}
+
+func testTimestampParser(input string, _ timeseries.FieldDefinition) (epoch.Epoch, error) {
+	i, err := strconv.ParseInt(input, 10, 64)
+	return epoch.Epoch(i), err
+}
+
+func testParser(t *testing.T, firstDataRow int) Parser {
+	t.Helper()
+	p, err := NewParser(testFieldParser, testDataTypeParser, testTimestampParser, firstDataRow)
+	if err != nil {
+		t.Fatalf("NewParser: %v", err)
+	}
+	return p
+}
+
+func testMatrix() [][]string {
+	return [][]string{
+		{"result", "host", "time", "value", "count"},
+		{"_result1", "host-a", "1000", "1.5", "10"},
+		{"_result1", "host-b", "2000", "2.5", "20"},
+		{"_result2", "host-a", "3000", "3.5", "30"},
+	}
+}
+
+func testTimeRangeQuery() *timeseries.TimeRangeQuery {
+	return &timeseries.TimeRangeQuery{
+		Extent: timeseries.Extent{
+			Start: time.Unix(0, 1000),
+			End:   time.Unix(0, 3000),
+		},
+		Step: time.Second,
+	}
+}
+
+func TestNewParser(t *testing.T) {
+	t.Parallel()
+
+	fp := testFieldParser
+	dp := testDataTypeParser
+	tp := testTimestampParser
+
+	cases := []struct {
+		name    string
+		fp      FieldParserFunc
+		dp      DataTypeParserFunc
+		tp      TimestampParserFunc
+		first   int
+		wantErr error
+	}{
+		{name: "valid", fp: fp, dp: dp, tp: tp, first: 1},
+		{name: "nil-field-parser", fp: nil, dp: dp, tp: tp, first: 1, wantErr: ErrInvalidFieldParserFunc},
+		{name: "nil-data-type-parser", fp: fp, dp: nil, tp: tp, first: 1, wantErr: ErrInvalidDataTypeParserFunc},
+		{name: "nil-timestamp-parser", fp: fp, dp: dp, tp: nil, first: 1, wantErr: ErrInvalidTimestampParserFunc},
+		{name: "negative-first-data-row-clamped", fp: fp, dp: dp, tp: tp, first: -1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p, err := NewParser(tc.fp, tc.dp, tc.tp, tc.first)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("NewParser() error = %v, want %v", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewParser() unexpected error: %v", err)
+			}
+			if p == nil {
+				t.Fatal("NewParser() returned nil parser")
+			}
+		})
+	}
+}
+
+func TestNewParserMust(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+		p := NewParserMust(testFieldParser, testDataTypeParser, testTimestampParser, 1)
+		if p == nil {
+			t.Fatal("NewParserMust returned nil parser")
+		}
+	})
+
+	t.Run("panics-on-invalid", func(t *testing.T) {
+		t.Parallel()
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("expected panic from NewParserMust")
+			}
+		}()
+		NewParserMust(nil, testDataTypeParser, testTimestampParser, 1)
+	})
+}
+
+func TestParserToDataSet(t *testing.T) {
+	t.Parallel()
+
+	p := testParser(t, 1)
+	ds, err := p.ToDataSet(testMatrix(), testTimeRangeQuery())
+	if err != nil {
+		t.Fatalf("ToDataSet: %v", err)
+	}
+	if ds == nil {
+		t.Fatal("ToDataSet returned nil dataset")
+	}
+	if ds.TimeRangeQuery == nil {
+		t.Fatal("expected TimeRangeQuery to be set")
+	}
+	if len(ds.ExtentList) != 1 {
+		t.Fatalf("expected 1 extent, got %d", len(ds.ExtentList))
+	}
+	if len(ds.Results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(ds.Results))
+	}
+
+	seriesByResult := map[string]int{}
+	pointsBySeries := map[string]int{}
+	for _, r := range ds.Results {
+		seriesByResult[r.Name] = len(r.SeriesList)
+		for _, s := range r.SeriesList {
+			pointsBySeries[s.Header.Name] = len(s.Points)
+			if s.Header.Tags["host"] == "" {
+				t.Fatalf("series %q missing host tag", s.Header.Name)
+			}
+		}
+	}
+
+	if seriesByResult["_result1"] != 2 {
+		t.Fatalf("_result1 series count = %d, want 2", seriesByResult["_result1"])
+	}
+	if seriesByResult["_result2"] != 1 {
+		t.Fatalf("_result2 series count = %d, want 1", seriesByResult["_result2"])
+	}
+
+	for name, count := range pointsBySeries {
+		if count != 1 {
+			t.Fatalf("series %q point count = %d, want 1", name, count)
+		}
+	}
+
+	var found dataset.Point
+	for _, r := range ds.Results {
+		for _, s := range r.SeriesList {
+			if s.Header.Tags["host"] == "host-a" && r.Name == "_result1" {
+				found = s.Points[0]
+			}
+		}
+	}
+	if found.Epoch != 1000 {
+		t.Fatalf("host-a epoch = %d, want 1000", found.Epoch)
+	}
+	if v, ok := found.Values[0].(float64); !ok || v != 1.5 {
+		t.Fatalf("host-a value = %#v, want 1.5", found.Values[0])
+	}
+	if v, ok := found.Values[1].(int64); !ok || v != 10 {
+		t.Fatalf("host-a count = %#v, want 10", found.Values[1])
+	}
+}
+
+func TestParserToTimeseries(t *testing.T) {
+	t.Parallel()
+
+	p := testParser(t, 1)
+	ts, err := p.ToTimeseries(testMatrix(), testTimeRangeQuery())
+	if err != nil {
+		t.Fatalf("ToTimeseries: %v", err)
+	}
+	ds, ok := ts.(*dataset.DataSet)
+	if !ok {
+		t.Fatalf("ToTimeseries returned %T, want *dataset.DataSet", ts)
+	}
+	if len(ds.Results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(ds.Results))
+	}
+}
+
+func TestParserSkipsHeaderAndMalformedRows(t *testing.T) {
+	t.Parallel()
+
+	p := testParser(t, 1)
+	matrix := testMatrix()
+	matrix = append(matrix, []string{"only", "three", "cells"})
+
+	ds, err := p.ToDataSet(matrix, testTimeRangeQuery())
+	if err != nil {
+		t.Fatalf("ToDataSet: %v", err)
+	}
+
+	totalPoints := 0
+	for _, r := range ds.Results {
+		for _, s := range r.SeriesList {
+			totalPoints += len(s.Points)
+		}
+	}
+	if totalPoints != 3 {
+		t.Fatalf("total points = %d, want 3", totalPoints)
+	}
+}
+
+func TestParserInvalidTimestampSkipped(t *testing.T) {
+	t.Parallel()
+
+	p := testParser(t, 1)
+	matrix := [][]string{
+		{"result", "host", "time", "value", "count"},
+		{"_result1", "host-a", "not-a-number", "1.5", "10"},
+		{"_result1", "host-a", "2000", "2.5", "20"},
+	}
+
+	ds, err := p.ToDataSet(matrix, testTimeRangeQuery())
+	if err != nil {
+		t.Fatalf("ToDataSet: %v", err)
+	}
+	if len(ds.Results) != 1 || len(ds.Results[0].SeriesList) != 1 {
+		t.Fatalf("unexpected result layout: %#v", ds.Results)
+	}
+	s := ds.Results[0].SeriesList[0]
+	if len(s.Points) != 1 {
+		t.Fatalf("expected 1 point after skipping invalid timestamp, got %d", len(s.Points))
+	}
+	if s.Points[0].Epoch != 2000 {
+		t.Fatalf("point epoch = %d, want 2000", s.Points[0].Epoch)
+	}
+}
+
+func TestParserFieldParserError(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewParser(
+		func(_ [][]string, _ *timeseries.TimeRangeQuery) (timeseries.SeriesFields, error) {
+			return timeseries.SeriesFields{}, timeseries.ErrInvalidBody
+		},
+		testDataTypeParser,
+		testTimestampParser,
+		1,
+	)
+	if err != nil {
+		t.Fatalf("NewParser: %v", err)
+	}
+	_, err = p.ToDataSet(testMatrix(), testTimeRangeQuery())
+	if !errors.Is(err, timeseries.ErrInvalidBody) {
+		t.Fatalf("ToDataSet() error = %v, want ErrInvalidBody", err)
+	}
+}
+
+func TestParserInvalidTimestampField(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewParser(
+		func(_ [][]string, _ *timeseries.TimeRangeQuery) (timeseries.SeriesFields, error) {
+			sf, _ := testFieldParser(nil, nil)
+			sf.Timestamp.OutputPosition = -1
+			return sf, nil
+		},
+		testDataTypeParser,
+		testTimestampParser,
+		1,
+	)
+	if err != nil {
+		t.Fatalf("NewParser: %v", err)
+	}
+	_, err = p.ToDataSet(testMatrix(), testTimeRangeQuery())
+	if !errors.Is(err, timeseries.ErrInvalidBody) {
+		t.Fatalf("ToDataSet() error = %v, want ErrInvalidBody", err)
+	}
+}
+
+func TestParserEmptyValueSkipped(t *testing.T) {
+	t.Parallel()
+
+	p := testParser(t, 1)
+	matrix := [][]string{
+		{"result", "host", "time", "value", "count"},
+		{"_result1", "host-a", "1000", "", "10"},
+	}
+
+	ds, err := p.ToDataSet(matrix, testTimeRangeQuery())
+	if err != nil {
+		t.Fatalf("ToDataSet: %v", err)
+	}
+	pt := ds.Results[0].SeriesList[0].Points[0]
+	if pt.Values[0] != nil {
+		t.Fatalf("expected empty value slot, got %#v", pt.Values[0])
+	}
+	if v, ok := pt.Values[1].(int64); !ok || v != 10 {
+		t.Fatalf("count value = %#v, want 10", pt.Values[1])
+	}
+}
+
+func TestAddValue(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		input    string
+		typ      timeseries.FieldDataType
+		wantVal  any
+		wantSize int
+	}{
+		{name: "int64", input: "42", typ: timeseries.Int64, wantVal: int64(42), wantSize: 8},
+		{name: "float64", input: "3.14", typ: timeseries.Float64, wantVal: 3.14, wantSize: 8},
+		{name: "string", input: "hello", typ: timeseries.String, wantVal: "hello", wantSize: 5},
+		{name: "bool-true", input: "true", typ: timeseries.Bool, wantVal: true, wantSize: 1},
+		{name: "byte", input: "7", typ: timeseries.Byte, wantVal: int64(7), wantSize: 1},
+		{name: "int16", input: "1000", typ: timeseries.Int16, wantVal: int64(1000), wantSize: 2},
+		{name: "uint64", input: "9007199254740991", typ: timeseries.Uint64, wantVal: uint64(9007199254740991), wantSize: 8},
+		{name: "datetime-rfc3339", input: "2020-01-02T03:04:05Z", typ: timeseries.DateTimeRFC3339, wantVal: "2020-01-02T03:04:05Z", wantSize: 20},
+		{name: "unknown", input: "x", typ: timeseries.Unknown, wantVal: nil, wantSize: 0},
+		{name: "null", input: "x", typ: timeseries.Null, wantVal: nil, wantSize: 0},
+		{name: "invalid-int64", input: "nope", typ: timeseries.Int64, wantVal: nil, wantSize: 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			vals := make([]any, 1)
+			size := addValue(tc.input, vals, 0, tc.typ)
+			if size != tc.wantSize {
+				t.Fatalf("addValue size = %d, want %d", size, tc.wantSize)
+			}
+			if tc.wantVal == nil {
+				if vals[0] != nil {
+					t.Fatalf("addValue value = %#v, want nil", vals[0])
+				}
+				return
+			}
+			if vals[0] != tc.wantVal {
+				t.Fatalf("addValue value = %#v, want %#v", vals[0], tc.wantVal)
+			}
+		})
+	}
+}
+
+func TestSeriesKeyData(t *testing.T) {
+	t.Parallel()
+
+	sf := timeseries.SeriesFields{
+		Tags: timeseries.FieldDefinitions{
+			{Name: "host", OutputPosition: 1},
+			{Name: "region", OutputPosition: 2},
+		},
+		ResultNameCol: 0,
+	}
+
+	t.Run("string-with-tags", func(t *testing.T) {
+		t.Parallel()
+		row := []string{"result-a", "host-1", "us-east"}
+		item := getSeriesKeyData(row, sf)
+		if item.resultID != "result-a" {
+			t.Fatalf("resultID = %q, want result-a", item.resultID)
+		}
+		want := seriesKeyData{
+			{name: "host", value: "host-1"},
+			{name: "region", value: "us-east"},
+		}.String("result-a")
+		if item.s != want {
+			t.Fatalf("series key = %q, want %q", item.s, want)
+		}
+	})
+
+	t.Run("map", func(t *testing.T) {
+		t.Parallel()
+		row := []string{"result-a", "host-1", "us-east"}
+		item := getSeriesKeyData(row, sf)
+		m := item.seriesKeyData.Map()
+		if m["host"] != "host-1" || m["region"] != "us-east" {
+			t.Fatalf("unexpected tag map: %#v", m)
+		}
+	})
+
+	t.Run("skips-empty-tag-values", func(t *testing.T) {
+		t.Parallel()
+		row := []string{"result-a", "host-1", ""}
+		item := getSeriesKeyData(row, sf)
+		if len(item.seriesKeyData) != 1 {
+			t.Fatalf("seriesKeyData length = %d, want 1", len(item.seriesKeyData))
+		}
+		want := seriesKeyData{{name: "host", value: "host-1"}}.String("result-a")
+		if item.s != want {
+			t.Fatalf("series key = %q, want %q", item.s, want)
+		}
+	})
+
+	t.Run("string-skips-empty-name-or-value", func(t *testing.T) {
+		t.Parallel()
+		d := seriesKeyData{
+			{name: "", value: "ignored"},
+			{name: "host", value: ""},
+			{name: "region", value: "west"},
+		}
+		got := d.String("result-b")
+		want := seriesKeyData{{name: "region", value: "west"}}.String("result-b")
+		if got != want {
+			t.Fatalf("String() = %q, want %q", got, want)
+		}
+	})
+}


### PR DESCRIPTION
## Description
<!-- Describe changes and the problem solved -->
This change extends test coverage across a number of packages, and fixes 1 defect in the authenticator that was detected by the new tests. Adds a common/scripted mechanism to prune generated files and test utilities from the code coverage report and calculate/print total coverage percent following `make test`.

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [x] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
