### PR TITLE
fix: finalize topk and bottomk tsm results

### DIFF
--- a/docs/alb.md
+++ b/docs/alb.md
@@ -100,12 +100,15 @@ For Federation use cases where backends hold different, non-overlapping data, Tr
 | `max` | Maximum value per unique label set + timestamp |
 | `group` | Deduplicate per unique label set + timestamp |
 | `avg` | Dual queries (avg→sum and avg→count); weighted arithmetic mean per unique label set + timestamp |
-| `stddev`, `stdvar`, `quantile`, `topk`, `bottomk`, `limitk`, `limit_ratio` | Deduplicate + inject a warning into the Prometheus response |
+| `topk`, `bottomk` | Query the inner expression across backends, merge it, then apply final top/bottom-k selection per timestamp and aggregation group |
+| `stddev`, `stdvar`, `quantile`, `limitk`, `limit_ratio` | Deduplicate + inject a warning into the Prometheus response |
 | _(none)_ | Deduplicate (default) |
 
 For `avg` queries, Trickster issues two concurrent sub-queries per backend shard — one rewriting the outer `avg` to `sum` and another to `count` — then computes a true weighted arithmetic mean (`sum_total / count_total`) per series per timestamp. This avoids the skew introduced by a naïve avg-of-averages when backends have different data cardinalities.
 
-For non-supportable aggregators (`stddev`, `stdvar`, `quantile`, `topk`, `bottomk`, `limitk`, `limit_ratio`), Trickster falls back to deduplication and injects a `warnings` entry in the Prometheus response body to alert the caller that results may be inaccurate.
+For `topk` and `bottomk`, Trickster sends the inner expression to each backend, merges those inner results using the inner expression's merge strategy, then applies the final rank-and-trim step per timestamp and aggregation group. This prevents each backend's local `topk`/`bottomk` result from being weighted equally during the merge. If the inner expression is `avg`, Trickster still uses the weighted `sum`/`count` rewrite before applying the final rank. This also applies when the rank aggregation is wrapped in `sort()` or `sort_desc()`.
+
+For non-supportable aggregators (`stddev`, `stdvar`, `quantile`, `limitk`, `limit_ratio`), Trickster falls back to deduplication and injects a `warnings` entry in the Prometheus response body to alert the caller that results may be inaccurate.
 
 When a non-dedup strategy is in effect and backends have [injected labels](./prometheus.md#injecting-labels) configured, those labels are automatically stripped before merging. This ensures series from different backends hash identically for aggregation, and the injected labels do not appear in the response.
 

--- a/integration/alb_tsm_correctness_test.go
+++ b/integration/alb_tsm_correctness_test.go
@@ -232,6 +232,148 @@ func TestALBTSMCorrectness(t *testing.T) {
 			resp.StatusCode, resp.Header.Get("X-Trickster-Result"), string(body))
 	})
 
+	t.Run("R1 topk and bottomk trim globally across shards", func(t *testing.T) {
+		type vectorSeries struct {
+			Metric map[string]string `json:"metric"`
+			Value  []any             `json:"value"`
+		}
+		type vectorData struct {
+			ResultType string         `json:"resultType"`
+			Result     []vectorSeries `json:"result"`
+		}
+		type vectorResponse struct {
+			Status string     `json:"status"`
+			Data   vectorData `json:"data"`
+		}
+
+		writeVector := func(w http.ResponseWriter, series []vectorSeries) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(vectorResponse{
+				Status: "success",
+				Data: vectorData{
+					ResultType: "vector",
+					Result:     series,
+				},
+			})
+		}
+		mkSeries := func(job, value string) vectorSeries {
+			return vectorSeries{
+				Metric: map[string]string{"__name__": "up", "job": job},
+				Value:  []any{float64(1700000000), value},
+			}
+		}
+
+		var rankHits atomic.Int64
+		makeMock := func(hits *atomic.Int64, series []vectorSeries) *httptest.Server {
+			return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == promstub.BuildInfoPath {
+					promstub.WriteBuildInfo(w)
+					return
+				}
+				_ = r.ParseForm()
+				q := r.Form.Get("query")
+				if strings.Contains(q, "topk") || strings.Contains(q, "bottomk") {
+					rankHits.Add(1)
+					w.WriteHeader(http.StatusInternalServerError)
+					fmt.Fprintf(w, `{"status":"error","error":"rank wrapper was not unwrapped: %s"}`, q)
+					return
+				}
+				hits.Add(1)
+				writeVector(w, series)
+			}))
+		}
+
+		var m1Hits, m2Hits atomic.Int64
+		m1 := makeMock(&m1Hits, []vectorSeries{
+			mkSeries("east-low", "1"),
+			mkSeries("east-high", "9"),
+		})
+		t.Cleanup(m1.Close)
+		m2 := makeMock(&m2Hits, []vectorSeries{
+			mkSeries("west-low", "0.5"),
+			mkSeries("west-mid", "5"),
+		})
+		t.Cleanup(m2.Close)
+
+		frontPort := 18830
+		metricsPort := 18831
+		mgmtPort := 18832
+
+		yaml := fmt.Sprintf(albTestdata(t, "alb_tsm_correctness/d2.yaml.tmpl"),
+			frontPort, metricsPort, mgmtPort, m1.URL, m2.URL)
+
+		cfgPath := filepath.Join(t.TempDir(), "trickster.yaml")
+		require.NoError(t, os.WriteFile(cfgPath, []byte(yaml), 0644))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		go startTrickster(t, ctx, expectedStartError{}, "-config", cfgPath)
+		waitForTrickster(t, fmt.Sprintf("127.0.0.1:%d", metricsPort))
+
+		queryRank := func(operator string) []vectorSeries {
+			t.Helper()
+			var series []vectorSeries
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				beforeM1 := m1Hits.Load()
+				beforeM2 := m2Hits.Load()
+				query := fmt.Sprintf("%s(1, up + 0*%d)", operator, time.Now().UnixNano())
+				u := fmt.Sprintf("http://127.0.0.1:%d/alb-tsm-avg/api/v1/query?query=%s",
+					frontPort, url.QueryEscape(query))
+				r, err := http.Get(u)
+				if !assert.NoError(c, err) {
+					return
+				}
+				b, _ := io.ReadAll(r.Body)
+				r.Body.Close()
+				if !assert.Greater(c, m1Hits.Load(), beforeM1, "query=%s body=%s", query, string(b)) {
+					return
+				}
+				if !assert.Greater(c, m2Hits.Load(), beforeM2, "query=%s body=%s", query, string(b)) {
+					return
+				}
+				if !assert.Equal(c, http.StatusOK, r.StatusCode, "body=%s", string(b)) {
+					return
+				}
+				var pr promResponse
+				if !assert.NoError(c, json.Unmarshal(b, &pr)) {
+					return
+				}
+				if !assert.Equal(c, "success", pr.Status, "body=%s", string(b)) {
+					return
+				}
+				var qd promQueryData
+				if !assert.NoError(c, json.Unmarshal(pr.Data, &qd)) {
+					return
+				}
+				if !assert.Equal(c, "vector", qd.ResultType, "body=%s", string(b)) {
+					return
+				}
+				var got []vectorSeries
+				if !assert.NoError(c, json.Unmarshal(qd.Result, &got)) {
+					return
+				}
+				if !assert.Len(c, got, 1, "body=%s", string(b)) {
+					return
+				}
+				series = got
+			}, 5*time.Second, 100*time.Millisecond, "rank query never returned one globally trimmed series")
+			return series
+		}
+
+		top := queryRank("topk")
+		require.Equal(t, "east-high", top[0].Metric["job"])
+		require.Equal(t, "9", top[0].Value[1])
+
+		bottom := queryRank("bottomk")
+		require.Equal(t, "west-low", bottom[0].Metric["job"])
+		require.Equal(t, "0.5", bottom[0].Value[1])
+
+		require.GreaterOrEqual(t, m1Hits.Load()+m2Hits.Load(), int64(4),
+			"expected both topk and bottomk queries to fan out their inner expressions to both shards")
+		require.Zero(t, rankHits.Load(), "rank wrapper should not be sent to upstream shards")
+	})
+
 	t.Run("V2 partial failure surfaces in X-Trickster-Result", func(t *testing.T) {
 		okVector := albTestdata(t, "alb_tsm_correctness/v2_vector.json")
 

--- a/pkg/backends/alb/mech/tsm/time_series_merge.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge.go
@@ -44,6 +44,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/proxy/params"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
 	"golang.org/x/sync/errgroup"
 )
@@ -73,6 +74,14 @@ type handler struct {
 	// as the pool hasn't been replaced. Hot path is a single atomic load
 	// plus a uint64 compare.
 	cachedStripKeys atomic.Pointer[stripKeysSnapshot]
+}
+
+type mergeFinalizer interface {
+	FinalizeTSMMerge(query string, ts timeseries.Timeseries)
+}
+
+type mergeRequestRewriter interface {
+	RewriteForTSMMerge(r *http.Request, query string) (*http.Request, string)
 }
 
 // stripKeysSnapshot binds a computed stripKeys slice to the poolVersion it
@@ -304,12 +313,20 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var needsDualQuery bool
 	var warnMsg string
 	var mp backends.TSMMergeProvider
+	var finalizer mergeFinalizer
+	var rewriter mergeRequestRewriter
 	if hl[0] != nil {
 		if b := hl[0].Backend(); b != nil {
 			if p, ok := b.(backends.TSMMergeProvider); ok {
 				mp = p
 				strategyInt, dq, w := mp.ClassifyMerge(query)
 				mergeStrategy, needsDualQuery, warnMsg = dataset.MergeStrategy(strategyInt), dq, w
+			}
+			if f, ok := b.(mergeFinalizer); ok {
+				finalizer = f
+			}
+			if rw, ok := b.(mergeRequestRewriter); ok {
+				rewriter = rw
 			}
 			// backends that don't implement TSMMergeProvider default to dedup.
 		}
@@ -365,12 +382,17 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if needsDualQuery {
-		h.serveWeightedAvg(w, r, hl, rsc, mp, query, stripKeys)
+		h.serveWeightedAvg(w, r, hl, rsc, mp, query, stripKeys, finalizer)
 		return
 	}
 
+	fanoutReq := r
+	if rewriter != nil {
+		fanoutReq, _ = rewriter.RewriteForTSMMerge(r, query)
+	}
+
 	// Standard scatter/gather for all non-avg strategies.
-	h.serveStandard(w, r, hl, rsc, mergeStrategy, stripKeys, warnMsg)
+	h.serveStandard(w, fanoutReq, hl, rsc, mergeStrategy, stripKeys, query, finalizer, warnMsg)
 }
 
 // gatherResult captures the per-member fanout outcome used to assemble the
@@ -459,6 +481,8 @@ func (h *handler) serveStandard(
 	hl pool.Targets, rsc *request.Resources,
 	mergeStrategy dataset.MergeStrategy,
 	stripKeys []string,
+	query string,
+	finalizer mergeFinalizer,
 	warnMsg string,
 ) {
 	l := len(hl)
@@ -572,6 +596,10 @@ func (h *handler) serveStandard(
 				ds.Warnings = append(ds.Warnings, warnMsg)
 			}
 		}
+	}
+
+	if finalizer != nil {
+		finalizer.FinalizeTSMMerge(query, accumulator.GetTSData())
 	}
 
 	// If every fanout slot failed at the dispatch level (panics, transport
