### PR TITLE
fix: include OTLP service resource

### DIFF
--- a/pkg/observability/tracing/exporters/otlp/otlp.go
+++ b/pkg/observability/tracing/exporters/otlp/otlp.go
@@ -49,12 +49,10 @@ func New(o *options.Options) (*tracing.Tracer, error) {
 		sampler = sdktrace.TraceIDRatioBased(*o.SampleRate)
 	}
 
-	var tags []attribute.KeyValue
-	if len(o.Tags) > 0 {
-		tags = make([]attribute.KeyValue, len(o.Tags))
-		for k, v := range o.Tags {
-			tags = append(tags, attribute.String(k, v))
-		}
+	tags := make([]attribute.KeyValue, 1, len(o.Tags)+1)
+	tags[0] = attribute.String("service.name", o.ServiceName)
+	for k, v := range o.Tags {
+		tags = append(tags, attribute.String(k, v))
 	}
 
 	opts := make([]otlp.Option, 0, 10)
@@ -92,10 +90,8 @@ func New(o *options.Options) (*tracing.Tracer, error) {
 
 	tracerOpts := make([]sdktrace.TracerProviderOption, 0, 3)
 	tracerOpts = append(tracerOpts, sdktrace.WithSampler(sampler))
-	if len(tags) > 0 {
-		tracerOpts = append(tracerOpts,
-			sdktrace.WithResource(resource.NewWithAttributes("", tags...)))
-	}
+	tracerOpts = append(tracerOpts,
+		sdktrace.WithResource(resource.NewWithAttributes("", tags...)))
 	tracerOpts = append(tracerOpts, sdktrace.WithBatcher(exporter))
 	tp = sdktrace.NewTracerProvider(tracerOpts...)
 	tracer := tp.Tracer(o.Name)

--- a/pkg/observability/tracing/exporters/otlp/otlp_test.go
+++ b/pkg/observability/tracing/exporters/otlp/otlp_test.go
@@ -28,6 +28,8 @@ import (
 
 	errs "github.com/trickstercache/trickster/v2/pkg/observability/tracing/errors"
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing/options"
+	collectortracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestNew(t *testing.T) {
@@ -148,4 +150,93 @@ func TestNewAppliesEndpointOptions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewAppliesResourceAttributes(t *testing.T) {
+	payloads := make(chan *collectortracepb.ExportTraceServiceRequest, 10)
+	handlerErrs := make(chan error, 10)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			handlerErrs <- err
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		var req collectortracepb.ExportTraceServiceRequest
+		if err := proto.Unmarshal(body, &req); err != nil {
+			handlerErrs <- err
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		payloads <- &req
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Setenv("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "1")
+
+	opt := options.New()
+	opt.Endpoint = srv.URL + "/v1/traces"
+	opt.ServiceName = "trickster-test"
+	opt.Tags = map[string]string{
+		"component":              "proxy",
+		"deployment.environment": "test",
+	}
+	opt.DisableCompression = true
+	opt.Timeout = time.Second
+
+	tr, err := New(opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, span := tr.Start(context.Background(), "test-span")
+	span.End()
+
+	req := waitForOTLPRequest(t, payloads, handlerErrs)
+	attrs := resourceAttributeValues(req)
+	if got := attrs["service.name"]; got != "trickster-test" {
+		t.Errorf("expected service.name %q, got %q", "trickster-test", got)
+	}
+	if got := attrs["component"]; got != "proxy" {
+		t.Errorf("expected component tag %q, got %q", "proxy", got)
+	}
+	if got := attrs["deployment.environment"]; got != "test" {
+		t.Errorf("expected deployment.environment tag %q, got %q", "test", got)
+	}
+	if _, ok := attrs[""]; ok {
+		t.Error("unexpected empty resource attribute")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err = tr.ShutdownFunc(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func waitForOTLPRequest(t *testing.T, payloads <-chan *collectortracepb.ExportTraceServiceRequest,
+	handlerErrs <-chan error) *collectortracepb.ExportTraceServiceRequest {
+	t.Helper()
+	select {
+	case req := <-payloads:
+		return req
+	case err := <-handlerErrs:
+		t.Fatalf("failed to decode OTLP request: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("expected OTLP request")
+	}
+	return nil
+}
+
+func resourceAttributeValues(req *collectortracepb.ExportTraceServiceRequest) map[string]string {
+	out := map[string]string{}
+	for _, rs := range req.GetResourceSpans() {
+		for _, attr := range rs.GetResource().GetAttributes() {
+			out[attr.GetKey()] = attr.GetValue().GetStringValue()
+		}
+	}
+	return out
 }


### PR DESCRIPTION
## Description
Includes the configured `service_name` as the OTLP resource `service.name`, matching the stdout exporter behavior and the tracing config documentation. This also fixes OTLP resource tag construction so configured tags are appended without leading empty attributes.

Related to #381.

Tests run:
- `go test -count=1 ./pkg/observability/tracing/exporters/otlp`
- `go test -count=1 ./pkg/observability/tracing/...`
- `go test -count=1 ./pkg/observability/...`
- `go tool golangci-lint run --timeout 5m ./pkg/observability/tracing/...`
- `git diff --check`

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [x] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.