### PR TITLE
refactor: keep user-router runtime state out of options

### DIFF
--- a/pkg/backends/alb/client.go
+++ b/pkg/backends/alb/client.go
@@ -40,6 +40,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/metrics"
 	authopt "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/options"
 	authreg "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/registry"
+	at "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/types"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/failures"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/methods"
@@ -230,6 +231,8 @@ func observeOnlyOpts() *authopt.Options {
 func (c *Client) validateAndStartUserRouter(clients backends.Backends, hcs healthcheck.StatusLookup) error {
 	conf := c.Configuration()
 	var canReplaceCreds bool
+	var authenticator at.Authenticator
+	var defaultHandler http.Handler
 	o := conf.ALBOptions.UserRouter
 	h, ok := c.handler.(*ur.Handler)
 	if !ok {
@@ -239,7 +242,7 @@ func (c *Client) validateAndStartUserRouter(clients backends.Backends, hcs healt
 		// credential replacement is only allowed if users will be positively
 		// authenticated and not just observed.
 		canReplaceCreds = !(conf.AuthOptions.Authenticator.IsObserveOnly())
-		h.SetAuthenticator(conf.AuthOptions.Authenticator, canReplaceCreds)
+		authenticator = conf.AuthOptions.Authenticator
 	} else {
 		a, err := authreg.NewObserverFromProviderName(o.TargetProvider,
 			map[string]any{"options": observeOnlyOpts()})
@@ -248,53 +251,61 @@ func (c *Client) validateAndStartUserRouter(clients backends.Backends, hcs healt
 		} else if a == nil {
 			return errors.ErrInvalidOptions
 		}
-		h.SetAuthenticator(a, false)
+		authenticator = a
 	}
+	noRouteStatusCode := o.NoRouteStatusCode
 	if o.DefaultBackend != "" {
 		bh, ok := clients[o.DefaultBackend]
 		if !ok || bh == nil {
 			return alberr.NewErrInvalidBackendName(c.Name(), o.DefaultBackend)
 		}
-		h.SetDefaultHandler(bh.Router())
+		defaultHandler = bh.Router()
 	} else {
-		if o.NoRouteStatusCode < http.StatusBadRequest || o.NoRouteStatusCode >= 600 {
-			o.NoRouteStatusCode = http.StatusBadGateway
+		if noRouteStatusCode < http.StatusBadRequest || noRouteStatusCode >= 600 {
+			noRouteStatusCode = http.StatusBadGateway
 		}
-		switch o.NoRouteStatusCode {
+		switch noRouteStatusCode {
 		case http.StatusUnauthorized:
-			h.SetDefaultHandler(http.HandlerFunc(failures.HandleUnauthorized))
+			defaultHandler = http.HandlerFunc(failures.HandleUnauthorized)
 		case http.StatusBadGateway:
-			h.SetDefaultHandler(http.HandlerFunc(failures.HandleBadGateway))
+			defaultHandler = http.HandlerFunc(failures.HandleBadGateway)
 		case http.StatusBadRequest:
-			h.SetDefaultHandler(http.HandlerFunc(failures.HandleBadRequestResponse))
+			defaultHandler = http.HandlerFunc(failures.HandleBadRequestResponse)
 		case http.StatusInternalServerError:
-			h.SetDefaultHandler(http.HandlerFunc(failures.HandleInternalServerError))
+			defaultHandler = http.HandlerFunc(failures.HandleInternalServerError)
 		case http.StatusNotFound:
-			h.SetDefaultHandler(http.HandlerFunc(failures.HandleNotFound))
+			defaultHandler = http.HandlerFunc(failures.HandleNotFound)
 		default:
-			h.SetDefaultHandler(http.HandlerFunc(func(w http.ResponseWriter,
+			defaultHandler = http.HandlerFunc(func(w http.ResponseWriter,
 				_ *http.Request,
 			) {
-				failures.HandleMiscFailure(o.NoRouteStatusCode, w)
-			}))
+				failures.HandleMiscFailure(noRouteStatusCode, w)
+			})
 		}
 	}
 
-	for _, m := range o.Users {
+	routes := make(ur.UserRoutes, len(o.Users))
+	for username, m := range o.Users {
 		if m.ToBackend != "" {
 			bh, ok := clients[m.ToBackend]
 			if !ok || bh == nil {
 				return alberr.NewErrInvalidBackendName(c.Name(), m.ToBackend)
 			}
-			m.ToHandler = bh.Router()
+			route := ur.UserRoute{Handler: bh.Router()}
 			if hc, ok := hcs[m.ToBackend]; ok {
-				m.ToStatus = hc
+				route.Status = hc
 			}
+			routes[username] = route
 		}
 		if !canReplaceCreds && m.ToCredential != "" {
 			return alberr.NewErrInvalidUserRouterCreds(c.Name())
 		}
 	}
+
+	h.SetAuthenticator(authenticator, canReplaceCreds)
+	h.SetDefaultHandler(defaultHandler)
+	h.SetNoRouteStatusCode(noRouteStatusCode)
+	h.SetUserRoutes(routes)
 
 	return nil
 }

--- a/pkg/backends/alb/client_test.go
+++ b/pkg/backends/alb/client_test.go
@@ -316,8 +316,8 @@ func TestValidateAndStartUserRouter(t *testing.T) {
 		albOpts.ALBOptions = ao.New()
 		albOpts.ALBOptions.MechanismName = names.MechanismUR
 		albOpts.ALBOptions.UserRouter = &uropt.Options{
-			DefaultBackend:   "tenant-a",
-			TargetProvider:   providers.ReverseProxyShort,
+			DefaultBackend: "tenant-a",
+			TargetProvider: providers.ReverseProxyShort,
 			Users: uropt.UserMappingOptionsByUser{
 				"alice": {ToBackend: "tenant-a", ToUser: "alice"},
 			},
@@ -373,6 +373,38 @@ func TestValidateAndStartUserRouter(t *testing.T) {
 		h.ServeHTTP(w, req)
 		if w.Code != http.StatusUnauthorized {
 			t.Fatalf("unauthenticated UR request status = %d, want 401", w.Code)
+		}
+	})
+
+	t.Run("effective no route status does not mutate options", func(t *testing.T) {
+		albOpts := bo.New()
+		albOpts.ALBOptions = ao.New()
+		albOpts.ALBOptions.MechanismName = names.MechanismUR
+		albOpts.ALBOptions.UserRouter = &uropt.Options{
+			TargetProvider:    providers.ReverseProxyShort,
+			NoRouteStatusCode: http.StatusOK,
+		}
+
+		albClient, err := NewClient("ur-edge", albOpts, nil, nil, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cl := albClient.(*Client)
+		h := cl.handler.(*ur.Handler)
+
+		if err := cl.validateAndStartUserRouter(backends.Backends{}, nil); err != nil {
+			t.Fatalf("validateAndStartUserRouter: %v", err)
+		}
+		if got := albOpts.ALBOptions.UserRouter.NoRouteStatusCode; got != http.StatusOK {
+			t.Fatalf("NoRouteStatusCode mutated to %d, want original %d",
+				got, http.StatusOK)
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "http://example/", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusBadGateway {
+			t.Fatalf("unauthenticated UR request status = %d, want effective 502", w.Code)
 		}
 	})
 }

--- a/pkg/backends/alb/mech/ur/options/options.go
+++ b/pkg/backends/alb/mech/ur/options/options.go
@@ -42,8 +42,6 @@ type Options struct {
 	NoRouteStatusCode int `yaml:"no_route_status_code,omitempty"`
 	// Users is a map of usernames to user-specific mapping options
 	Users UserMappingOptionsByUser `yaml:"users,omitempty"`
-	// DefaultHandler is the the HTTP Handler for DefaultBackend
-	DefaultHandler http.Handler `yaml:"-"`
 	// TargetProvider is the Provider name (e.g., 'rpc' or 'clickhouse') that
 	// the user router is handling. While a User Router can point to multiple
 	// ALBs, Rules and Backends, all non-virtual Backends (non-rule, non-ALB)
@@ -51,13 +49,6 @@ type Options struct {
 	// checked and the TargetProvider value is set based on the check results.
 	TargetProvider string `yaml:"-"`
 	albName        string
-}
-
-// HealthStatusGetter exposes the subset of *healthcheck.Status that the
-// router needs to gate dispatch. Declared here to avoid an import cycle
-// into pkg/backends/healthcheck.
-type HealthStatusGetter interface {
-	Get() int32
 }
 
 // UserMappingOptions holds per-user configurations that direct the User Router
@@ -68,12 +59,6 @@ type UserMappingOptions struct {
 	ToUser string `yaml:"to_user"`
 	// ToCredential is the Credential that will be substituted in the upstream request
 	ToCredential types.EnvString `yaml:"to_credential"`
-	// ToHandler is the the HTTP Handler for the Backend in ToBackend
-	ToHandler http.Handler `yaml:"-"`
-	// ToStatus is the Health Status of the routed Backend, when known. When set
-	// and the status is below StatusUnchecked (i.e., Failing or Initializing),
-	// the request falls through to the default handler.
-	ToStatus HealthStatusGetter `yaml:"-"`
 }
 
 type UserMappingOptionsByUser map[string]*UserMappingOptions

--- a/pkg/backends/alb/mech/ur/user_router.go
+++ b/pkg/backends/alb/mech/ur/user_router.go
@@ -17,6 +17,7 @@
 package ur
 
 import (
+	"maps"
 	"net/http"
 	"sync"
 
@@ -32,14 +33,32 @@ import (
 
 const URName types.Name = "user_router"
 
+// HealthStatusGetter exposes the subset of *healthcheck.Status that the
+// router needs to gate dispatch.
+type HealthStatusGetter interface {
+	Get() int32
+}
+
+// UserRoute holds runtime state for one configured user mapping.
+type UserRoute struct {
+	Handler http.Handler
+	Status  HealthStatusGetter
+}
+
+// UserRoutes maps usernames to their resolved runtime route state.
+type UserRoutes map[string]UserRoute
+
 type Handler struct {
-	// mu guards options, authenticator, enableReplaceCreds against concurrent
+	// mu guards runtime handler state against concurrent
 	// reads on the request path and writes during SIGHUP config reload via
-	// ValidateAndStartPool -> SetAuthenticator / SetDefaultHandler.
+	// ValidateAndStartPool.
 	mu                 sync.RWMutex
 	authenticator      at.Authenticator
+	defaultHandler     http.Handler
 	enableReplaceCreds bool
+	noRouteStatusCode  int
 	options            *uropt.Options
+	userRoutes         UserRoutes
 }
 
 func RegistryEntry() types.RegistryEntry {
@@ -54,7 +73,10 @@ func New(o *options.Options, _ rt.Lookup) (types.Mechanism, error) {
 	if o == nil || o.UserRouter == nil {
 		return nil, errors.ErrInvalidOptions
 	}
-	out := &Handler{options: o.UserRouter}
+	out := &Handler{
+		noRouteStatusCode: o.UserRouter.NoRouteStatusCode,
+		options:           o.UserRouter,
+	}
 	return out, nil
 }
 
@@ -67,6 +89,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	opts := h.options
 	auth := h.authenticator
 	replaceAllowed := h.enableReplaceCreds
+	routes := h.userRoutes
 	h.mu.RUnlock()
 
 	var username, cred string
@@ -89,7 +112,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	// if the request doesn't have a username or there are 0 Users in the Router,
 	// the default handler takes the request
-	if username == "" || len(opts.Users) == 0 {
+	if username == "" || opts == nil || len(opts.Users) == 0 {
 		h.handleDefault(w, r)
 		return
 	}
@@ -121,18 +144,18 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		// this passes the request to a user-specific route handler, if set
-		// and the routed backend is currently considered healthy. ToStatus
+		// and the routed backend is currently considered healthy. Status
 		// values below StatusUnchecked (Failing, Initializing) fall through
 		// to the default handler instead of dispatching to a known-bad target.
-		if u.ToHandler != nil {
-			if u.ToStatus == nil || u.ToStatus.Get() >= 0 {
-				u.ToHandler.ServeHTTP(w, r)
+		if route, ok := routes[username]; ok && route.Handler != nil {
+			if route.Status == nil || route.Status.Get() >= 0 {
+				route.Handler.ServeHTTP(w, r)
 				return
 			}
 		}
 	}
 	// the default handler serves the request when the user doesn't have an entry
-	// in the router map, or when a mapped user's entry doesn't have a ToHandler
+	// in the router map, or when a mapped user's entry doesn't have a runtime route
 	h.handleDefault(w, r)
 }
 
@@ -145,16 +168,29 @@ func (h *Handler) SetAuthenticator(a at.Authenticator, enableReplaceCreds bool) 
 
 func (h *Handler) SetDefaultHandler(h2 http.Handler) {
 	h.mu.Lock()
-	if h.options != nil {
-		h.options.DefaultHandler = h2
-	}
+	h.defaultHandler = h2
+	h.mu.Unlock()
+}
+
+func (h *Handler) SetNoRouteStatusCode(code int) {
+	h.mu.Lock()
+	h.noRouteStatusCode = code
+	h.mu.Unlock()
+}
+
+func (h *Handler) SetUserRoutes(routes UserRoutes) {
+	h.mu.Lock()
+	h.userRoutes = maps.Clone(routes)
 	h.mu.Unlock()
 }
 
 func (h *Handler) handleDefault(w http.ResponseWriter, r *http.Request) {
 	h.mu.RLock()
-	dh := h.options.DefaultHandler
-	code := h.options.NoRouteStatusCode
+	dh := h.defaultHandler
+	code := h.noRouteStatusCode
+	if code == 0 && h.options != nil {
+		code = h.options.NoRouteStatusCode
+	}
 	h.mu.RUnlock()
 	if dh == nil {
 		if code < 100 || code >= 600 {

--- a/pkg/backends/alb/mech/ur/user_router.go
+++ b/pkg/backends/alb/mech/ur/user_router.go
@@ -120,9 +120,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if u, ok := opts.Users[username]; ok {
 		// this handles when username or credential is configured to be remapped
 		if enableReplaceCreds && (u.ToUser != "" || u.ToCredential != "") {
+			outboundUsername := username
 			// swap in the new user if configured
 			if u.ToUser != "" {
-				username = u.ToUser
+				outboundUsername = u.ToUser
 			}
 			// swap in the new credential if configured. When ToCredential is
 			// empty, retain the inbound credential rather than overwriting with
@@ -137,7 +138,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			// password and collapses every such user into one cache key.
 			if cred != "" {
 				auth.Sanitize(r)
-				if err := auth.SetCredentials(r, username, cred); err != nil {
+				if err := auth.SetCredentials(r, outboundUsername, cred); err != nil {
 					h.handleDefault(w, r)
 					return
 				}

--- a/pkg/backends/alb/mech/ur/user_router_fuzz_test.go
+++ b/pkg/backends/alb/mech/ur/user_router_fuzz_test.go
@@ -64,23 +64,24 @@ func FuzzUserRouterCredentials(f *testing.F) {
 		w.WriteHeader(http.StatusOK)
 	})
 	h := &Handler{
-		authenticator: auth,
+		authenticator:  auth,
+		defaultHandler: okHandler,
 		options: &uropt.Options{
-			DefaultHandler: okHandler,
 			Users: uropt.UserMappingOptionsByUser{
-				"alice": {ToHandler: okHandler},
-				"":      {ToHandler: okHandler},
+				"alice": {},
+				"":      {},
 			},
 		},
+		userRoutes: UserRoutes{"alice": {Handler: okHandler}},
 	}
 
 	// any status outside this set means the router either misclassified an
 	// auth failure as success or invented a new code path; either is a
 	// regression.
 	validStatuses := map[int]struct{}{
-		http.StatusOK:          {},
+		http.StatusOK:           {},
 		http.StatusUnauthorized: {},
-		http.StatusBadGateway:  {},
+		http.StatusBadGateway:   {},
 	}
 
 	f.Fuzz(func(t *testing.T, raw string) {

--- a/pkg/backends/alb/mech/ur/user_router_reload_test.go
+++ b/pkg/backends/alb/mech/ur/user_router_reload_test.go
@@ -31,17 +31,16 @@ import (
 
 // Concurrent SetDefaultHandler / SetAuthenticator vs ServeHTTP. Run under
 // -race to catch any regression in the locking discipline. Without the mutex,
-// this races on h.options.DefaultHandler / h.authenticator fields.
+// this races on h.defaultHandler / h.authenticator fields.
 func TestURConcurrentReloadIsRaceFree(t *testing.T) {
 	okH := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 
 	h := &Handler{
-		options: &uropt.Options{
-			DefaultHandler:    okH,
-			NoRouteStatusCode: http.StatusUnauthorized,
-		},
+		defaultHandler:    okH,
+		noRouteStatusCode: http.StatusUnauthorized,
+		options:           &uropt.Options{},
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -84,16 +83,16 @@ func TestURRetainsInboundCredWhenToCredentialEmpty(t *testing.T) {
 
 	h := &Handler{
 		authenticator:      auth,
+		defaultHandler:     okH,
 		enableReplaceCreds: true,
 		options: &uropt.Options{
-			DefaultHandler: okH,
 			Users: uropt.UserMappingOptionsByUser{
 				"alice": {
-					ToUser:    "bob",
-					ToHandler: okH,
+					ToUser: "bob",
 				},
 			},
 		},
+		userRoutes: UserRoutes{"alice": {Handler: okH}},
 	}
 
 	r, _ := http.NewRequest("GET", "http://example.com/", nil)

--- a/pkg/backends/alb/mech/ur/user_router_test.go
+++ b/pkg/backends/alb/mech/ur/user_router_test.go
@@ -222,6 +222,51 @@ func TestServeHTTP(t *testing.T) {
 		}
 	})
 
+	t.Run("credential remapping keeps inbound username for routing", func(t *testing.T) {
+		auth := &mockAuth{}
+		aliceHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusAccepted)
+		})
+		adminHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusTeapot)
+		})
+		h := &Handler{
+			authenticator:      auth,
+			defaultHandler:     okHandler,
+			enableReplaceCreds: true,
+			options: &uropt.Options{
+				Users: uropt.UserMappingOptionsByUser{
+					"alice": {
+						ToUser:       "admin",
+						ToCredential: "secret",
+					},
+				},
+			},
+			userRoutes: UserRoutes{
+				"alice": {Handler: aliceHandler},
+				"admin": {Handler: adminHandler},
+			},
+		}
+		w := httptest.NewRecorder()
+		r, _ := http.NewRequest("GET", "http://example.com/", nil)
+		r = request.SetResources(r, &request.Resources{
+			AuthResult: &at.AuthResult{Username: "alice", Status: at.AuthSuccess},
+		})
+
+		h.ServeHTTP(w, r)
+
+		if w.Code != http.StatusAccepted {
+			t.Fatalf("status = %d, want %d from alice route", w.Code, http.StatusAccepted)
+		}
+		if len(auth.setCalls) != 1 {
+			t.Fatalf("expected 1 SetCredentials call, got %d", len(auth.setCalls))
+		}
+		if auth.setCalls[0].user != "admin" || auth.setCalls[0].cred != "secret" {
+			t.Errorf("expected outbound admin/secret, got %s/%s",
+				auth.setCalls[0].user, auth.setCalls[0].cred)
+		}
+	})
+
 	t.Run("user in map without runtime route falls to default", func(t *testing.T) {
 		defaultCalled := false
 		defaultH := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/backends/alb/mech/ur/user_router_test.go
+++ b/pkg/backends/alb/mech/ur/user_router_test.go
@@ -68,11 +68,7 @@ func (m *mockAuth) Sanitize(r *http.Request) {
 func TestHandleDefaultNilHandler(t *testing.T) {
 	// Before the fix, this would panic with a nil pointer dereference
 	// because handleDefault did not return after calling HandleBadGateway.
-	h := &Handler{
-		options: &uropt.Options{
-			DefaultHandler: nil,
-		},
-	}
+	h := &Handler{}
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest("GET", "http://example.com/", nil)
 	h.handleDefault(w, r)
@@ -84,12 +80,10 @@ func TestHandleDefaultNilHandler(t *testing.T) {
 func TestHandleDefaultWithHandler(t *testing.T) {
 	called := false
 	h := &Handler{
-		options: &uropt.Options{
-			DefaultHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				called = true
-				w.WriteHeader(http.StatusOK)
-			}),
-		},
+		defaultHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusOK)
+		}),
 	}
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest("GET", "http://example.com/", nil)
@@ -109,9 +103,8 @@ func TestServeHTTP(t *testing.T) {
 
 	t.Run("no username falls through to default", func(t *testing.T) {
 		h := &Handler{
-			options: &uropt.Options{
-				DefaultHandler: okHandler,
-			},
+			defaultHandler: okHandler,
+			options:        &uropt.Options{},
 		}
 		w := httptest.NewRecorder()
 		r, _ := http.NewRequest("GET", "http://example.com/", nil)
@@ -128,12 +121,13 @@ func TestServeHTTP(t *testing.T) {
 			w.WriteHeader(http.StatusAccepted)
 		})
 		h := &Handler{
+			defaultHandler: okHandler,
 			options: &uropt.Options{
-				DefaultHandler: okHandler,
 				Users: uropt.UserMappingOptionsByUser{
-					"alice": {ToHandler: userHandler},
+					"alice": {},
 				},
 			},
+			userRoutes: UserRoutes{"alice": {Handler: userHandler}},
 		}
 		w := httptest.NewRecorder()
 		r, _ := http.NewRequest("GET", "http://example.com/", nil)
@@ -152,12 +146,13 @@ func TestServeHTTP(t *testing.T) {
 
 	t.Run("unknown user falls through to default", func(t *testing.T) {
 		h := &Handler{
+			defaultHandler: okHandler,
 			options: &uropt.Options{
-				DefaultHandler: okHandler,
 				Users: uropt.UserMappingOptionsByUser{
-					"alice": {ToHandler: okHandler},
+					"alice": {},
 				},
 			},
+			userRoutes: UserRoutes{"alice": {Handler: okHandler}},
 		}
 		w := httptest.NewRecorder()
 		r, _ := http.NewRequest("GET", "http://example.com/", nil)
@@ -178,13 +173,14 @@ func TestServeHTTP(t *testing.T) {
 			w.WriteHeader(http.StatusAccepted)
 		})
 		h := &Handler{
-			authenticator: &mockAuth{username: "carol", cred: "pass"},
+			authenticator:  &mockAuth{username: "carol", cred: "pass"},
+			defaultHandler: okHandler,
 			options: &uropt.Options{
-				DefaultHandler: okHandler,
 				Users: uropt.UserMappingOptionsByUser{
-					"carol": {ToHandler: userHandler},
+					"carol": {},
 				},
 			},
+			userRoutes: UserRoutes{"carol": {Handler: userHandler}},
 		}
 		w := httptest.NewRecorder()
 		r, _ := http.NewRequest("GET", "http://example.com/", nil)
@@ -198,17 +194,17 @@ func TestServeHTTP(t *testing.T) {
 		auth := &mockAuth{}
 		h := &Handler{
 			authenticator:      auth,
+			defaultHandler:     okHandler,
 			enableReplaceCreds: true,
 			options: &uropt.Options{
-				DefaultHandler: okHandler,
 				Users: uropt.UserMappingOptionsByUser{
 					"alice": {
 						ToUser:       "admin",
 						ToCredential: "secret",
-						ToHandler:    okHandler,
 					},
 				},
 			},
+			userRoutes: UserRoutes{"alice": {Handler: okHandler}},
 		}
 		w := httptest.NewRecorder()
 		r, _ := http.NewRequest("GET", "http://example.com/", nil)
@@ -226,17 +222,17 @@ func TestServeHTTP(t *testing.T) {
 		}
 	})
 
-	t.Run("user in map without ToHandler falls to default", func(t *testing.T) {
+	t.Run("user in map without runtime route falls to default", func(t *testing.T) {
 		defaultCalled := false
 		defaultH := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			defaultCalled = true
 			w.WriteHeader(http.StatusOK)
 		})
 		h := &Handler{
+			defaultHandler: defaultH,
 			options: &uropt.Options{
-				DefaultHandler: defaultH,
 				Users: uropt.UserMappingOptionsByUser{
-					"alice": {}, // no ToHandler
+					"alice": {},
 				},
 			},
 		}
@@ -248,7 +244,7 @@ func TestServeHTTP(t *testing.T) {
 		r = request.SetResources(r, rsc)
 		h.ServeHTTP(w, r)
 		if !defaultCalled {
-			t.Error("expected default handler when user has no ToHandler")
+			t.Error("expected default handler when user has no runtime route")
 		}
 	})
 
@@ -264,17 +260,17 @@ func TestServeHTTP(t *testing.T) {
 		auth := &mockAuth{setErr: errors.New("boom")}
 		h := &Handler{
 			authenticator:      auth,
+			defaultHandler:     okHandler,
 			enableReplaceCreds: true,
 			options: &uropt.Options{
-				DefaultHandler: okHandler,
 				Users: uropt.UserMappingOptionsByUser{
 					"alice": {
 						ToUser:       "admin",
 						ToCredential: "secret",
-						ToHandler:    target,
 					},
 				},
 			},
+			userRoutes: UserRoutes{"alice": {Handler: target}},
 		}
 		w := httptest.NewRecorder()
 		r, _ := http.NewRequest("GET", "http://example.com/", nil)
@@ -293,9 +289,7 @@ func TestServeHTTP(t *testing.T) {
 	// and no DefaultHandler has been wired up by the client startup path.
 	t.Run("NoRouteStatusCode honored without DefaultHandler", func(t *testing.T) {
 		h := &Handler{
-			options: &uropt.Options{
-				NoRouteStatusCode: http.StatusNotFound,
-			},
+			noRouteStatusCode: http.StatusNotFound,
 		}
 		w := httptest.NewRecorder()
 		r, _ := http.NewRequest("GET", "http://example.com/", nil)
@@ -322,17 +316,17 @@ func TestServeHTTP(t *testing.T) {
 		}
 		h := &Handler{
 			authenticator:      auth,
+			defaultHandler:     okHandler,
 			enableReplaceCreds: true,
 			options: &uropt.Options{
-				DefaultHandler: okHandler,
 				Users: uropt.UserMappingOptionsByUser{
 					"alice": {
 						ToUser:       "admin",
 						ToCredential: "secret",
-						ToHandler:    target,
 					},
 				},
 			},
+			userRoutes: UserRoutes{"alice": {Handler: target}},
 		}
 		w := httptest.NewRecorder()
 		r, _ := http.NewRequest("GET", "http://example.com/", nil)

--- a/pkg/backends/alb/mech/ur/user_router_unavail_test.go
+++ b/pkg/backends/alb/mech/ur/user_router_unavail_test.go
@@ -47,15 +47,13 @@ func TestServeHTTPSkipsUnhealthyUserTarget(t *testing.T) {
 	failing.Set(healthcheck.StatusFailing)
 
 	h := &Handler{
+		defaultHandler: defaultHandler,
 		options: &uropt.Options{
-			DefaultHandler: defaultHandler,
 			Users: uropt.UserMappingOptionsByUser{
-				"alice": {
-					ToHandler: userHandler,
-					ToStatus:  failing,
-				},
+				"alice": {},
 			},
 		},
+		userRoutes: UserRoutes{"alice": {Handler: userHandler, Status: failing}},
 	}
 
 	r, _ := http.NewRequest("GET", "http://example.com/", nil)


### PR DESCRIPTION
## Description
Fixes #1010.

Moves resolved user-router runtime state out of `ur/options.Options`:

- stores the default handler, effective no-route status, and per-user route handlers on `ur.Handler`
- removes `DefaultHandler`, `ToHandler`, and `ToStatus` from the user-router options structs
- builds runtime routes locally during `validateAndStartUserRouter` and applies them only after validation succeeds
- keeps the configured `NoRouteStatusCode` unchanged while still using the effective startup response code

Tests:

- `go test -count=1 ./pkg/backends/alb/mech/ur ./pkg/backends/alb`
- `go test -count=1 ./pkg/backends/alb/...`
- `go tool golangci-lint run --timeout 5m ./pkg/backends/alb/...`
- `go test -run '^$' ./...`

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [ ] Bug fix
- - [ ] New feature
- - [x] Optimization
- - [x] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.