@@ -724,6 +752,7 @@ func (h *handler) serveWeightedAvg(
 	w http.ResponseWriter, r *http.Request,
 	hl pool.Targets, rsc *request.Resources,
 	mp backends.TSMMergeProvider, query string, stripKeys []string,
+	finalizer mergeFinalizer,
 ) {
 	l := len(hl)
 
@@ -871,6 +900,10 @@ func (h *handler) serveWeightedAvg(
 			countDS.Warnings = append(countDS.Warnings, warnSumFailed)
 		}
 		sumAccum.SetTSData(countTS)
+	}
+
+	if finalizer != nil {
+		finalizer.FinalizeTSMMerge(query, sumAccum.GetTSData())
 	}
 
 	// Aggregate status and headers from sum-query results (count results are

--- a/pkg/backends/alb/mech/tsm/time_series_merge_finalizer_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_finalizer_test.go
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tsm
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/backends/alb/pool"
+	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/params"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
+)
+
+type finalizerStubBackend struct {
+	stripKeysStubBackend
+	mu    sync.Mutex
+	query string
+}
+
+func (b *finalizerStubBackend) ClassifyMerge(string) (int, bool, string) {
+	return int(dataset.MergeStrategyDedup), false, ""
+}
+
+func (b *finalizerStubBackend) RewriteForWeightedAvg(r *http.Request, _ string) (*http.Request, *http.Request) {
+	return r, r
+}
+
+func (b *finalizerStubBackend) FinalizeTSMMerge(query string, ts timeseries.Timeseries) {
+	b.mu.Lock()
+	b.query = query
+	b.mu.Unlock()
+
+	ds, ok := ts.(*dataset.DataSet)
+	if !ok || ds == nil || len(ds.Results) == 0 || len(ds.Results[0].SeriesList) == 0 {
+		return
+	}
+	ds.Results[0].SeriesList = ds.Results[0].SeriesList[:1]
+	ds.Warnings = append(ds.Warnings, "finalized")
+}
+
+func (b *finalizerStubBackend) Query() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.query
+}
+
+type rankRewriteFinalizerStubBackend struct {
+	finalizerStubBackend
+	innerQuery string
+}
+
+func (b *rankRewriteFinalizerStubBackend) ClassifyMerge(string) (int, bool, string) {
+	return int(dataset.MergeStrategySum), false, ""
+}
+
+func (b *rankRewriteFinalizerStubBackend) RewriteForTSMMerge(
+	r *http.Request, _ string,
+) (*http.Request, string) {
+	next, err := request.Clone(r)
+	if err != nil {
+		return r, b.innerQuery
+	}
+	params.SetRequestValues(next, url.Values{"query": {b.innerQuery}})
+	return next, b.innerQuery
+}
+
+type queryRecorder struct {
+	mu      sync.Mutex
+	queries []string
+}
+
+func (qr *queryRecorder) Append(query string) {
+	qr.mu.Lock()
+	defer qr.mu.Unlock()
+	qr.queries = append(qr.queries, query)
+}
+
+func (qr *queryRecorder) Queries() []string {
+	qr.mu.Lock()
+	defer qr.mu.Unlock()
+	return append([]string(nil), qr.queries...)
+}
+
+func recordingMergeHandler(marker string, qr *queryRecorder) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		qp, _, _ := params.GetRequestValues(r)
+		qr.Append(qp.Get("query"))
+		stubMergeHandler(marker, http.StatusOK).ServeHTTP(w, r)
+	})
+}
+
+func TestServeStandardCallsMergeFinalizer(t *testing.T) {
+	logger.SetLogger(testLogger)
+
+	be := &finalizerStubBackend{}
+	targets := make(pool.Targets, 2)
+	for i, h := range []http.Handler{
+		stubMergeHandler("alpha", http.StatusOK),
+		stubMergeHandler("beta", http.StatusOK),
+	} {
+		st := &healthcheck.Status{}
+		st.Set(healthcheck.StatusPassing)
+		targets[i] = pool.NewTarget(h, st, be)
+	}
+	p := pool.New(targets, -1)
+	defer p.Stop()
+	p.RefreshHealthy()
+
+	h := &handler{mergePaths: []string{"/"}}
+	h.SetPool(p)
+
+	req := newTestMergeRequest(t)
+	rsc := request.GetResources(req)
+	rsc.TimeRangeQuery = &timeseries.TimeRangeQuery{Statement: "topk(1, up)"}
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if got := be.Query(); got != "topk(1, up)" {
+		t.Fatalf("finalizer query got %q want %q", got, "topk(1, up)")
+	}
+	body := w.Body.String()
+	if !strings.HasPrefix(body, "MERGED:series=alpha|warnings=") {
+		t.Fatalf("body got %q; expected only alpha series after finalization", body)
+	}
+	if strings.Contains(body, "series=alpha,beta") || strings.Contains(body, "series=beta") {
+		t.Fatalf("body got %q; beta should have been removed by finalizer", body)
+	}
+	for _, warning := range []string{"alpha", "beta", "finalized"} {
+		if !strings.Contains(body, warning) {
+			t.Fatalf("body got %q; missing warning %q", body, warning)
+		}
+	}
+}
+
+func TestServeStandardRewritesRankFanoutToInnerQuery(t *testing.T) {
+	logger.SetLogger(testLogger)
+
+	const (
+		outerQuery = "topk(1, sum by (service) (requests))"
+		innerQuery = "sum by (service) (requests)"
+	)
+	be := &rankRewriteFinalizerStubBackend{innerQuery: innerQuery}
+	qr := &queryRecorder{}
+	targets := make(pool.Targets, 2)
+	for i, h := range []http.Handler{
+		recordingMergeHandler("alpha", qr),
+		recordingMergeHandler("beta", qr),
+	} {
+		st := &healthcheck.Status{}
+		st.Set(healthcheck.StatusPassing)
+		targets[i] = pool.NewTarget(h, st, be)
+	}
+	p := pool.New(targets, -1)
+	defer p.Stop()
+	p.RefreshHealthy()
+
+	h := &handler{mergePaths: []string{"/"}}
+	h.SetPool(p)
+
+	req := newTestMergeRequest(t)
+	req.URL.RawQuery = "query=" + url.QueryEscape(outerQuery)
+	rsc := request.GetResources(req)
+	rsc.TimeRangeQuery = &timeseries.TimeRangeQuery{Statement: outerQuery}
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if got := be.Query(); got != outerQuery {
+		t.Fatalf("finalizer query got %q want %q", got, outerQuery)
+	}
+	queries := qr.Queries()
+	if len(queries) != 2 {
+		t.Fatalf("recorded queries got %v want two entries", queries)
+	}
+	for _, got := range queries {
+		if got != innerQuery {
+			t.Fatalf("fanout query got %q want %q (all queries: %v)", got, innerQuery, queries)
+		}
+	}
+}

