### PR TITLE
fix: apply configured OTLP endpoint

### DIFF
--- a/pkg/observability/tracing/exporters/otlp/otlp.go
+++ b/pkg/observability/tracing/exporters/otlp/otlp.go
@@ -61,6 +61,7 @@ func New(o *options.Options) (*tracing.Tracer, error) {
 	// this determines if the collector endpoint is a path, uri or url
 	// and calls the appropriate Options decorator
 	switch {
+	case o.Endpoint == "":
 	case strings.HasPrefix(o.Endpoint, "/"):
 		opts = append(opts, otlp.WithURLPath(o.Endpoint))
 	case strings.HasPrefix(o.Endpoint, "http"):
@@ -69,7 +70,7 @@ func New(o *options.Options) (*tracing.Tracer, error) {
 			opts = append(opts, otlp.WithInsecure())
 		}
 	default:
-		otlp.WithEndpoint(o.Endpoint)
+		opts = append(opts, otlp.WithEndpoint(o.Endpoint))
 	}
 
 	if o.Timeout > 0 {

--- a/pkg/observability/tracing/exporters/otlp/otlp_test.go
+++ b/pkg/observability/tracing/exporters/otlp/otlp_test.go
@@ -18,7 +18,13 @@
 package otlp
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	errs "github.com/trickstercache/trickster/v2/pkg/observability/tracing/errors"
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing/options"
@@ -49,5 +55,97 @@ func TestNew(t *testing.T) {
 	_, err = New(opt)
 	if err != nil {
 		t.Error(err)
+	}
+}
+
+func TestNewAppliesEndpointOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint func(*httptest.Server) string
+		env      map[string]string
+		wantPath string
+	}{
+		{
+			name: "hostport endpoint",
+			endpoint: func(s *httptest.Server) string {
+				return strings.TrimPrefix(s.URL, "http://")
+			},
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_TRACES_INSECURE": "true",
+			},
+			wantPath: "/v1/traces",
+		},
+		{
+			name: "url endpoint",
+			endpoint: func(s *httptest.Server) string {
+				return s.URL + "/custom/traces"
+			},
+			wantPath: "/custom/traces",
+		},
+		{
+			name: "path endpoint",
+			endpoint: func(_ *httptest.Server) string {
+				return "/path-only/traces"
+			},
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://example.invalid/ignored",
+			},
+			wantPath: "/path-only/traces",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			requests := make(chan *http.Request, 10)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.Copy(io.Discard, r.Body)
+				select {
+				case requests <- r.Clone(context.Background()):
+				default:
+				}
+				w.Header().Set("Content-Type", "application/x-protobuf")
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			for k, v := range tc.env {
+				if k == "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT" {
+					v = strings.Replace(v, "http://example.invalid", srv.URL, 1)
+				}
+				t.Setenv(k, v)
+			}
+			t.Setenv("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "1")
+
+			opt := options.New()
+			opt.Endpoint = tc.endpoint(srv)
+			opt.Headers = map[string]string{"X-Trickster-Test": tc.name}
+			opt.Timeout = time.Second
+
+			tr, err := New(opt)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, span := tr.Start(context.Background(), "test-span")
+			span.End()
+
+			select {
+			case req := <-requests:
+				if req.URL.Path != tc.wantPath {
+					t.Errorf("expected request path %q, got %q", tc.wantPath, req.URL.Path)
+				}
+				if got := req.Header.Get("X-Trickster-Test"); got != tc.name {
+					t.Errorf("expected custom header %q, got %q", tc.name, got)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("expected OTLP request to configured endpoint")
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			if err = tr.ShutdownFunc(ctx); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Description

Related to #381.

This fixes OTLP tracer setup so a configured host:port endpoint is actually applied. The previous default branch called `otlp.WithEndpoint(o.Endpoint)` without appending the returned option, so a bare endpoint such as `collector:4318` could be ignored and the exporter would fall back to OpenTelemetry defaults.

The change also leaves an empty endpoint unset so OTEL environment/default endpoint behavior remains intact.

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [x] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.

## Tests

- `go test -count=1 ./pkg/observability/tracing/exporters/otlp`
- `go test -count=1 ./pkg/observability/tracing/...`
- `go test -count=1 ./pkg/observability/...`
- `go tool golangci-lint run --timeout 5m ./pkg/observability/tracing/...`
- `git diff --check`