### PR TITLE
fix: [proxy] decrement active-connections gauge correctly under connections_limit

### DIFF
--- a/pkg/proxy/listener/listener.go
+++ b/pkg/proxy/listener/listener.go
@@ -66,13 +66,21 @@ type Listener struct {
 }
 
 type observedConnection struct {
-	*net.TCPConn
+	net.Conn
+	closeOnce sync.Once
 }
 
 func (o *observedConnection) Close() error {
-	err := o.TCPConn.Close()
-	metrics.ProxyActiveConnections.Dec()
-	metrics.ProxyConnectionClosed.Inc()
+	err := o.Conn.Close()
+	// Decrement the gauge (and bump the closed counter) at most once per
+	// connection. net/http may call Close more than once on the same conn
+	// (e.g. handler close followed by the server's shutdown sweep), and
+	// without this guard each extra Close double-decremented
+	// ProxyActiveConnections, drifting the gauge negative over time.
+	o.closeOnce.Do(func() {
+		metrics.ProxyActiveConnections.Dec()
+		metrics.ProxyConnectionClosed.Inc()
+	})
 	return err
 }
 
@@ -88,12 +96,19 @@ func (l *Listener) Accept() (net.Conn, error) {
 
 	metrics.ProxyActiveConnections.Inc()
 	metrics.ProxyConnectionAccepted.Inc()
-	// this is necessary for HTTP/2 to work
-	if t, ok := c.(*net.TCPConn); ok {
-		return &observedConnection{t}, nil
+	// Do not wrap *tls.Conn: the http.Server type-asserts it to negotiate
+	// HTTP/2 (ALPN), so wrapping would silently disable HTTP/2 over TLS.
+	// Wrap every other connection type -- including *net.TCPConn and the
+	// netutil.LimitListener wrapper used when frontend.connections_limit is
+	// set -- so Close decrements ProxyActiveConnections. Previously only
+	// *net.TCPConn was wrapped, so enabling connections_limit hid the
+	// connection behind *netutil.limitListenerConn and the active-connection
+	// gauge incremented on accept but never decremented on close.
+	if _, ok := c.(*tls.Conn); ok {
+		return c, nil
 	}
 
-	return c, nil
+	return &observedConnection{Conn: c}, nil
 }
 
 // CertSwapper returns the CertSwapper reference from the Listener

--- a/pkg/proxy/listener/listener_test.go
+++ b/pkg/proxy/listener/listener_test.go
@@ -29,11 +29,13 @@ import (
 	"testing"
 	"time"
 
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
 	"github.com/trickstercache/trickster/v2/pkg/config"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/level"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
+	"github.com/trickstercache/trickster/v2/pkg/observability/metrics"
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing"
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing/exporters/stdout"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/errors"
@@ -42,6 +44,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
 	testutil "github.com/trickstercache/trickster/v2/pkg/testutil"
 	tlstest "github.com/trickstercache/trickster/v2/pkg/testutil/tls"
+	"golang.org/x/net/netutil"
 )
 
 func testListener() net.Listener {
@@ -347,10 +350,67 @@ func TestCloseObservedConnection(t *testing.T) {
 		t.Error("invalid connection type")
 	}
 	oconn := &observedConnection{
-		TCPConn: tconn,
+		Conn: tconn,
 	}
 	err = oconn.Close()
 	if err != nil {
 		t.Error(err)
+	}
+}
+
+// TestAcceptWrapsLimitListenerConn ensures Accept wraps connections in
+// *observedConnection even when the underlying listener is a
+// netutil.LimitListener (which is used when frontend.connections_limit is set).
+// Without the wrap, observedConnection.Close never runs, so
+// ProxyActiveConnections is incremented on accept but never decremented on
+// close, producing a monotonic gauge leak that ignores the configured limit.
+func TestAcceptWrapsLimitListenerConn(t *testing.T) {
+	inner, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer inner.Close()
+	l := &Listener{Listener: netutil.LimitListener(inner, 10)}
+
+	dialed := make(chan net.Conn, 1)
+	go func() {
+		c, derr := net.Dial("tcp", inner.Addr().String())
+		if derr != nil {
+			dialed <- nil
+			return
+		}
+		dialed <- c
+	}()
+
+	c, err := l.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	if _, ok := c.(*observedConnection); !ok {
+		t.Errorf("expected *observedConnection so Close decrements the active gauge, got %T", c)
+	}
+
+	if dc := <-dialed; dc != nil {
+		dc.Close()
+	}
+}
+
+// TestObservedConnectionCloseIdempotent ensures Close decrements the
+// active-connections gauge at most once even when invoked multiple times.
+// net/http can call Close more than once per connection; without the
+// sync.Once guard each extra Close double-decremented the gauge, drifting
+// trickster_proxy_active_connections negative over time.
+func TestObservedConnectionCloseIdempotent(t *testing.T) {
+	_, client := net.Pipe()
+	oc := &observedConnection{Conn: client}
+	metrics.ProxyActiveConnections.Inc() // simulate the Inc performed in Accept
+	before := promtest.ToFloat64(metrics.ProxyActiveConnections)
+	_ = oc.Close()
+	_ = oc.Close()
+	_ = oc.Close()
+	after := promtest.ToFloat64(metrics.ProxyActiveConnections)
+	if before-after != 1 {
+		t.Errorf("Inc + triple Close changed gauge by %v; want net -1 (single Dec)", before-after)
 	}
 }


### PR DESCRIPTION
## Description
  When `frontend.connections_limit` is set, `NewListener` wraps the listener with
  `netutil.LimitListener`, so `Accept` returns a `*netutil.limitListenerConn` rather
  than a `*net.TCPConn`. The previous code only wrapped `*net.TCPConn` in
  `observedConnection` (which decrements `ProxyActiveConnections` on `Close`), so a
  limited connection was returned unwrapped: the gauge incremented on accept but never
  decremented on close, growing monotonically and ignoring the configured limit.

  Real connections were unaffected (`limitListenerConn.Close` closes the socket and
  releases the semaphore) — only the `trickster_proxy_active_connections` metric leaked.
  Observed in production: with `connections_limit` enabled the gauge climbed to several
  thousand while `go_goroutines` / `process_open_fds` stayed flat.

  Fix:
  - Embed `net.Conn` in `observedConnection` and wrap every accepted connection except
    `*tls.Conn` (which `http.Server` must type-assert for HTTP/2 ALPN), so `Close`
    decrements the gauge for `*net.TCPConn` and `*netutil.limitListenerConn` alike.
  - Guard the decrement with `sync.Once` so a connection is counted closed exactly once
    even if `net/http` calls `Close` more than once (otherwise the gauge drifts negative).

  Tests: `TestAcceptWrapsLimitListenerConn`, `TestObservedConnectionCloseIdempotent`.

  ## Type of Change

  - - [x] Bug fix

  ## AI Disclosure

  - - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.