--- a/pkg/backends/alb/mech/tsm/time_series_merge_serve_weighted_avg_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_serve_weighted_avg_test.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends"
@@ -63,6 +64,42 @@ func (b *weightedAvgStubBackend) RewriteForWeightedAvg(r *http.Request, query st
 	params.SetRequestValues(sumReq, sumQP)
 	params.SetRequestValues(countReq, countQP)
 	return sumReq, countReq
+}
+
+type weightedAvgRankStubBackend struct {
+	weightedAvgStubBackend
+	mu    sync.Mutex
+	query string
+}
+
+func (b *weightedAvgRankStubBackend) ClassifyMerge(query string) (int, bool, string) {
+	if strings.HasPrefix(query, "topk(") {
+		return int(dataset.MergeStrategySum), true, ""
+	}
+	return b.weightedAvgStubBackend.ClassifyMerge(query)
+}
+
+func (b *weightedAvgRankStubBackend) RewriteForWeightedAvg(r *http.Request, query string) (*http.Request, *http.Request) {
+	if strings.HasPrefix(query, "topk(") {
+		query = "avg(requests)"
+	}
+	return b.weightedAvgStubBackend.RewriteForWeightedAvg(r, query)
+}
+
+func (b *weightedAvgRankStubBackend) FinalizeTSMMerge(query string, ts timeseries.Timeseries) {
+	b.mu.Lock()
+	b.query = query
+	b.mu.Unlock()
+
+	if ds, ok := ts.(*dataset.DataSet); ok && ds != nil {
+		ds.Warnings = append(ds.Warnings, "rank-finalized")
+	}
+}
+
+func (b *weightedAvgRankStubBackend) Query() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.query
 }
 
 type weightedAvgMemberSpec struct {
@@ -188,6 +225,18 @@ func newWeightedAvgPool(handlers []http.Handler) pool.Pool {
 	targets := make(pool.Targets, len(handlers))
 	for i, h := range handlers {
 		targets[i] = newWeightedAvgTarget(h)
+	}
+	p := pool.New(targets, -1)
+	p.RefreshHealthy()
+	return p
+}
+
+func newWeightedAvgRankPool(handlers []http.Handler, be *weightedAvgRankStubBackend) pool.Pool {
+	targets := make(pool.Targets, len(handlers))
+	for i, h := range handlers {
+		st := &healthcheck.Status{}
+		st.Set(healthcheck.StatusPassing)
+		targets[i] = pool.NewTarget(h, st, be)
 	}
 	p := pool.New(targets, -1)
 	p.RefreshHealthy()
@@ -331,6 +380,37 @@ func TestServeWeightedAvg(t *testing.T) {
 		}
 		if !strings.Contains(w.Body.String(), "100=10") {
 			t.Fatalf("body: want weighted avg 100=10, got %q", w.Body.String())
+		}
+	})
+
+	t.Run("rank_wrapper_finalizes_after_weighted_average", func(t *testing.T) {
+		be := &weightedAvgRankStubBackend{}
+		p := newWeightedAvgRankPool([]http.Handler{
+			weightedAvgMemberHandler(weightedAvgMemberSpec{sumValue: "60", countValue: "3"}),
+			weightedAvgMemberHandler(weightedAvgMemberSpec{sumValue: "40", countValue: "1"}),
+		}, be)
+		defer p.Stop()
+		albpool.WaitHealthy(t, p, 2)
+
+		h := &handler{mergePaths: []string{"/"}}
+		h.SetPool(p)
+
+		const query = "topk(1, avg(requests))"
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newWeightedAvgRequest(t, query))
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status: want 200 got %d body=%q", w.Code, w.Body.String())
+		}
+		body := w.Body.String()
+		if !strings.Contains(body, "100=25") {
+			t.Fatalf("body: want weighted avg 100=25, got %q", body)
+		}
+		if !strings.Contains(body, "rank-finalized") {
+			t.Fatalf("body: want finalizer warning, got %q", body)
+		}
+		if got := be.Query(); got != query {
+			t.Fatalf("finalizer query got %q want %q", got, query)
 		}
 	})
 }

