### PR TITLE
test: cover sharded query-range integration

### DIFF
--- a/integration/alb_tsm_scale_test.go
+++ b/integration/alb_tsm_scale_test.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -46,6 +47,7 @@ func TestALB_TSM_Scale(t *testing.T) {
 		labeledBackendName = "alb-tsm-scale-labeled"
 		fgrBackendName     = "alb-fgr-scale"
 		nlmBackendName     = "alb-nlm-scale"
+		shardedBackendName = "prom-sharded"
 		numBackends        = 50
 		numLabeledBackends = 10
 	)
@@ -57,7 +59,7 @@ func TestALB_TSM_Scale(t *testing.T) {
 
 	cfgPath := writeScaleConfig(t, fakes, listenPort, metricsPort, mgmtPort,
 		backendName, labeledBackendName, numLabeledBackends,
-		fgrBackendName, nlmBackendName)
+		fgrBackendName, nlmBackendName, shardedBackendName)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -99,6 +101,51 @@ func TestALB_TSM_Scale(t *testing.T) {
 
 		_, hdr2 := queryTricksterProm(t, listenAddr, backendName, "/api/v1/query_range", params)
 		t.Logf("repeat: %s", hdr2.Get("X-Trickster-Result"))
+	})
+
+	t.Run("sharded_range_query_high_shard_count", func(t *testing.T) {
+		resetAll()
+		fakes[0].hits.Store(0)
+		fakes[0].setBehavior(behaviorRangeFromRequest())
+
+		step := 15 * time.Second
+		end := time.Now().Add(-10 * time.Minute).Truncate(time.Minute)
+		start := end.Add(-7 * time.Minute)
+		params := url.Values{
+			"query": {fmt.Sprintf("up + 0*%d", time.Now().UnixNano())},
+			"start": {fmt.Sprintf("%d", start.Unix())},
+			"end":   {fmt.Sprintf("%d", end.Unix())},
+			"step":  {fmt.Sprintf("%d", int(step.Seconds()))},
+		}
+
+		pr, hdr := queryTricksterProm(t, listenAddr, shardedBackendName, "/api/v1/query_range", params)
+		require.Equal(t, "success", pr.Status)
+		var qd promQueryData
+		require.NoError(t, json.Unmarshal(pr.Data, &qd))
+		require.Equal(t, "matrix", qd.ResultType)
+
+		var series []struct {
+			Metric map[string]string `json:"metric"`
+			Values [][]any           `json:"values"`
+		}
+		require.NoError(t, json.Unmarshal(qd.Result, &series))
+		require.Len(t, series, 1)
+		require.Equal(t, fakes[0].label, series[0].Metric["instance"])
+
+		expectedPoints := int(end.Sub(start)/step) + 1
+		require.Len(t, series[0].Values, expectedPoints)
+		for i, point := range series[0].Values {
+			require.Len(t, point, 2)
+			gotTS, ok := point[0].(float64)
+			require.True(t, ok, "timestamp should decode as a JSON number")
+			require.Equal(t, float64(start.Add(time.Duration(i)*step).Unix()), gotTS)
+			require.Equal(t, "1", point[1])
+		}
+
+		hits := fakes[0].hits.Load()
+		require.GreaterOrEqual(t, hits, int64(7))
+		t.Logf("%d points from %d sharded upstream fetches, %s",
+			expectedPoints, hits, hdr.Get("X-Trickster-Result"))
 	})
 
 	t.Run("50_backends_instant_query", func(t *testing.T) {
@@ -585,6 +632,7 @@ func behaviorBadEncoding() *promBehavior         { return &promBehavior{mode: "b
 func behaviorLabelValuesKB(kb int) *promBehavior {
 	return &promBehavior{mode: "labelvalues", seriesKB: kb}
 }
+func behaviorRangeFromRequest() *promBehavior { return &promBehavior{mode: "rangefromrequest"} }
 
 func newFakeProm(t *testing.T, label string) *fakeProm {
 	t.Helper()
@@ -608,7 +656,7 @@ func newFakeProm(t *testing.T, label string) *fakeProm {
 func (f *fakeProm) URL() string                 { return f.srv.URL }
 func (f *fakeProm) setBehavior(b *promBehavior) { f.behavior.Store(b) }
 
-func (f *fakeProm) handleRange(w http.ResponseWriter, _ *http.Request) {
+func (f *fakeProm) handleRange(w http.ResponseWriter, r *http.Request) {
 	f.hits.Add(1)
 	b := f.behavior.Load()
 	if b.delay > 0 {
@@ -647,6 +695,15 @@ func (f *fakeProm) handleRange(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Content-Encoding", "gzip")
 		_, _ = w.Write(buildMatrixBody(f.label))
+		return
+	case "rangefromrequest":
+		body, err := buildMatrixBodyFromRequest(f.label, r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -788,6 +845,55 @@ func buildMatrixBody(instance string) []byte {
 	return []byte(sb.String())
 }
 
+func buildMatrixBodyFromRequest(instance string, r *http.Request) ([]byte, error) {
+	q := r.URL.Query()
+	start, err := parsePromTimeParam(q.Get("start"))
+	if err != nil {
+		return nil, err
+	}
+	end, err := parsePromTimeParam(q.Get("end"))
+	if err != nil {
+		return nil, err
+	}
+	step, err := parsePromStepParam(q.Get("step"))
+	if err != nil {
+		return nil, err
+	}
+	if step <= 0 {
+		return nil, fmt.Errorf("invalid non-positive step %q", q.Get("step"))
+	}
+
+	var sb strings.Builder
+	sb.WriteString(`{"status":"success","data":{"resultType":"matrix","result":[`)
+	sb.WriteString(fmt.Sprintf(
+		`{"metric":{"__name__":"up","job":"fake","instance":%q},"values":[`, instance))
+	for i, ts := 0, start; !ts.After(end); i, ts = i+1, ts.Add(step) {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(fmt.Sprintf(`[%d,"1"]`, ts.Unix()))
+	}
+	sb.WriteString("]}]}}")
+	return []byte(sb.String()), nil
+}
+
+func parsePromTimeParam(input string) (time.Time, error) {
+	if v, err := strconv.ParseInt(input, 10, 64); err == nil {
+		return time.Unix(v, 0), nil
+	}
+	if v, err := strconv.ParseFloat(input, 64); err == nil {
+		return time.Unix(0, int64(v*float64(time.Second))), nil
+	}
+	return time.Parse(time.RFC3339Nano, input)
+}
+
+func parsePromStepParam(input string) (time.Duration, error) {
+	if v, err := strconv.ParseFloat(input, 64); err == nil {
+		return time.Duration(v * float64(time.Second)), nil
+	}
+	return time.ParseDuration(input)
+}
+
 func buildOversizedMatrix(instance string, targetKB int) []byte {
 	now := time.Now().Unix()
 	var sb strings.Builder
@@ -855,7 +961,7 @@ func doRaw(t *testing.T, address, backend, path string, params url.Values) ([]by
 func writeScaleConfig(t *testing.T, fakes []*fakeProm,
 	listenPort, metricsPort, mgmtPort int,
 	albName, labeledAlbName string, labeledN int,
-	fgrAlbName, nlmAlbName string) string {
+	fgrAlbName, nlmAlbName, shardedBackendName string) string {
 	t.Helper()
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "frontend:\n  listen_port: %d\n", listenPort)
@@ -870,6 +976,12 @@ func writeScaleConfig(t *testing.T, fakes []*fakeProm,
 		fmt.Fprintf(&sb, "    origin_url: %s\n", f.URL())
 		sb.WriteString("    cache_name: mem\n")
 	}
+	fmt.Fprintf(&sb, "  %s:\n", shardedBackendName)
+	sb.WriteString("    provider: prometheus\n")
+	fmt.Fprintf(&sb, "    origin_url: %s\n", fakes[0].URL())
+	sb.WriteString("    cache_name: mem\n")
+	sb.WriteString("    shard_max_size_time: 1m\n")
+	sb.WriteString("    shard_step: 1m\n")
 	for i := range labeledN {
 		fmt.Fprintf(&sb, "  prom-lab-%d:\n", i)
 		sb.WriteString("    provider: prometheus\n")


### PR DESCRIPTION
## Description
Fixes #1017.

Adds integration coverage for Prometheus request sharding by configuring a fake-backed `prom-sharded` backend with `shard_max_size_time: 1m` and `shard_step: 1m`. The new test sends a 7-minute `query_range` request, has the fake upstream return data for each requested shard extent, and verifies:

- the client response is 200/success matrix data
- the merged series covers every expected timestamp in the requested range
- the fake upstream received at least 7 `query_range` requests, proving the request was split into more than 4 shards

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [ ] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.

## Tests
- `go test -count=1 -run 'TestALB_TSM_Scale/sharded_range_query_high_shard_count' -v .\main_test.go .\alb_tsm_scale_test.go`
- `go test -count=1 -run '^TestALB_TSM_Scale$' -v .\main_test.go .\alb_tsm_scale_test.go`
- `go test -count=1 ./pkg/timeseries ./pkg/proxy/engines ./pkg/backends/prometheus`

Note: a normal package-level `go test` for `integration` does not build in my Windows environment because existing tests in that package reference `syscall.Kill`.