### PR TITLE
test: use synctest for healthcheck timing

### DIFF
--- a/pkg/backends/alb/pool/pool_stale_cache_repro_test.go
+++ b/pkg/backends/alb/pool/pool_stale_cache_repro_test.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
@@ -73,175 +74,151 @@ func TestRepro_H1_DeadRefreshWorker(t *testing.T) {
 // H1b: same as H1 but with a real pool. Mark target 0 Failing, then flip
 // target 1 to saturate the refresh path. Assert target 0 stays excluded.
 func TestRepro_H1b_RealPoolFlapStorm(t *testing.T) {
-	const n = 3
-	targets := make(Targets, n)
-	statuses := make([]*healthcheck.Status, n)
-	for i := range n {
-		st := &healthcheck.Status{}
-		st.Set(healthcheck.StatusPassing)
-		statuses[i] = st
-		targets[i] = NewTarget(http.NotFoundHandler(), st, nil)
-	}
-	p := New(targets, 1)
-	defer p.Stop()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if len(p.Targets()) == n {
-			break
+	synctest.Test(t, func(t *testing.T) {
+		const n = 3
+		targets := make(Targets, n)
+		statuses := make([]*healthcheck.Status, n)
+		for i := range n {
+			st := &healthcheck.Status{}
+			st.Set(healthcheck.StatusPassing)
+			statuses[i] = st
+			targets[i] = NewTarget(http.NotFoundHandler(), st, nil)
 		}
-		time.Sleep(2 * time.Millisecond)
-	}
-	if len(p.Targets()) != n {
-		t.Fatalf("setup: expected %d healthy, got %d", n, len(p.Targets()))
-	}
-
-	statuses[0].Set(healthcheck.StatusFailing)
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		for range 200 {
-			statuses[1].Set(healthcheck.StatusFailing)
-			statuses[1].Set(healthcheck.StatusPassing)
+		p := New(targets, 1)
+		defer p.Stop()
+		synctest.Wait()
+		if len(p.Targets()) != n {
+			t.Fatalf("setup: expected %d healthy, got %d", n, len(p.Targets()))
 		}
-	})
-	wg.Wait()
 
-	deadline = time.Now().Add(1 * time.Second)
-	for time.Now().Before(deadline) {
+		statuses[0].Set(healthcheck.StatusFailing)
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			for range 200 {
+				statuses[1].Set(healthcheck.StatusFailing)
+				statuses[1].Set(healthcheck.StatusPassing)
+			}
+		})
+		wg.Wait()
+		synctest.Wait()
+
 		ts := p.Targets()
 		ok := !slices.Contains(ts, targets[0])
 		if ok && len(ts) == n-1 {
 			return
 		}
-		time.Sleep(time.Millisecond)
-	}
-	t.Fatalf("REPRO: Failing target still present 1s after flap storm")
+		t.Fatalf("REPRO: Failing target still present after flap storm")
+	})
 }
 
 // H2: saturate statusCh while refreshPending is being toggled, then flip
 // target 0 Failing and assert it propagates.
 func TestRepro_H2_ChannelDrop(t *testing.T) {
-	const n = 10
-	targets := make(Targets, n)
-	statuses := make([]*healthcheck.Status, n)
-	for i := range n {
-		st := &healthcheck.Status{}
-		st.Set(healthcheck.StatusPassing)
-		statuses[i] = st
-		targets[i] = NewTarget(http.NotFoundHandler(), st, nil)
-	}
-	p := New(targets, 1)
-	defer p.Stop()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if len(p.Targets()) == n {
-			break
+	synctest.Test(t, func(t *testing.T) {
+		const n = 10
+		targets := make(Targets, n)
+		statuses := make([]*healthcheck.Status, n)
+		for i := range n {
+			st := &healthcheck.Status{}
+			st.Set(healthcheck.StatusPassing)
+			statuses[i] = st
+			targets[i] = NewTarget(http.NotFoundHandler(), st, nil)
 		}
-		time.Sleep(2 * time.Millisecond)
-	}
-	if len(p.Targets()) != n {
-		t.Fatalf("setup: %d", len(p.Targets()))
-	}
+		p := New(targets, 1)
+		defer p.Stop()
+		synctest.Wait()
+		if len(p.Targets()) != n {
+			t.Fatalf("setup: %d", len(p.Targets()))
+		}
 
-	var wg sync.WaitGroup
-	for i := range n {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			for range 50 {
-				statuses[idx].Set(healthcheck.StatusFailing)
-				statuses[idx].Set(healthcheck.StatusPassing)
-			}
-		}(i)
-	}
-	wg.Wait()
+		var wg sync.WaitGroup
+		for i := range n {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				for range 50 {
+					statuses[idx].Set(healthcheck.StatusFailing)
+					statuses[idx].Set(healthcheck.StatusPassing)
+				}
+			}(i)
+		}
+		wg.Wait()
 
-	statuses[0].Set(healthcheck.StatusFailing)
-	deadline = time.Now().Add(1 * time.Second)
-	for time.Now().Before(deadline) {
+		statuses[0].Set(healthcheck.StatusFailing)
+		synctest.Wait()
 		ts := p.Targets()
 		hasFailing := slices.Contains(ts, targets[0])
 		if !hasFailing && len(ts) == n-1 {
 			return
 		}
-		time.Sleep(time.Millisecond)
-	}
-	t.Fatalf("REPRO: channel-drop left Failing target in pool")
+		t.Fatalf("REPRO: channel-drop left Failing target in pool")
+	})
 }
 
 // H4: 50 targets, persistent failing subset + churn. Assert no Failing
 // target ever appears in Targets() output for 1 second.
 func TestRepro_H4_ScaleRace(t *testing.T) {
-	const n = 50
-	targets := make(Targets, n)
-	statuses := make([]*healthcheck.Status, n)
-	for i := range n {
-		st := &healthcheck.Status{}
-		st.Set(healthcheck.StatusPassing)
-		statuses[i] = st
-		targets[i] = NewTarget(http.NotFoundHandler(), st, nil)
-	}
-	p := New(targets, 1)
-	defer p.Stop()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if len(p.Targets()) == n {
-			break
+	synctest.Test(t, func(t *testing.T) {
+		const n = 50
+		targets := make(Targets, n)
+		statuses := make([]*healthcheck.Status, n)
+		for i := range n {
+			st := &healthcheck.Status{}
+			st.Set(healthcheck.StatusPassing)
+			statuses[i] = st
+			targets[i] = NewTarget(http.NotFoundHandler(), st, nil)
 		}
-		time.Sleep(2 * time.Millisecond)
-	}
-	if len(p.Targets()) != n {
-		t.Fatalf("setup: %d", len(p.Targets()))
-	}
-
-	stop := make(chan struct{})
-	failingMask := make([]atomic.Bool, n)
-
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		for i := 0; i < n; i += 3 {
-			statuses[i].Set(healthcheck.StatusFailing)
-			failingMask[i].Store(true)
+		p := New(targets, 1)
+		defer p.Stop()
+		synctest.Wait()
+		if len(p.Targets()) != n {
+			t.Fatalf("setup: %d", len(p.Targets()))
 		}
-		ticker := time.NewTicker(2 * time.Millisecond)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-stop:
-				return
-			case <-ticker.C:
-				for i := 1; i < n; i += 5 {
-					if failingMask[i].Load() {
-						continue
+
+		stop := make(chan struct{})
+		failingMask := make([]atomic.Bool, n)
+
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			for i := 0; i < n; i += 3 {
+				statuses[i].Set(healthcheck.StatusFailing)
+				failingMask[i].Store(true)
+			}
+			ticker := time.NewTicker(2 * time.Millisecond)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-stop:
+					return
+				case <-ticker.C:
+					for i := 1; i < n; i += 5 {
+						if failingMask[i].Load() {
+							continue
+						}
+						statuses[i].Set(healthcheck.StatusPassing)
 					}
-					statuses[i].Set(healthcheck.StatusPassing)
+				}
+			}
+		})
+
+		time.Sleep(50 * time.Millisecond)
+		synctest.Wait()
+
+		var iterations atomic.Int64
+		for range 1000 {
+			time.Sleep(time.Millisecond)
+			ts := p.Targets()
+			iterations.Add(1)
+			for _, tt := range ts {
+				if tt.hcStatus.Get() == healthcheck.StatusFailing {
+					close(stop)
+					wg.Wait()
+					t.Fatalf("REPRO: Targets() returned Failing target after %d iters", iterations.Load())
 				}
 			}
 		}
+		close(stop)
+		wg.Wait()
+		t.Logf("H4: completed %d Targets() calls without seeing a Failing target", iterations.Load())
 	})