--- a/pkg/backends/prometheus/promql/rank_aggregation.go
+++ b/pkg/backends/prometheus/promql/rank_aggregation.go
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package promql
+
+import (
+	"math/big"
+	"slices"
+	"strings"
+)
+
+type AggregationGrouping struct {
+	Labels  []string
+	Without bool
+}
+
+type RankAggregation struct {
+	Operator       string
+	K              int
+	InnerQuery     string
+	Grouping       AggregationGrouping
+	SortSet        bool
+	SortDescending bool
+}
+
+var maxRankK = int(^uint(0) >> 1)
+
+func ParseRankAggregation(query string) (RankAggregation, bool) {
+	q := strings.TrimSpace(query)
+	if inner, ok := unwrapUnaryFunction(q, "sort_desc"); ok {
+		spec, found := ParseRankAggregation(inner)
+		if found {
+			spec.SortSet = true
+			spec.SortDescending = true
+		}
+		return spec, found
+	}
+	if inner, ok := unwrapUnaryFunction(q, "sort"); ok {
+		spec, found := ParseRankAggregation(inner)
+		if found {
+			spec.SortSet = true
+			spec.SortDescending = false
+		}
+		return spec, found
+	}
+	return parseRankAggregation(q)
+}
+
+func parseRankAggregation(query string) (RankAggregation, bool) {
+	q := strings.TrimSpace(query)
+	ql := strings.ToLower(q)
+	var op string
+	for _, candidate := range []string{"bottomk", "topk"} {
+		if !strings.HasPrefix(ql, candidate) {
+			continue
+		}
+		if len(q) == len(candidate) || isPromQLBoundary(q[len(candidate)]) {
+			op = candidate
+			q = strings.TrimSpace(q[len(candidate):])
+			break
+		}
+	}
+	if op == "" {
+		return RankAggregation{}, false
+	}
+
+	var grouping AggregationGrouping
+	var hasGrouping bool
+	if g, rest, ok := parseGrouping(q); ok {
+		grouping = g
+		hasGrouping = true
+		q = rest
+	}
+
+	if q == "" || q[0] != '(' {
+		return RankAggregation{}, false
+	}
+	closeIdx := findMatchingCloser(q, 0, '(', ')')
+	if closeIdx < 0 {
+		return RankAggregation{}, false
+	}
+	args := q[1:closeIdx]
+	trailer := strings.TrimSpace(q[closeIdx+1:])
+	if !hasGrouping && trailer != "" {
+		if g, rest, ok := parseGrouping(trailer); ok {
+			grouping = g
+			hasGrouping = true
+			trailer = rest
+		}
+	}
+	if trailer != "" {
+		return RankAggregation{}, false
+	}
+
+	comma := findTopLevelComma(args)
+	if comma < 0 {
+		return RankAggregation{}, false
+	}
+	k, ok := parseRankK(args[:comma])
+	if !ok {
+		return RankAggregation{}, false
+	}
+	innerQuery := strings.TrimSpace(args[comma+1:])
+	if innerQuery == "" {
+		return RankAggregation{}, false
+	}
+	if !hasGrouping {
+		grouping = AggregationGrouping{}
+	}
+	return RankAggregation{Operator: op, K: k, InnerQuery: innerQuery, Grouping: grouping}, true
+}
+
+func parseRankK(input string) (int, bool) {
+	v, _, err := big.ParseFloat(strings.TrimSpace(input), 10, 256, big.ToNearestEven)
+	if err != nil || v.IsInf() || v.Sign() < 0 {
+		return 0, false
+	}
+	bi, acc := v.Int(nil)
+	if acc != big.Exact || bi.Cmp(big.NewInt(int64(maxRankK))) > 0 {
+		return 0, false
+	}
+	return int(bi.Int64()), true
+}
+
+func parseGrouping(input string) (AggregationGrouping, string, bool) {
+	q := strings.TrimSpace(input)
+	ql := strings.ToLower(q)
+	for _, kw := range []string{"without", "by"} {
+		if !strings.HasPrefix(ql, kw) {
+			continue
+		}
+		if len(q) > len(kw) && !isPromQLBoundary(q[len(kw)]) {
+			continue
+		}
+		rest := strings.TrimSpace(q[len(kw):])
+		if rest == "" || rest[0] != '(' {
+			return AggregationGrouping{}, input, false
+		}
+		closeIdx := findMatchingCloser(rest, 0, '(', ')')
+		if closeIdx < 0 {
+			return AggregationGrouping{}, input, false
+		}
+		labels := parseLabels(rest[1:closeIdx])
+		return AggregationGrouping{
+			Labels:  labels,
+			Without: kw == "without",
+		}, strings.TrimSpace(rest[closeIdx+1:]), true
+	}
+	return AggregationGrouping{}, input, false
+}
+
+func parseLabels(input string) []string {
+	if strings.TrimSpace(input) == "" {
+		return nil
+	}
+	parts := strings.Split(input, ",")
+	seen := make(map[string]struct{}, len(parts))
+	labels := make([]string, 0, len(parts))
+	for _, part := range parts {
+		label := strings.TrimSpace(part)
+		if label == "" {
+			continue
+		}
+		if _, ok := seen[label]; ok {
+			continue
+		}
+		seen[label] = struct{}{}
+		labels = append(labels, label)
+	}
+	slices.Sort(labels)
+	return labels
+}
+
+func unwrapUnaryFunction(query, name string) (string, bool) {
+	q := strings.TrimSpace(query)
+	ql := strings.ToLower(q)
+	prefix := name + "("
+	if !strings.HasPrefix(ql, prefix) {
+		return "", false
+	}
+	openIdx := len(name)
+	closeIdx := findMatchingCloser(q, openIdx, '(', ')')
+	if closeIdx != len(q)-1 {
+		return "", false
+	}
+	return q[openIdx+1 : closeIdx], true
+}
+
+func findTopLevelComma(input string) int {
+	var parens, brackets, braces int
+	var quote byte
+	var escaped bool
+	for i := range input {
+		c := input[i]
+		if quote != 0 {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if c == '\\' && quote != '`' {
+				escaped = true
+				continue
+			}
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch c {
+		case '"', '\'', '`':
+			quote = c
+		case '(':
+			parens++
+		case ')':
+			parens--
+		case '[':
+			brackets++
+		case ']':
+			brackets--
+		case '{':
+			braces++
+		case '}':
+			braces--
+		case ',':
+			if parens == 0 && brackets == 0 && braces == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func findMatchingCloser(input string, openIdx int, open, close byte) int {
+	if openIdx < 0 || openIdx >= len(input) || input[openIdx] != open {
+		return -1
+	}
+	depth := 0
+	var quote byte
+	var escaped bool
+	for i := openIdx; i < len(input); i++ {
+		c := input[i]
+		if quote != 0 {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if c == '\\' && quote != '`' {
+				escaped = true
+				continue
+			}
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch c {
+		case '"', '\'', '`':
+			quote = c
+		case open:
+			depth++
+		case close:
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func isPromQLBoundary(c byte) bool {
+	switch c {
+	case '(', ' ', '\t', '\n', '\r':
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/backends/prometheus/promql/rank_aggregation_test.go
+++ b/pkg/backends/prometheus/promql/rank_aggregation_test.go
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package promql
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestParseRankAggregation(t *testing.T) {
+	tests := []struct {
+		name        string
+		query       string
+		wantFound   bool
+		wantOp      string
+		wantK       int
+		wantInner   string
+		wantLabels  []string
+		wantWithout bool
+		wantSortSet bool
+		wantSortDir bool
+	}{
+		{
+			name:      "topk direct",
+			query:     "topk(5, up)",
+			wantFound: true,
+			wantOp:    "topk",
+			wantK:     5,
+			wantInner: "up",
+		},
+		{
+			name:      "bottomk direct",
+			query:     "bottomk(2, rate(http_requests_total[5m]))",
+			wantFound: true,
+			wantOp:    "bottomk",
+			wantK:     2,
+			wantInner: "rate(http_requests_total[5m])",
+		},
+		{
+			name:       "topk with pre by grouping",
+			query:      "topk by (job, region) (3, up)",
+			wantFound:  true,
+			wantOp:     "topk",
+			wantK:      3,
+			wantInner:  "up",
+			wantLabels: []string{"job", "region"},
+		},
+		{
+			name:        "topk with post without grouping",
+			query:       "topk(4, up) without (instance)",
+			wantFound:   true,
+			wantOp:      "topk",
+			wantK:       4,
+			wantInner:   "up",
+			wantLabels:  []string{"instance"},
+			wantWithout: true,
+		},
+		{
+			name:        "sort_desc wrapper",
+			query:       "sort_desc(topk(7, up))",
+			wantFound:   true,
+			wantOp:      "topk",
+			wantK:       7,
+			wantInner:   "up",
+			wantSortSet: true,
+			wantSortDir: true,
+		},
+		{
+			name:        "sort wrapper",
+			query:       "sort(bottomk(8, up))",
+			wantFound:   true,
+			wantOp:      "bottomk",
+			wantK:       8,
+			wantInner:   "up",
+			wantSortSet: true,
+		},
+		{
+			name:      "inner expression contains commas",
+			query:     `topk(5, label_replace(up, "dst", "$1", "src", "(.*)"))`,
+			wantFound: true,
+			wantOp:    "topk",
+			wantK:     5,
+			wantInner: `label_replace(up, "dst", "$1", "src", "(.*)")`,
+		},
+		{
+			name:      "nested under non-sort expression is not final rank aggregation",
+			query:     "sum(topk(5, up))",
+			wantFound: false,
+		},
+		{
+			name:      "non rank aggregator",
+			query:     "max(up)",
+			wantFound: false,
+		},
+		{
+			name:      "non literal k is not finalized",
+			query:     "topk(k, up)",
+			wantFound: false,
+		},
+		{
+			name:      "fractional k is not finalized",
+			query:     "topk(1.5, up)",
+			wantFound: false,
+		},
+		{
+			name:      "overflowing k is not finalized",
+			query:     "topk(9223372036854775808, up)",
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, found := ParseRankAggregation(tt.query)
+			if found != tt.wantFound {
+				t.Fatalf("found got %v want %v", found, tt.wantFound)
+			}
+			if !found {
+				return
+			}
+			if got.Operator != tt.wantOp {
+				t.Errorf("operator got %q want %q", got.Operator, tt.wantOp)
+			}
+			if got.K != tt.wantK {
+				t.Errorf("k got %d want %d", got.K, tt.wantK)
+			}
+			if got.InnerQuery != tt.wantInner {
+				t.Errorf("inner query got %q want %q", got.InnerQuery, tt.wantInner)
+			}
+			if got.Grouping.Without != tt.wantWithout {
+				t.Errorf("without got %v want %v", got.Grouping.Without, tt.wantWithout)
+			}
+			if !slices.Equal(got.Grouping.Labels, tt.wantLabels) {
+				t.Errorf("labels got %v want %v", got.Grouping.Labels, tt.wantLabels)
+			}
+			if got.SortSet != tt.wantSortSet {
+				t.Errorf("sort set got %v want %v", got.SortSet, tt.wantSortSet)
+			}
+			if got.SortDescending != tt.wantSortDir {
+				t.Errorf("sort direction got %v want %v", got.SortDescending, tt.wantSortDir)
+			}
+		})
+	}
+}

--- a/pkg/backends/prometheus/tsm_provider.go
+++ b/pkg/backends/prometheus/tsm_provider.go
@@ -19,6 +19,7 @@ package prometheus
 import (
 	"maps"
 	"net/http"
+	"net/url"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends/prometheus/promql"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
@@ -38,6 +39,14 @@ const promQueryParam = "query"
 // weighted average is required, and an optional warning for operators whose
 // results cannot be correctly merged across shards.
 func (c *Client) ClassifyMerge(query string) (strategy int, needsDualQuery bool, warning string) {
+	if spec, ok := promql.ParseRankAggregation(query); ok {
+		query = spec.InnerQuery
+	}
+
+	return classifyPromMerge(query)
+}
+
+func classifyPromMerge(query string) (strategy int, needsDualQuery bool, warning string) {
 	agg, found := promql.OuterAggregator(query)
 	if !found {
 		return int(dataset.MergeStrategyDedup), false, ""
@@ -64,37 +73,47 @@ func (c *Client) ClassifyMerge(query string) (strategy int, needsDualQuery bool,
 	}
 }
 
+// RewriteForTSMMerge rewrites Prometheus rank aggregations before TSM fanout.
+// The shards receive the inner query; FinalizeTSMMerge later applies the
+// original topk/bottomk operation to the merged inner result.
+func (c *Client) RewriteForTSMMerge(r *http.Request, query string) (*http.Request, string) {
+	spec, ok := promql.ParseRankAggregation(query)
+	if !ok {
+		return r, query
+	}
+	return rewritePromQueryParam(r, spec.InnerQuery, "rank aggregation"), spec.InnerQuery
+}
+
 // RewriteForWeightedAvg implements backends.TSMMergeProvider for the Prometheus
 // backend. It returns two copies of r — one with the outer "avg" aggregator
 // replaced by "sum" and one by "count" — with the rewritten expression injected
 // into the Prometheus "query" parameter. Both GET (query string) and POST
 // (request body) encodings are handled transparently by params.SetRequestValues.
 func (c *Client) RewriteForWeightedAvg(r *http.Request, query string) (*http.Request, *http.Request) {
+	if spec, ok := promql.ParseRankAggregation(query); ok {
+		query = spec.InnerQuery
+	}
 
-	// Read the original params from r
-	qp, _, _ := params.GetRequestValues(r)
-
-	// construct the sumReq
 	sumQuery := promql.ReplaceOuterAggregator(query, "avg", "sum")
-	sumReq, err := request.Clone(r)
-	if err != nil {
-		logger.Error("failed to clone avg aggregator sumReq",
-			logging.Pairs{"error": err})
-	}
-	sumQP := maps.Clone(qp)
-	sumQP.Set(promQueryParam, sumQuery)
-	params.SetRequestValues(sumReq, sumQP)
-
-	// construct the countReq
 	countQuery := promql.ReplaceOuterAggregator(query, "avg", "count")
-	countReq, err := request.Clone(r)
-	if err != nil {
-		logger.Error("failed to clone avg aggregator countReq",
-			logging.Pairs{"error": err})
-	}
-	countQP := maps.Clone(qp)
-	countQP.Set(promQueryParam, countQuery)
-	params.SetRequestValues(countReq, countQP)
+	sumReq := rewritePromQueryParam(r, sumQuery, "avg aggregator sumReq")
+	countReq := rewritePromQueryParam(r, countQuery, "avg aggregator countReq")
 
 	return sumReq, countReq
+}
+
+func rewritePromQueryParam(r *http.Request, query, cloneName string) *http.Request {
+	qp, _, _ := params.GetRequestValues(r)
+	req, err := request.Clone(r)
+	if err != nil {
+		logger.Error("failed to clone "+cloneName, logging.Pairs{"error": err})
+		return r
+	}
+	nextQP := maps.Clone(qp)
+	if nextQP == nil {
+		nextQP = url.Values{}
+	}
+	nextQP.Set(promQueryParam, query)
+	params.SetRequestValues(req, nextQP)
+	return req
 }

--- a/pkg/backends/prometheus/tsm_provider_test.go
+++ b/pkg/backends/prometheus/tsm_provider_test.go
@@ -51,12 +51,19 @@ func TestClassifyMerge(t *testing.T) {
 		// min / max
 		{"min(up)", int(dataset.MergeStrategyMin), false, ""},
 		{"max(up)", int(dataset.MergeStrategyMax), false, ""},
+		// rank aggregators are finalized after merge
+		{"topk(5, up)", int(dataset.MergeStrategyDedup), false, ""},
+		{"topk(5, sum by (service) (up))", int(dataset.MergeStrategySum), false, ""},
+		{"topk(5, avg by (service) (up))", int(dataset.MergeStrategySum), true, ""},
+		{"sort_desc(topk(5, max(up)))", int(dataset.MergeStrategyMax), false, ""},
+		{"bottomk(5, up)", int(dataset.MergeStrategyDedup), false, ""},
+		{"sort_desc(topk(5, up))", int(dataset.MergeStrategyDedup), false, ""},
 		// unsupported aggregators → dedup + warning containing the operator name
 		{"stddev(up)", int(dataset.MergeStrategyDedup), false, "stddev"},
 		{"stdvar(up)", int(dataset.MergeStrategyDedup), false, "stdvar"},
 		{"quantile(0.9, up)", int(dataset.MergeStrategyDedup), false, "quantile"},
-		{"topk(5, up)", int(dataset.MergeStrategyDedup), false, "topk"},
-		{"bottomk(5, up)", int(dataset.MergeStrategyDedup), false, "bottomk"},
+		{"topk(5, stddev(up))", int(dataset.MergeStrategyDedup), false, "stddev"},
+		{"topk(k, up)", int(dataset.MergeStrategyDedup), false, "topk"},
 		{"limitk(5, up)", int(dataset.MergeStrategyDedup), false, "limitk"},
 		{"limit_ratio(0.5, up)", int(dataset.MergeStrategyDedup), false, "limit_ratio"},
 		// group → default → dedup, no warning
@@ -209,6 +216,83 @@ func TestRewriteForWeightedAvgGET(t *testing.T) {
 					t.Errorf("expected empty rsc.RequestBody for GET, got %q",
 						string(gotRsc.RequestBody))
 				}
+			}
+		})
+	}
+}
+
+func TestRewriteForTSMMergeRankAggregationPOST(t *testing.T) {
+	const (
+		query    = "topk(5, sum(up))"
+		wantQ    = "sum(up)"
+		origBody = "query=topk%285%2C+sum%28up%29%29&start=1000&end=2000&step=15"
+	)
+	r, _ := http.NewRequest(http.MethodPost,
+		"http://example.com/api/v1/query_range",
+		io.NopCloser(bytes.NewBufferString(origBody)))
+	r.Header.Set(headers.NameContentType, headers.ValueXFormURLEncoded)
+	r = request.SetResources(r, &request.Resources{RequestBody: []byte(origBody)})
+
+	rewritten, rewrittenQuery := (&Client{}).RewriteForTSMMerge(r, query)
+	if rewrittenQuery != wantQ {
+		t.Fatalf("rewritten query got %q want %q", rewrittenQuery, wantQ)
+	}
+
+	gotURL, err := url.ParseQuery(rewritten.URL.RawQuery)
+	if err != nil {
+		t.Fatalf("parse URL RawQuery: %v", err)
+	}
+	if q := gotURL.Get("query"); q != wantQ {
+		t.Errorf("URL query param: got %q, want %q", q, wantQ)
+	}
+
+	bodyBytes, err := io.ReadAll(rewritten.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	gotBody, err := url.ParseQuery(string(bodyBytes))
+	if err != nil {
+		t.Fatalf("parse body: %v", err)
+	}
+	if q := gotBody.Get("query"); q != wantQ {
+		t.Errorf("body query param: got %q, want %q", q, wantQ)
+	}
+
+	gotRsc := request.GetResources(rewritten)
+	if gotRsc == nil {
+		t.Fatal("expected non-nil resources")
+	}
+	gotCache, err := url.ParseQuery(string(gotRsc.RequestBody))
+	if err != nil {
+		t.Fatalf("parse rsc.RequestBody: %v", err)
+	}
+	if q := gotCache.Get("query"); q != wantQ {
+		t.Errorf("rsc.RequestBody query param: got %q, want %q", q, wantQ)
+	}
+}
+
+func TestRewriteForWeightedAvgRankAggregationGET(t *testing.T) {
+	const query = "topk(5, avg by (service) (requests))"
+	r, _ := http.NewRequest(http.MethodGet,
+		"http://example.com/api/v1/query_range?query="+url.QueryEscape(query)+"&start=1000&end=2000&step=15",
+		nil)
+
+	sumReq, countReq := (&Client{}).RewriteForWeightedAvg(r, query)
+	for _, tc := range []struct {
+		name  string
+		req   *http.Request
+		wantQ string
+	}{
+		{"sum", sumReq, "sum by (service) (requests)"},
+		{"count", countReq, "count by (service) (requests)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotURL, err := url.ParseQuery(tc.req.URL.RawQuery)
+			if err != nil {
+				t.Fatalf("parse URL RawQuery: %v", err)
+			}
+			if q := gotURL.Get("query"); q != tc.wantQ {
+				t.Errorf("URL query param: got %q, want %q", q, tc.wantQ)
 			}
 		})
 	}

--- a/pkg/backends/prometheus/tsm_rank_finalize.go
+++ b/pkg/backends/prometheus/tsm_rank_finalize.go
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus
+
+import (
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/trickstercache/trickster/v2/pkg/backends/prometheus/promql"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
+)
+
+const (
+	rankOperatorBottomK = "bottomk"
+	rankOperatorTopK    = "topk"
+)
+
+type rankBucketKey struct {
+	epoch int64
+	group string
+}
+
+type rankCandidate struct {
+	series   *dataset.Series
+	pointIdx int
+	value    float64
+	tagsJSON string
+}
+
+// FinalizeTSMMerge applies Prometheus-only merge finalization after TSM fanout
+// has accumulated the rewritten inner-query responses. The rank step belongs
+// here so topk/bottomk operate on globally merged values, not per-backend ranks.
+func (c *Client) FinalizeTSMMerge(query string, ts timeseries.Timeseries) {
+	spec, ok := promql.ParseRankAggregation(query)
+	if !ok {
+		return
+	}
+	ds, ok := ts.(*dataset.DataSet)
+	if !ok || ds == nil {
+		return
+	}
+	finalizeRankAggregation(ds, spec)
+}
+
+func finalizeRankAggregation(ds *dataset.DataSet, spec promql.RankAggregation) {
+	ds.UpdateLock.Lock()
+	defer ds.UpdateLock.Unlock()
+
+	for _, result := range ds.Results {
+		if result == nil || len(result.SeriesList) == 0 {
+			continue
+		}
+		buckets := make(map[rankBucketKey][]rankCandidate)
+		for _, series := range result.SeriesList {
+			if series == nil {
+				continue
+			}
+			group := rankGroupKey(series.Header.Tags, spec.Grouping)
+			tagsJSON := series.Header.Tags.JSON()
+			for i, point := range series.Points {
+				value, ok := rankPointValue(point)
+				if !ok {
+					continue
+				}
+				key := rankBucketKey{epoch: int64(point.Epoch), group: group}
+				buckets[key] = append(buckets[key], rankCandidate{
+					series:   series,
+					pointIdx: i,
+					value:    value,
+					tagsJSON: tagsJSON,
+				})
+			}
+		}
+
+		selected := make(map[*dataset.Series]map[int]struct{})
+		for _, candidates := range buckets {
+			sortRankCandidates(candidates, spec.Operator)
+			limit := min(spec.K, len(candidates))
+			for _, candidate := range candidates[:limit] {
+				if selected[candidate.series] == nil {
+					selected[candidate.series] = make(map[int]struct{})
+				}
+				selected[candidate.series][candidate.pointIdx] = struct{}{}
+			}
+		}
+		result.SeriesList = keepSelectedRankPoints(result.SeriesList, selected)
+		sortRankSeriesIfInstant(result.SeriesList, spec)
+	}
+}
+
+func rankPointValue(point dataset.Point) (float64, bool) {
+	if len(point.Values) == 0 {
+		return 0, false
+	}
+	v, ok := point.Values[0].(string)
+	if !ok {
+		return 0, false
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return 0, false
+	}
+	return f, true
+}
+
+func sortRankCandidates(candidates []rankCandidate, operator string) {
+	slices.SortStableFunc(candidates, func(a, b rankCandidate) int {
+		if rankValueLess(a.value, b.value, operator) {
+			return -1
+		}
+		if rankValueLess(b.value, a.value, operator) {
+			return 1
+		}
+		return strings.Compare(a.tagsJSON, b.tagsJSON)
+	})
+}
+
+func rankValueLess(a, b float64, operator string) bool {
+	aNaN, bNaN := math.IsNaN(a), math.IsNaN(b)
+	if aNaN || bNaN {
+		if aNaN && bNaN {
+			return false
+		}
+		return !aNaN
+	}
+	if operator == rankOperatorBottomK {
+		return a < b
+	}
+	return a > b
+}
+
+func rankGroupKey(tags dataset.Tags, grouping promql.AggregationGrouping) string {
+	if len(grouping.Labels) == 0 {
+		if grouping.Without {
+			return tags.String()
+		}
+		return ""
+	}
+	labelSet := make(map[string]struct{}, len(grouping.Labels))
+	for _, label := range grouping.Labels {
+		labelSet[label] = struct{}{}
+	}
+	if grouping.Without {
+		keys := tags.Keys()
+		kept := make([]string, 0, len(keys))
+		for _, key := range keys {
+			if _, skip := labelSet[key]; !skip {
+				kept = append(kept, key+"="+tags[key])
+			}
+		}
+		return strings.Join(kept, ";")
+	}
+	parts := make([]string, 0, len(grouping.Labels))
+	for _, label := range grouping.Labels {
+		parts = append(parts, label+"="+tags[label])
+	}
+	return strings.Join(parts, ";")
+}
+
+func keepSelectedRankPoints(
+	seriesList dataset.SeriesList, selected map[*dataset.Series]map[int]struct{},
+) dataset.SeriesList {
+	keptSeries := seriesList[:0]
+	for _, series := range seriesList {
+		if series == nil {
+			continue
+		}
+		selectedPoints := selected[series]
+		if len(selectedPoints) == 0 {
+			continue
+		}
+		keptPoints := series.Points[:0]
+		for i, point := range series.Points {
+			if _, ok := selectedPoints[i]; ok {
+				keptPoints = append(keptPoints, point)
+			}
+		}
+		if len(keptPoints) == 0 {
+			continue
+		}
+		series.Points = keptPoints
+		series.PointSize = series.Points.Size()
+		keptSeries = append(keptSeries, series)
+	}
+	return keptSeries
+}
+
+func sortRankSeriesIfInstant(seriesList dataset.SeriesList, spec promql.RankAggregation) {
+	if len(seriesList) < 2 {
+		return
+	}
+	if seriesList[0] == nil || len(seriesList[0].Points) != 1 {
+		return
+	}
+	epoch := seriesList[0].Points[0].Epoch
+	for _, series := range seriesList {
+		if series == nil || len(series.Points) != 1 || series.Points[0].Epoch != epoch {
+			return
+		}
+	}
+	desc := spec.Operator == rankOperatorTopK
+	if spec.SortSet {
+		desc = spec.SortDescending
+	}
+	slices.SortStableFunc(seriesList, func(a, b *dataset.Series) int {
+		iv, iok := rankPointValue(a.Points[0])
+		jv, jok := rankPointValue(b.Points[0])
+		if !iok || !jok {
+			if iok {
+				return -1
+			}
+			if jok {
+				return 1
+			}
+			return 0
+		}
+		op := rankOperatorBottomK
+		if desc {
+			op = rankOperatorTopK
+		}
+		if rankValueLess(iv, jv, op) {
+			return -1
+		}
+		if rankValueLess(jv, iv, op) {
+			return 1
+		}
+		return strings.Compare(a.Header.Tags.JSON(), b.Header.Tags.JSON())
+	})
+}

--- a/pkg/backends/prometheus/tsm_rank_finalize_test.go
+++ b/pkg/backends/prometheus/tsm_rank_finalize_test.go
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus
+
+import (
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/epoch"
+)
+
+func TestFinalizeTSMMergeRankAggregation(t *testing.T) {
+	t.Run("topk trims merged instant vector", func(t *testing.T) {
+		ds := rankDataSet(
+			rankSeries("a", "1", 100),
+			rankSeries("c", "3", 100),
+			rankSeries("b", "4", 100),
+			rankSeries("d", "2", 100),
+		)
+
+		(&Client{}).FinalizeTSMMerge("topk(2, up)", ds)
+
+		got := seriesNames(ds)
+		want := []string{"b", "c"}
+		if !equalStrings(got, want) {
+			t.Fatalf("series got %v want %v", got, want)
+		}
+	})
+
+	t.Run("sort wrapper orders finalized instant vector", func(t *testing.T) {
+		ds := rankDataSet(
+			rankSeries("a", "1", 100),
+			rankSeries("c", "3", 100),
+			rankSeries("b", "4", 100),
+			rankSeries("d", "2", 100),
+		)
+
+		(&Client{}).FinalizeTSMMerge("sort(topk(2, up))", ds)
+
+		got := seriesNames(ds)
+		want := []string{"c", "b"}
+		if !equalStrings(got, want) {
+			t.Fatalf("series got %v want %v", got, want)
+		}
+	})
+
+	t.Run("bottomk trims merged instant vector", func(t *testing.T) {
+		ds := rankDataSet(
+			rankSeries("a", "1", 100),
+			rankSeries("b", "4", 100),
+			rankSeries("c", "3", 100),
+			rankSeries("d", "2", 100),
+		)
+
+		(&Client{}).FinalizeTSMMerge("bottomk(2, up)", ds)
+
+		got := seriesNames(ds)
+		want := []string{"a", "d"}
+		if !equalStrings(got, want) {
+			t.Fatalf("series got %v want %v", got, want)
+		}
+	})
+
+	t.Run("topk filters each range timestamp", func(t *testing.T) {
+		ds := rankDataSet(
+			rankSeries("a", "1", 100, "10", 200),
+			rankSeries("b", "2", 100, "9", 200),
+			rankSeries("c", "3", 100, "8", 200),
+		)
+
+		(&Client{}).FinalizeTSMMerge("topk(2, up)", ds)
+
+		got := seriesPointValues(ds)
+		want := map[string][]string{
+			"a": {"10"},
+			"b": {"2", "9"},
+			"c": {"3"},
+		}
+		if !equalStringSlicesByKey(got, want) {
+			t.Fatalf("points got %v want %v", got, want)
+		}
+	})
+
+	t.Run("topk groups by label", func(t *testing.T) {
+		ds := rankDataSet(
+			rankSeriesWithTags("a", dataset.Tags{"job": "api", "instance": "a"}, "1", 100),
+			rankSeriesWithTags("b", dataset.Tags{"job": "api", "instance": "b"}, "4", 100),
+			rankSeriesWithTags("c", dataset.Tags{"job": "worker", "instance": "c"}, "3", 100),
+			rankSeriesWithTags("d", dataset.Tags{"job": "worker", "instance": "d"}, "2", 100),
+		)
+
+		(&Client{}).FinalizeTSMMerge("topk by (job) (1, up)", ds)
+
+		got := seriesNames(ds)
+		want := []string{"b", "c"}
+		if !equalStrings(got, want) {
+			t.Fatalf("series got %v want %v", got, want)
+		}
+	})
+}
+
+func rankDataSet(series ...*dataset.Series) *dataset.DataSet {
+	return &dataset.DataSet{
+		Results: dataset.Results{{
+			SeriesList: series,
+		}},
+	}
+}
+
+func rankSeries(name string, valuesAndEpochs ...any) *dataset.Series {
+	return rankSeriesWithTags(name, dataset.Tags{"__name__": "up", "instance": name}, valuesAndEpochs...)
+}
+
+func rankSeriesWithTags(name string, tags dataset.Tags, valuesAndEpochs ...any) *dataset.Series {
+	points := make(dataset.Points, 0, len(valuesAndEpochs)/2)
+	for i := 0; i < len(valuesAndEpochs); i += 2 {
+		points = append(points, dataset.Point{
+			Epoch:  epoch.Epoch(valuesAndEpochs[i+1].(int) * 1e9),
+			Size:   32,
+			Values: []any{valuesAndEpochs[i].(string)},
+		})
+	}
+	return &dataset.Series{
+		Header: dataset.SeriesHeader{Name: name, Tags: tags},
+		Points: points,
+	}
+}
+
+func seriesNames(ds *dataset.DataSet) []string {
+	if ds == nil || len(ds.Results) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(ds.Results[0].SeriesList))
+	for _, series := range ds.Results[0].SeriesList {
+		if series != nil {
+			names = append(names, series.Header.Name)
+		}
+	}
+	return names
+}
+
+func seriesPointValues(ds *dataset.DataSet) map[string][]string {
+	out := make(map[string][]string)
+	if ds == nil || len(ds.Results) == 0 {
+		return out
+	}
+	for _, series := range ds.Results[0].SeriesList {
+		if series == nil {
+			continue
+		}
+		for _, point := range series.Points {
+			if len(point.Values) > 0 {
+				out[series.Header.Name] = append(out[series.Header.Name], point.Values[0].(string))
+			}
+		}
+	}
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func equalStringSlicesByKey(a, b map[string][]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key, av := range a {
+		bv, ok := b[key]
+		if !ok || !equalStrings(av, bv) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Description
Fixes #1034.

This makes Prometheus TSM fanout handle `topk` and `bottomk` by unwrapping the rank aggregation before fanout. Shards receive the inner query, Trickster merges the inner results using that inner query's merge strategy, and then the Prometheus finalizer applies the final top/bottom-k rank-and-trim step per timestamp and aggregation group.

This avoids merging backend-local `topk`/`bottomk` candidate sets as if every shard had equal weight. For example, `topk(5, sum by (service) (...))` now fans out `sum by (service) (...)`, merges with the sum strategy, and then ranks the globally merged values. `topk(5, avg by (service) (...))` uses the existing weighted-average path by fanning out sum/count rewrites for the inner avg, finalizing the weighted average, then applying the rank trim.

It also recognizes `sort(...)` and `sort_desc(...)` wrappers around rank aggregations. Unfinalizable forms such as non-literal k still fall back to the existing unsupported-aggregator warning behavior.

Docs are updated to describe inner-query fanout and final rank trimming for `topk` and `bottomk`.

Tests run:

- `go test -count=1 ./pkg/backends/alb/... ./pkg/backends/prometheus/... ./pkg/timeseries/dataset`
- `go tool golangci-lint run --timeout 5m ./pkg/backends/prometheus/... ./pkg/backends/alb/... ./pkg/timeseries/dataset`
- `git diff --check`

Also ran `go test -count=1 ./...`; it still has unrelated local Windows/environment failures in cache access-denial tests using `/root/...` paths and a config golden line-ending mismatch. The Prometheus and ALB packages touched by this PR pass in that full run.

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [x] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [x] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.