### PR TITLE
fix: [alb] expose localresponse via Handlers() so paths: overrides apply

### DIFF
--- a/pkg/backends/alb/client.go
+++ b/pkg/backends/alb/client.go
@@ -42,6 +42,7 @@ import (
 	authreg "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/registry"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/failures"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/local"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/methods"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
 	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
@@ -54,9 +55,17 @@ type Client struct {
 	handler types.Mechanism // this is the actual handler for all request to this backend
 }
 
-// Handlers returns a map of the HTTP Handlers the client has registered
+// Handlers returns a map of the HTTP Handlers the client has registered.
+// "localresponse" is exposed so operators can use the standard `paths:`
+// override to short-circuit non-mergeable endpoints (e.g. /api/v1/query_exemplars,
+// /api/v1/metadata) before they enter the ALB mechanism. Without this entry
+// the routing layer silently drops the path config because client.Handlers()
+// has no matching handler for the requested name.
 func (c *Client) Handlers() handlers.Lookup {
-	return handlers.Lookup{providers.ALB: c.handler}
+	return handlers.Lookup{
+		providers.ALB:   c.handler,
+		"localresponse": http.HandlerFunc(local.HandleLocalResponse),
+	}
 }
 
 var _ rt.NewBackendClientFunc = NewClient

--- a/pkg/backends/alb/client_test.go
+++ b/pkg/backends/alb/client_test.go
@@ -57,6 +57,10 @@ func TestHandlers(t *testing.T) {
 		t.Error("expected alb handler")
 	}
 
+	if _, ok := cl.Handlers()["localresponse"]; !ok {
+		t.Error("expected localresponse handler")
+	}
+
 	a.MechanismName = names.MechanismFGR
 	_, err = NewClient("test", o, nil, nil, nil, nil)
 	if err != nil {


### PR DESCRIPTION
## Description
The ALB client's `Handlers()` lookup previously returned only the ALB mechanism handler, so any `paths:` override in the YAML configuration that named a generic handler (e.g. `handler: localresponse`) was silently dropped by `RegisterPathRoutes`. This was because `handlers[p.HandlerName]` returned nil, leaving `p.Handler` unset and skipping route registration.

This patch exposes the `localresponse` handler via `Handlers()` so operators can short-circuit non-mergeable endpoints (such as `/api/v1/query_exemplars` or `/api/v1/metadata`) before they enter a TSM fanout pool where a missing `MergeFunc` would surface as a client-side `502 Bad Gateway`.

Unit test verification has been added in `client_test.go` to assert that `localresponse` is correctly returned.

## Type of Change
- [x] Bug fix
- [x] Test coverage

## AI Disclosure
- [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