-
-	time.Sleep(50 * time.Millisecond)
-
-	var iterations atomic.Int64
-	asserter := time.NewTimer(1 * time.Second)
-	defer asserter.Stop()
-loop:
-	for {
-		select {
-		case <-asserter.C:
-			break loop
-		default:
-		}
-		ts := p.Targets()
-		iterations.Add(1)
-		for _, tt := range ts {
-			if tt.hcStatus.Get() == healthcheck.StatusFailing {
-				close(stop)
-				wg.Wait()
-				t.Fatalf("REPRO: Targets() returned Failing target after %d iters", iterations.Load())
-			}
-		}
-	}
-	close(stop)
-	wg.Wait()
-	t.Logf("H4: completed %d Targets() calls without seeing a Failing target", iterations.Load())
 }

--- a/pkg/backends/healthcheck/healthcheck_reregister_test.go
+++ b/pkg/backends/healthcheck/healthcheck_reregister_test.go
@@ -17,13 +17,13 @@
 package healthcheck
 
 import (
-	"net"
+	"io"
 	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -42,123 +42,111 @@ import (
 // in-handler lifetimes overlap.
 func TestHealthcheckReregisterNoOverlap(t *testing.T) {
 	logger.SetLogger(testLogger)
+	synctest.Test(t, func(t *testing.T) {
+		// handlerDelay must exceed the max randomJitter (1s) used by probeLoop so
+		// the in-flight pre-reregister probe is still occupying the upstream when
+		// an asynchronously-stopped old loop and a new loop could overlap.
+		const interval = 50 * time.Millisecond
+		const handlerDelay = 1500 * time.Millisecond
 
-	// handlerDelay must exceed the max randomJitter (1s) used by probeLoop so
-	// the in-flight pre-reregister probe is still occupying the upstream when
-	// the new loop's first probe fires.
-	const interval = 50 * time.Millisecond
-	const handlerDelay = 1500 * time.Millisecond
-
-	type probe struct {
-		start, end time.Time
-	}
-	var (
-		mu     sync.Mutex
-		probes []probe
-	)
-	first := make(chan struct{}, 1)
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		start := time.Now()
-		mu.Lock()
-		idx := len(probes)
-		probes = append(probes, probe{start: start})
-		mu.Unlock()
-		if idx == 0 {
-			select {
-			case first <- struct{}{}:
-			default:
-			}
+		type probe struct {
+			start, end time.Time
 		}
-		// Ignore cancellation so the upstream sees the full overlap window.
-		time.Sleep(handlerDelay)
-		end := time.Now()
-		mu.Lock()
-		probes[idx].end = end
-		mu.Unlock()
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-	u, err := url.Parse(ts.URL)
-	require.NoError(t, err)
+		var (
+			mu     sync.Mutex
+			probes []probe
+		)
+		first := make(chan struct{}, 1)
 
-	hc := New()
-	defer hc.Shutdown()
-
-	mkOpts := func() *ho.Options {
-		return &ho.Options{
-			Verb:          "GET",
-			Scheme:        u.Scheme,
-			Host:          u.Host,
-			Path:          "/",
-			Interval:      interval,
-			ExpectedCodes: []int{http.StatusOK},
-		}
-	}
-
-	// Default healthcheck client caps MaxConnsPerHost at 1, which serializes
-	// requests on the wire and hides any concurrency. Use an unbounded one.
-	mkClient := func() *http.Client {
-		return &http.Client{
-			Timeout: 5 * time.Second,
-			Transport: &http.Transport{
-				DialContext:         (&net.Dialer{Timeout: time.Second}).DialContext,
-				MaxConnsPerHost:     0,
-				MaxIdleConnsPerHost: 0,
-				DisableKeepAlives:   true,
-			},
-		}
-	}
-
-	_, err = hc.Register("x", "x", mkOpts(), mkClient())
-	require.NoError(t, err)
-
-	select {
-	case <-first:
-	case <-time.After(2 * time.Second):
-		t.Fatal("first probe never arrived")
-	}
-
-	mu.Lock()
-	boundary := time.Now()
-	mu.Unlock()
-
-	_, err = hc.Register("x", "x", mkOpts(), mkClient())
-	require.NoError(t, err)
-	// Allow new loop's jitter (10ms-1s) plus one handlerDelay window to land.
-	time.Sleep(handlerDelay + 1500*time.Millisecond)
-
-	mu.Lock()
-	snapshot := make([]probe, 0, len(probes))
-	for _, p := range probes {
-		if !p.end.IsZero() {
-			snapshot = append(snapshot, p)
-		}
-	}
-	mu.Unlock()
-	sort.Slice(snapshot, func(i, j int) bool { return snapshot[i].start.Before(snapshot[j].start) })
-
-	// Include in-flight probes whose lifetimes touched the post-reregister
-	// window so a leaked old loop's probe and the new loop's first probe
-	// would both appear here.
-	post := make([]probe, 0, len(snapshot))
-	for _, p := range snapshot {
-		if p.end.After(boundary) {
-			post = append(post, p)
-		}
-	}
-
-	for i := 0; i < len(post); i++ {
-		for j := i + 1; j < len(post); j++ {
-			if post[j].start.Before(post[i].end) {
-				offsets := make([][2]time.Duration, len(post))
-				for k, p := range post {
-					offsets[k] = [2]time.Duration{p.start.Sub(boundary), p.end.Sub(boundary)}
+		client := &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				start := time.Now()
+				mu.Lock()
+				idx := len(probes)
+				probes = append(probes, probe{start: start})
+				mu.Unlock()
+				if idx == 0 {
+					select {
+					case first <- struct{}{}:
+					default:
+					}
 				}
-				t.Fatalf("overlapping probes: probe[%d] (%v..%v) overlaps probe[%d] (%v..%v); all probes: %v",
-					i, post[i].start.Sub(boundary), post[i].end.Sub(boundary),
-					j, post[j].start.Sub(boundary), post[j].end.Sub(boundary), offsets)
+
+				// Ignore cancellation so the upstream sees the full overlap window.
+				time.Sleep(handlerDelay)
+				end := time.Now()
+				mu.Lock()
+				probes[idx].end = end
+				mu.Unlock()
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("OK")),
+					Header:     http.Header{},
+					Request:    req,
+				}, nil
+			}),
+		}
+
+		hc := New()
+		defer hc.Shutdown()
+
+		mkOpts := func() *ho.Options {
+			return &ho.Options{
+				Verb:          "GET",
+				Scheme:        "http",
+				Host:          "healthcheck-reregister.invalid",
+				Path:          "/",
+				Interval:      interval,
+				ExpectedCodes: []int{http.StatusOK},
 			}
 		}
-	}
+
+		_, err := hc.Register("x", "x", mkOpts(), client)
+		require.NoError(t, err)
+
+		<-first
+
+		boundary := time.Now()
+
+		_, err = hc.Register("x", "x", mkOpts(), client)
+		require.NoError(t, err)
+		// Allow new loop's jitter (10ms-1s) plus one handlerDelay window to land.
+		time.Sleep(handlerDelay + time.Second + interval)
+		synctest.Wait()
+
+		mu.Lock()
+		snapshot := make([]probe, 0, len(probes))
+		for _, p := range probes {
+			if !p.end.IsZero() {
+				snapshot = append(snapshot, p)
+			}
+		}
+		mu.Unlock()
+		sort.Slice(snapshot, func(i, j int) bool { return snapshot[i].start.Before(snapshot[j].start) })
+
+		// Include in-flight probes whose lifetimes touched the post-reregister
+		// window so a leaked old loop's probe and the new loop's first probe
+		// would both appear here.
+		post := make([]probe, 0, len(snapshot))
+		for _, p := range snapshot {
+			if p.end.After(boundary) {
+				post = append(post, p)
+			}
+		}
+
+		for i := 0; i < len(post); i++ {
+			for j := i + 1; j < len(post); j++ {
+				if post[j].start.Before(post[i].end) {
+					offsets := make([][2]time.Duration, len(post))
+					for k, p := range post {
+						offsets[k] = [2]time.Duration{p.start.Sub(boundary), p.end.Sub(boundary)}
+					}
+					t.Fatalf("overlapping probes: probe[%d] (%v..%v) overlaps probe[%d] (%v..%v); all probes: %v",
+						i, post[i].start.Sub(boundary), post[i].end.Sub(boundary),
+						j, post[j].start.Sub(boundary), post[j].end.Sub(boundary), offsets)
+				}
+			}
+		}
+	})
 }

--- a/pkg/backends/healthcheck/target_panic_test.go
+++ b/pkg/backends/healthcheck/target_panic_test.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -57,43 +58,38 @@ func (p *panicOnceTransport) RoundTrip(req *http.Request) (*http.Response, error
 // at StatusInitializing forever.
 func TestProbeLoopSurvivesPanic(t *testing.T) {
 	logger.SetLogger(testLogger)
+	synctest.Test(t, func(t *testing.T) {
+		tr := &panicOnceTransport{}
+		client := &http.Client{Transport: tr}
 
-	tr := &panicOnceTransport{}
-	client := &http.Client{Transport: tr}
+		u, err := url.Parse("http://probe-panic.invalid/")
+		require.NoError(t, err)
 
-	u, err := url.Parse("http://probe-panic.invalid/")
-	require.NoError(t, err)
+		const interval = 50 * time.Millisecond
+		tgt, err := newTarget(context.Background(), "panic-target", "panic-target", &ho.Options{
+			Verb:              "GET",
+			Scheme:            u.Scheme,
+			Host:              u.Host,
+			Path:              "/",
+			Interval:          interval,
+			ExpectedCodes:     []int{200},
+			FailureThreshold:  1,
+			RecoveryThreshold: 1,
+		}, client)
+		require.NoError(t, err)
 
-	const interval = 50 * time.Millisecond
-	tgt, err := newTarget(context.Background(), "panic-target", "panic-target", &ho.Options{
-		Verb:              "GET",
-		Scheme:            u.Scheme,
-		Host:              u.Host,
-		Path:              "/",
-		Interval:          interval,
-		ExpectedCodes:     []int{200},
-		FailureThreshold:  1,
-		RecoveryThreshold: 1,
-	}, client)
-	require.NoError(t, err)
+		tgt.Start(t.Context())
+		defer tgt.Stop()
 
-	ctx := t.Context()
-	tgt.Start(ctx)
-	defer tgt.Stop()
+		// Advance past the startup jitter and the first ticker fire. The first
+		// probe panics; the second one must still run and mark the target Passing.
+		time.Sleep(time.Second + interval)
+		synctest.Wait()
 
-	// Wait long enough for: jitter (up to ~1s) + first probe (panics) +
-	// several ticker fires (each returns 200, drives status -> Passing).
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		if tr.calls.Load() >= 3 && tgt.status.Get() == StatusPassing {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-
-	require.GreaterOrEqual(t, tr.calls.Load(), int32(2),
-		"probe loop did not survive panic: only %d RoundTrip calls observed", tr.calls.Load())
-	require.Equal(t, StatusPassing, tgt.status.Get(),
-		"status did not transition to Passing after panic recovery (calls=%d, status=%d)",
-		tr.calls.Load(), tgt.status.Get())
+		require.GreaterOrEqual(t, tr.calls.Load(), int32(2),
+			"probe loop did not survive panic: only %d RoundTrip calls observed", tr.calls.Load())
+		require.Equal(t, StatusPassing, tgt.status.Get(),
+			"status did not transition to Passing after panic recovery (calls=%d, status=%d)",
+			tr.calls.Load(), tgt.status.Get())
+	})
 }

--- a/pkg/backends/healthcheck/target_test.go
+++ b/pkg/backends/healthcheck/target_test.go
@@ -22,10 +22,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strconv"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -33,6 +33,21 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func okProbeResponse(req *http.Request) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("OK")),
+		Header:     http.Header{},
+		Request:    req,
+	}
+}
 
 func TestNewTarget(t *testing.T) {
 	_, err := newTarget(context.Background(), "", "", nil, nil)
@@ -249,30 +264,34 @@ func TestProbe(t *testing.T) {
 	})
 
 	t.Run("probe loop", func(t *testing.T) {
-		const intervalMS = 5
-		const windowMS = 1500
+		synctest.Test(t, func(t *testing.T) {
+			const intervalMS = 5
 
-		u, err := url.Parse(ts.URL)
-		require.NoError(t, err)
-		target, err := newTarget(context.Background(), "testprobe", "testprobe", &ho.Options{
-			Verb:          "GET",
-			Scheme:        u.Scheme,
-			Host:          u.Host,
-			Path:          "/",
-			Interval:      intervalMS * time.Millisecond,
-			ExpectedCodes: []int{200},
-		}, ts.Client())
-		require.NoError(t, err)
-		// start probe loop
-		ctx := t.Context()
-		target.Start(ctx)
-		time.Sleep((intervalMS + windowMS) * time.Millisecond)
-		// verify results
-		success := target.successConsecutiveCnt.Load()
-		fail := target.failConsecutiveCnt.Load()
-		require.Equal(t, int32(0), fail)
-		require.GreaterOrEqual(t, success, int32(90))
-		target.Stop()
+			client := &http.Client{
+				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					return okProbeResponse(req), nil
+				}),
+			}
+			target, err := newTarget(context.Background(), "testprobe", "testprobe", &ho.Options{
+				Verb:          "GET",
+				Scheme:        "http",
+				Host:          "probe-loop.invalid",
+				Path:          "/",
+				Interval:      intervalMS * time.Millisecond,
+				ExpectedCodes: []int{200},
+			}, client)
+			require.NoError(t, err)
+			target.Start(t.Context())
+			defer target.Stop()
+
+			time.Sleep(time.Second + 100*intervalMS*time.Millisecond)
+			synctest.Wait()
+
+			success := target.successConsecutiveCnt.Load()
+			fail := target.failConsecutiveCnt.Load()
+			require.Equal(t, int32(0), fail)
+			require.GreaterOrEqual(t, success, int32(90))
+		})
 	})
 }
 


### PR DESCRIPTION
## Description

Related to #1007.

This replaces several wall-clock-sensitive healthcheck and ALB pool tests with `testing/synctest` so they can exercise probe jitter, ticker advancement, status refresh, and stale-cache checks using fake time instead of sleeping for real seconds.

The production healthcheck and ALB pool code is unchanged. This first slice keeps the scope narrow by only updating tests that already depended on `time.Sleep`, polling deadlines, or long timers:

- healthcheck probe loop timing
- healthcheck reregister no-overlap coverage
- healthcheck probe panic recovery coverage
- ALB pool stale-cache repro tests

## Type of Change

- - [ ] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.

## Tests

```powershell
go test -count=1 ./pkg/backends/healthcheck ./pkg/backends/alb/pool
go test -count=1 ./pkg/backends/alb/...
go test -race -count=1 ./pkg/backends/healthcheck ./pkg/backends/alb/pool
```
