### PR TITLE
feat: add tracing attributes to proxy spans

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -25,7 +25,11 @@ Trickster can insert several spans to the traces that it captures, depending upo
 | QueryCache             | querying the cache for an object |
 | WriteCache             | writing an object to the cache |
 | DeltaProxyCacheRequest | handling a Time Series-based client request |
-| FastForward            | making a Fast Forward request for time series data |
+| FetchFastForward       | making a Fast Forward request for time series data |
+| FetchTimeSeries        | retrieving time series data from an Origin |
+| FetchRange             | retrieving one sharded time range from an Origin |
+| Fetch                  | retrieving one object or range from an Origin |
+| FetchRevalidation      | revalidating a stale cache object against its Origin |
 | ProxyRequest           | communicating with an Origin server to fulfill a client request |
 | PrepareFetchReader     | preparing a client response from a cached or Origin response |
 | CacheRevalidation      | revalidating a stale cache object against its Origin |
@@ -37,18 +41,28 @@ Trickster supports adding custom tags to every span via the configuration. Depen
 
 Trickster also supports omitting any tags that Trickster inserts by default. The list of default tags are below. For example on the "request" span, an `http.url` tag is attached with the current full URL. In deployments where that tag may introduce too much cardinality in your backend trace storage system, you may wish to omit that tag and rely on the more concise `path` tag. Each tracer config can be provided a string list of tags to omit from traces.
 
-### Attributes added to top level (request) span
+### Attributes added to request and core proxy/cache/fetch spans
 
-- `http.url` - the full HTTP request URL
 - `backend.name`
 - `backend.provider`
 - `cache.name`
 - `cache.provider`
 - `router.path` - request path trimmed to the route match path for the request (e.g., `/api/v1/query`), good for aggregating when there are large variations in the full URL path
+- `router.handler`
 
-### Attributes added to QueryCache span
+These resource attributes are attached when the corresponding backend, cache, or route configuration is available to the request flow.
 
-- `cache.status` - the lookup status of cache query. See the [cache status reference](./caches.md#cache-status) for a description of the attribute values.
+### Attributes added to top level (request) span
+
+- `http.url` - the full HTTP request URL
+
+### Attributes added to cache/proxy spans
+
+- `cache.status` - the lookup or proxy cache status where available. See the [cache status reference](./caches.md#cache-status) for a description of the attribute values.
+
+### Attributes added to proxy/fetch spans
+
+- `http.status_code` - the HTTP status returned by the Origin or generated proxy response, when available.
 
 ### Attributes added to the FetchRevalidation span
 

--- a/pkg/proxy/engines/cache.go
+++ b/pkg/proxy/engines/cache.go
@@ -114,6 +114,7 @@ func QueryCache(ctx context.Context, c cache.Cache, key string,
 	if span != nil {
 		defer span.End()
 	}
+	setResourceSpanAttributes(rsc, span)
 
 	var d *HTTPDocument
 	var lookupStatus status.LookupStatus
@@ -121,6 +122,7 @@ func QueryCache(ctx context.Context, c cache.Cache, key string,
 	// Query document
 	qr := queryConcurrent(ctx, c, key)
 	if qr.err != nil {
+		tspan.SetAttributes(rsc.Tracer, span, attribute.String("cache.status", qr.lookupStatus.String()))
 		return qr.d, qr.lookupStatus, ranges, qr.err
 	}
 	if unmarshal != nil {
@@ -259,6 +261,7 @@ func WriteCache(ctx context.Context, c cache.Cache, key string, d *HTTPDocument,
 	if span != nil {
 		defer span.End()
 	}
+	setResourceSpanAttributes(rsc, span)
 
 	d.headerLock.Lock()
 	h := http.Header(d.Headers)

--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -97,6 +97,7 @@ func fetchFastForward(
 		ffReq = ffReq.WithContext(trace.ContextWithSpan(ffReq.Context(), ffSpan))
 		defer ffSpan.End()
 	}
+	setResourceSpanAttributes(rs, ffSpan)
 	body, resp, isHit := FetchViaObjectProxyCache(ffReq)
 	if resp == nil || resp.StatusCode != http.StatusOK || len(body) == 0 {
 		return statusErr
@@ -194,6 +195,7 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request, modeler *tim
 	if span != nil {
 		defer span.End()
 	}
+	setResourceSpanAttributes(rsc, span)
 	r = r.WithContext(ctx)
 
 	pc := rsc.PathConfig
@@ -602,6 +604,7 @@ func fetchTimeseries(pr *proxyRequest, trq *timeseries.TimeRangeQuery,
 	if span != nil {
 		defer span.End()
 	}
+	setResourceSpanAttributes(rsc, span)
 
 	ctx = profile.ToContext(ctx, dpcEncodingProfile.Clone())
 	pr.upstreamRequest = request.SetResources(pr.upstreamRequest.WithContext(ctx), rsc)
@@ -610,6 +613,9 @@ func fetchTimeseries(pr *proxyRequest, trq *timeseries.TimeRangeQuery,
 	mts, _, resp, err := fetchExtents(timeseries.ExtentList{trq.Extent}.Splice(trq.Step,
 		o.MaxShardSizeTime, o.ShardStep, o.MaxShardSizePoints), rsc,
 		http.Header{}, client, pr, modeler.WireUnmarshalerReader, nil)
+	if resp != nil {
+		setHTTPStatusSpanAttributes(rsc.Tracer, resp.StatusCode, span)
+	}
 
 	// elaspsed measures only the time spent making origin requests
 	var elapsed time.Duration
@@ -726,8 +732,12 @@ func fetchExtents(el timeseries.ExtentList, rsc *request.Resources, h http.Heade
 				rq.upstreamRequest = rq.upstreamRequest.WithContext(ctxMR)
 				defer spanMR.End()
 			}
+			setResourceSpanAttributes(mrsc, spanMR)
 
 			body, resp, _, fetchErr := rq.Fetch()
+			if resp != nil {
+				setHTTPStatusSpanAttributes(rsc.Tracer, resp.StatusCode, spanMR)
+			}
 
 			respLock.Lock()
 			if resp.StatusCode > mresp.StatusCode {

--- a/pkg/proxy/engines/httpproxy.go
+++ b/pkg/proxy/engines/httpproxy.go
@@ -67,6 +67,7 @@ func DoProxy(w io.Writer, r *http.Request, closeResponse bool) *http.Response {
 	if span != nil {
 		defer span.End()
 	}
+	setResourceSpanAttributes(rsc, span)
 
 	pc := rsc.PathConfig
 
@@ -144,6 +145,10 @@ func DoProxy(w io.Writer, r *http.Request, closeResponse bool) *http.Response {
 		recordResults(r, "HTTPProxy", cacheStatusCode, resp.StatusCode,
 			r.URL.Path, "", elapsed.Seconds(), nil, resp.Header)
 	}
+	if resp != nil {
+		tspan.SetAttributes(rsc.Tracer, span, attribute.String("cache.status", cacheStatusCode.String()))
+		setHTTPStatusSpanAttributes(rsc.Tracer, resp.StatusCode, span)
+	}
 
 	return resp
 }
@@ -185,6 +190,7 @@ func PrepareFetchReader(r *http.Request) (io.ReadCloser, *http.Response, int64) 
 	if span != nil {
 		defer span.End()
 	}
+	setResourceSpanAttributes(rsc, span)
 
 	pc := rsc.PathConfig
 
@@ -221,6 +227,7 @@ func PrepareFetchReader(r *http.Request) (io.ReadCloser, *http.Response, int64) 
 	if doSpan != nil {
 		defer doSpan.End()
 	}
+	setResourceSpanAttributes(rsc, doSpan)
 
 	if ep := profile.FromContext(r.Context()); ep != nil && ep.SupportedHeaderVal != "" {
 		r.Header.Set(headers.NameAcceptEncoding, ep.SupportedHeaderVal)
@@ -241,6 +248,7 @@ func PrepareFetchReader(r *http.Request) (io.ReadCloser, *http.Response, int64) 
 			}
 			logger.Error("error buffering request body for retry",
 				logging.Pairs{"url": r.URL.String(), "detail": err.Error()})
+			setHTTPStatusSpanAttributes(rsc.Tracer, status, span, doSpan)
 			return nil, &http.Response{
 				StatusCode: status,
 				Request:    r, Header: make(http.Header),
@@ -285,6 +293,7 @@ func PrepareFetchReader(r *http.Request) (io.ReadCloser, *http.Response, int64) 
 			headers.UpdateHeaders(resp.Header, pc.ResponseHeaders)
 		}
 
+		setHTTPStatusSpanAttributes(rsc.Tracer, resp.StatusCode, span, doSpan)
 		if doSpan != nil {
 			doSpan.AddEvent(
 				"Failure",
@@ -354,6 +363,7 @@ func PrepareFetchReader(r *http.Request) (io.ReadCloser, *http.Response, int64) 
 		rc = resp.Body
 	}
 
+	setHTTPStatusSpanAttributes(rsc.Tracer, resp.StatusCode, span, doSpan)
 	return rc, resp, originalLen
 }
 

--- a/pkg/proxy/engines/objectproxycache.go
+++ b/pkg/proxy/engines/objectproxycache.go
@@ -155,6 +155,7 @@ func handleCacheRevalidation(pr *proxyRequest) error {
 			span.End()
 		}()
 	}
+	setResourceSpanAttributes(pr.rsc, span)
 
 	pr.revalidation = RevalStatusInProgress
 
@@ -307,6 +308,7 @@ func handlePCF(pr *proxyRequest) error {
 		span.SetAttributes(attribute.Bool("isPCF", true))
 		defer span.End()
 	}
+	setResourceSpanAttributes(pr.rsc, span)
 	pr.upstreamRequest = pr.upstreamRequest.WithContext(ctx)
 
 	reader, resp, contentLength := PrepareFetchReader(pr.upstreamRequest)
@@ -423,6 +425,7 @@ func fetchViaObjectProxyCache(w io.Writer, r *http.Request) (*http.Response, sta
 		pr.upstreamRequest = pr.upstreamRequest.WithContext(trace.ContextWithSpan(pr.upstreamRequest.Context(), span))
 		defer span.End()
 	}
+	setResourceSpanAttributes(rsc, span)
 
 	pr.parseRequestRanges()
 
@@ -437,6 +440,7 @@ func fetchViaObjectProxyCache(w io.Writer, r *http.Request) (*http.Response, sta
 	if pr.isPCF || pr.cachingPolicy.NoCache {
 		if pr.cachingPolicy.NoCache {
 			cc.Remove(pr.key)
+			tspan.SetAttributes(rsc.Tracer, span, attribute.String("cache.status", status.LookupStatusProxyOnly.String()))
 			return nil, status.LookupStatusProxyOnly
 		}
 		pcf := pcfResult.(ProgressiveCollapseForwarder)
@@ -445,8 +449,11 @@ func fetchViaObjectProxyCache(w io.Writer, r *http.Request) (*http.Response, sta
 		writer := PrepareResponseWriter(w, pr.upstreamResponse.StatusCode, pr.upstreamResponse.Header)
 		pr.mapLock.Unlock()
 		if err := pcf.AddClient(writer); err != nil {
+			tspan.SetAttributes(rsc.Tracer, span, attribute.String("cache.status", status.LookupStatusError.String()))
 			return nil, status.LookupStatusError
 		}
+		tspan.SetAttributes(rsc.Tracer, span, attribute.String("cache.status", status.LookupStatusProxyHit.String()))
+		setHTTPStatusSpanAttributes(rsc.Tracer, pr.upstreamResponse.StatusCode, span)
 		return pr.upstreamResponse, status.LookupStatusProxyHit
 	}
 
@@ -531,16 +538,19 @@ func fetchViaObjectProxyCache(w io.Writer, r *http.Request) (*http.Response, sta
 	})
 
 	if sfErr != nil {
+		tspan.SetAttributes(rsc.Tracer, span, attribute.String("cache.status", status.LookupStatusError.String()))
 		return nil, status.LookupStatusError
 	}
 	result := val.(*opcResult)
 	if result.cacheStatus == status.LookupStatusProxyOnly {
+		tspan.SetAttributes(rsc.Tracer, span, attribute.String("cache.status", status.LookupStatusProxyOnly.String()))
 		return nil, status.LookupStatusProxyOnly
 	}
 
 	// only serve the shared result for waiters; the executor already wrote its response
 	if !isExecutor {
 		if err := serveOPCResult(pr, result); err != nil {
+			tspan.SetAttributes(rsc.Tracer, span, attribute.String("cache.status", status.LookupStatusError.String()))
 			return nil, status.LookupStatusError
 		}
 	}
@@ -557,6 +567,8 @@ func fetchViaObjectProxyCache(w io.Writer, r *http.Request) (*http.Response, sta
 	}
 
 	recordOPCResult(pr, pr.cacheStatus, pr.upstreamResponse.StatusCode, r.URL.Path, result.elapsed, pr.upstreamResponse.Header)
+	tspan.SetAttributes(rsc.Tracer, span, attribute.String("cache.status", pr.cacheStatus.String()))
+	setHTTPStatusSpanAttributes(rsc.Tracer, pr.upstreamResponse.StatusCode, span)
 
 	return pr.upstreamResponse, pr.cacheStatus
 }

--- a/pkg/proxy/engines/proxy_request.go
+++ b/pkg/proxy/engines/proxy_request.go
@@ -42,6 +42,7 @@ import (
 // setupSpanForRequest configures a request span with range detection and returns the modified request
 func setupSpanForRequest(req *http.Request, span trace.Span) *http.Request {
 	if span != nil {
+		setResourceSpanAttributes(request.GetResources(req), span)
 		if req.Header != nil {
 			if _, ok := req.Header[headers.NameRange]; ok {
 				span.SetAttributes(attribute.Bool("isRange", true))
@@ -215,6 +216,7 @@ func (pr *proxyRequest) prepareRevalidationRequest() {
 	pr.revalidationRequest = request.SetResources(pr.revalidationRequest, pr.rsc)
 	_, span := tspan.NewChildSpan(pr.revalidationRequest.Context(), pr.rsc.Tracer, "FetchRevlidation")
 	if span != nil {
+		setResourceSpanAttributes(pr.rsc, span)
 		pr.revalidationRequest = pr.revalidationRequest.WithContext(trace.ContextWithSpan(pr.revalidationRequest.Context(), span))
 		defer span.End()
 	}
@@ -303,6 +305,9 @@ func (pr *proxyRequest) makeSimpleUpstreamRequests(req *http.Request,
 		defer span.End()
 	}
 	reader, resp, _ := PrepareFetchReader(req)
+	if resp != nil {
+		setHTTPStatusSpanAttributes(tracer, resp.StatusCode, span)
+	}
 
 	return reader, resp
 }
@@ -322,17 +327,15 @@ func (pr *proxyRequest) makeUpstreamRequests() error {
 		wg.Go(func() {
 			req := pr.revalidationRequest
 			_, span := tspan.NewChildSpan(req.Context(), pr.rsc.Tracer, "FetchRevalidation")
+			pr.revalidationRequest = setupSpanForRequest(req, span)
 			if span != nil {
-				if req.Header != nil {
-					if _, ok := req.Header[headers.NameRange]; ok {
-						span.SetAttributes(attribute.Bool("isRange", true))
-					}
-				}
-				pr.revalidationRequest = req.WithContext(trace.ContextWithSpan(req.Context(), span))
 				defer span.End()
 			}
 			var contentLength int64
 			pr.revalidationReader, pr.revalidationResponse, contentLength = PrepareFetchReader(pr.revalidationRequest)
+			if pr.revalidationResponse != nil {
+				setHTTPStatusSpanAttributes(pr.rsc.Tracer, pr.revalidationResponse.StatusCode, span)
+			}
 			if pr.revalidationReader == nil {
 				logger.Error("revalidation upstream returned no reader",
 					logging.Pairs{
@@ -356,6 +359,9 @@ func (pr *proxyRequest) makeUpstreamRequests() error {
 				}
 				var contentLength int64
 				pr.originReaders[i], pr.originResponses[i], contentLength = PrepareFetchReader(req)
+				if pr.originResponses[i] != nil {
+					setHTTPStatusSpanAttributes(pr.rsc.Tracer, pr.originResponses[i].StatusCode, span)
+				}
 				if pr.originReaders[i] == nil {
 					logger.Error("origin upstream returned no reader",
 						logging.Pairs{

--- a/pkg/proxy/engines/tracing.go
+++ b/pkg/proxy/engines/tracing.go
@@ -14,26 +14,26 @@
  * limitations under the License.
  */
 
-package middleware
+package engines
 
 import (
-	"net/http"
-
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing"
 	tspan "github.com/trickstercache/trickster/v2/pkg/observability/tracing/span"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
-// Trace attaches a Tracer to an HTTP request
-func Trace(tr *tracing.Tracer, next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r, span := tspan.PrepareRequest(r, tr)
-		if span != nil {
-			defer span.End()
+func setResourceSpanAttributes(rsc *request.Resources, span trace.Span) {
+	if rsc == nil {
+		return
+	}
+	tspan.SetAttributes(rsc.Tracer, span, rsc.TracingAttributes()...)
+}
 
-			rsc := request.GetResources(r)
-			tspan.SetAttributes(tr, span, rsc.TracingAttributes()...)
-		}
-		next.ServeHTTP(w, r)
-	})
+func setHTTPStatusSpanAttributes(tr *tracing.Tracer, statusCode int, spans ...trace.Span) {
+	attr := attribute.Int("http.status_code", statusCode)
+	for _, span := range spans {
+		tspan.SetAttributes(tr, span, attr)
+	}
 }

--- a/pkg/proxy/engines/tracing_test.go
+++ b/pkg/proxy/engines/tracing_test.go
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package engines
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	cr "github.com/trickstercache/trickster/v2/pkg/cache/registry"
+	"github.com/trickstercache/trickster/v2/pkg/config"
+	tc "github.com/trickstercache/trickster/v2/pkg/proxy/context"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+	tu "github.com/trickstercache/trickster/v2/pkg/testutil"
+	"github.com/trickstercache/trickster/v2/pkg/util/sets"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestCacheSpansIncludeResourceAttributesAndStatus(t *testing.T) {
+	conf, err := config.Load([]string{"-origin-url", "http://1", "-provider", "test"})
+	if err != nil {
+		t.Fatalf("could not load configuration: %s", err)
+	}
+	caches := cr.LoadCachesFromConfig(conf)
+	defer cr.CloseCaches(caches)
+	cache, ok := caches["default"]
+	if !ok {
+		t.Fatal("could not load default cache")
+	}
+
+	tr, sr := tu.NewRecordingTracer(t)
+	pc := &po.Options{Path: "/api/v1/query", HandlerName: "proxycache"}
+	rsc := request.NewResources(conf.Backends["default"], pc, cache.Configuration(), cache, nil, tr)
+	ctx := tc.WithResources(context.Background(), rsc)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     http.StatusText(http.StatusOK),
+		Header:     make(http.Header),
+	}
+	resp.Header.Set(headers.NameContentType, headers.ValueTextPlain)
+	doc := DocumentFromHTTPResponse(resp, []byte("ok"), nil)
+	doc.ContentType = headers.ValueTextPlain
+
+	if err = WriteCache(ctx, cache, "trace-key", doc, time.Minute, sets.New([]string{headers.ValueTextPlain}), nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err = QueryCache(ctx, cache, "trace-key", nil, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	tu.RequireSpanAttributes(t, sr, "WriteCache", resourceAttributeStrings(rsc))
+
+	wantQuery := resourceAttributeStrings(rsc)
+	wantQuery["cache.status"] = "hit"
+	tu.RequireSpanAttributes(t, sr, "QueryCache", wantQuery)
+}
+
+func TestDoProxySpanIncludesResourceStatusAttributes(t *testing.T) {
+	r, rsc, sr := newTracingFetchRequest(t, &mockRoundTripper{
+		resp: &http.Response{
+			StatusCode: http.StatusAccepted,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(bytes.NewReader([]byte("accepted"))),
+		},
+	})
+
+	w := httptest.NewRecorder()
+	DoProxy(w, r, true)
+	if got := w.Result().StatusCode; got != http.StatusAccepted {
+		t.Fatalf("expected status %d, got %d", http.StatusAccepted, got)
+	}
+
+	want := resourceAttributeStrings(rsc)
+	want["cache.status"] = "proxy-only"
+	want["http.status_code"] = "202"
+	tu.RequireSpanAttributes(t, sr, "ProxyRequest", want)
+}
+
+func TestPrepareFetchReaderSpansIncludeResourceStatusAttributes(t *testing.T) {
+	r, rsc, sr := newTracingFetchRequest(t, &mockRoundTripper{
+		resp: &http.Response{
+			StatusCode: http.StatusCreated,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(bytes.NewReader([]byte("created"))),
+		},
+	})
+
+	reader, resp, _ := PrepareFetchReader(r)
+	if resp == nil || resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected status %d, got %#v", http.StatusCreated, resp)
+	}
+	if reader != nil {
+		_, _ = io.ReadAll(reader)
+		reader.Close()
+	}
+
+	want := resourceAttributeStrings(rsc)
+	want["http.status_code"] = "201"
+	tu.RequireSpanAttributes(t, sr, "PrepareFetchReader", want)
+	tu.RequireSpanAttributes(t, sr, "ProxyRequest", want)
+}
+
+func TestPrepareFetchReaderErrorSpansIncludeBadGatewayStatus(t *testing.T) {
+	r, rsc, sr := newTracingFetchRequest(t, &mockRoundTripper{err: errors.New("dial failed")})
+
+	reader, resp, _ := PrepareFetchReader(r)
+	if reader != nil {
+		t.Fatal("expected nil reader")
+	}
+	if resp == nil || resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("expected status %d, got %#v", http.StatusBadGateway, resp)
+	}
+
+	want := resourceAttributeStrings(rsc)
+	want["http.status_code"] = "502"
+	tu.RequireSpanAttributes(t, sr, "PrepareFetchReader", want)
+	tu.RequireSpanAttributes(t, sr, "ProxyRequest", want)
+}
+
+func TestObjectProxyCacheRequestSpanIncludesResourceStatusAttributes(t *testing.T) {
+	hdrs := map[string]string{"Cache-Control": "max-age=60"}
+	ts, _, r, rsc, err := setupTestHarnessOPC("", "test", http.StatusPartialContent, hdrs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeTestHarness(ts, r)
+
+	tr, sr := tu.NewRecordingTracer(t)
+	rsc.Tracer = tr
+	rsc.BackendOptions.MaxTTL = 15 * time.Second
+	r.Header.Add(headers.NameRange, "bytes=0-3")
+	r = request.SetResources(r, rsc)
+
+	_, errs := testFetchOPC(r, http.StatusPartialContent, "test", map[string]string{"status": "kmiss"})
+	for _, err := range errs {
+		t.Error(err)
+	}
+
+	want := resourceAttributeStrings(rsc)
+	want["cache.status"] = "kmiss"
+	want["http.status_code"] = "206"
+	tu.RequireSpanAttributes(t, sr, "ObjectProxyCacheRequest", want)
+}
+
+func newTracingFetchRequest(t *testing.T, rt http.RoundTripper) (*http.Request, *request.Resources, *tracetest.SpanRecorder) {
+	t.Helper()
+
+	conf, err := config.Load([]string{"-origin-url", "http://example.com/", "-provider", "test"})
+	if err != nil {
+		t.Fatalf("could not load configuration: %s", err)
+	}
+	o := conf.Backends["default"]
+	o.HTTPClient = &http.Client{Transport: rt}
+
+	tr, sr := tu.NewRecordingTracer(t)
+	pc := &po.Options{
+		Path:            "/objects",
+		HandlerName:     "proxycache",
+		RequestHeaders:  map[string]string{},
+		ResponseHeaders: map[string]string{},
+	}
+	rsc := request.NewResources(o, pc, conf.Caches["default"], nil, nil, tr)
+
+	r := httptest.NewRequest(http.MethodGet, "http://example.com/objects", nil)
+	r = r.WithContext(tc.WithResources(r.Context(), rsc))
+	return r, rsc, sr
+}
+
+func resourceAttributeStrings(rsc *request.Resources) map[string]string {
+	attrs := rsc.TracingAttributes()
+	out := make(map[string]string, len(attrs))
+	for _, kv := range attrs {
+		out[string(kv.Key)] = kv.Value.AsString()
+	}
+	return out
+}

--- a/pkg/proxy/request/tracing.go
+++ b/pkg/proxy/request/tracing.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package request
+
+import "go.opentelemetry.io/otel/attribute"
+
+// TracingAttributes returns low-cardinality request resource attributes for spans.
+func (r *Resources) TracingAttributes() []attribute.KeyValue {
+	if r == nil {
+		return nil
+	}
+
+	attrs := make([]attribute.KeyValue, 0, 6)
+	if r.BackendOptions != nil {
+		if r.BackendOptions.Name != "" {
+			attrs = append(attrs, attribute.String("backend.name", r.BackendOptions.Name))
+		}
+		if r.BackendOptions.Provider != "" {
+			attrs = append(attrs, attribute.String("backend.provider", r.BackendOptions.Provider))
+		}
+	}
+	if r.CacheConfig != nil {
+		if r.CacheConfig.Name != "" {
+			attrs = append(attrs, attribute.String("cache.name", r.CacheConfig.Name))
+		}
+		if r.CacheConfig.Provider != "" {
+			attrs = append(attrs, attribute.String("cache.provider", r.CacheConfig.Provider))
+		}
+	}
+	if r.PathConfig != nil {
+		if r.PathConfig.Path != "" {
+			attrs = append(attrs, attribute.String("router.path", r.PathConfig.Path))
+		}
+		if r.PathConfig.HandlerName != "" {
+			attrs = append(attrs, attribute.String("router.handler", r.PathConfig.HandlerName))
+		}
+	}
+	return attrs
+}

--- a/pkg/proxy/request/tracing_test.go
+++ b/pkg/proxy/request/tracing_test.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package request
+
+import (
+	"testing"
+
+	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
+	co "github.com/trickstercache/trickster/v2/pkg/cache/options"
+	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestTracingAttributes(t *testing.T) {
+	rsc := &Resources{
+		BackendOptions: &bo.Options{Name: "origin-a", Provider: "prometheus"},
+		CacheConfig:    &co.Options{Name: "memory-cache", Provider: "memory"},
+		PathConfig:     &po.Options{Path: "/api/v1/query", HandlerName: "proxycache"},
+	}
+
+	got := tracingAttributesMap(rsc.TracingAttributes())
+	want := map[string]string{
+		"backend.name":     "origin-a",
+		"backend.provider": "prometheus",
+		"cache.name":       "memory-cache",
+		"cache.provider":   "memory",
+		"router.path":      "/api/v1/query",
+		"router.handler":   "proxycache",
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Fatalf("attribute %q: expected %q, got %q", k, v, got[k])
+		}
+	}
+}
+
+func TestTracingAttributesSkipsMissingResources(t *testing.T) {
+	rsc := &Resources{
+		BackendOptions: &bo.Options{Name: "origin-a"},
+		PathConfig:     &po.Options{Path: "/api/v1/query"},
+	}
+
+	got := tracingAttributesMap(rsc.TracingAttributes())
+	if got["backend.name"] != "origin-a" {
+		t.Fatalf("expected backend.name, got %q", got["backend.name"])
+	}
+	if got["router.path"] != "/api/v1/query" {
+		t.Fatalf("expected router.path, got %q", got["router.path"])
+	}
+	if _, ok := got["cache.name"]; ok {
+		t.Fatal("cache.name must not be set when cache config is nil")
+	}
+	if attrs := (*Resources)(nil).TracingAttributes(); len(attrs) != 0 {
+		t.Fatalf("nil resources must return no attributes, got %d", len(attrs))
+	}
+}
+
+func tracingAttributesMap(attrs []attribute.KeyValue) map[string]string {
+	out := make(map[string]string, len(attrs))
+	for _, kv := range attrs {
+		out[string(kv.Key)] = kv.Value.AsString()
+	}
+	return out
+}

--- a/pkg/testutil/tracing.go
+++ b/pkg/testutil/tracing.go
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/observability/tracing"
+	to "github.com/trickstercache/trickster/v2/pkg/observability/tracing/options"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// NewRecordingTracer returns a tracer and span recorder for assertions.
+func NewRecordingTracer(t testing.TB) (*tracing.Tracer, *tracetest.SpanRecorder) {
+	t.Helper()
+
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+	})
+
+	opts := to.New()
+	opts.Name = "test"
+	opts.Provider = "stdout"
+	to.ProcessTracingOptions(to.Lookup{opts.Name: opts})
+
+	return &tracing.Tracer{
+		Name:    opts.Name,
+		Tracer:  tp.Tracer(opts.Name),
+		Options: opts,
+	}, sr
+}
+
+// RequireSpanAttributes asserts that the most recently ended span named spanName has all wanted attributes.
+func RequireSpanAttributes(t testing.TB, sr *tracetest.SpanRecorder, spanName string, want map[string]string) {
+	t.Helper()
+
+	attrs := spanAttributes(t, sr, spanName)
+	for k, v := range want {
+		got, ok := attrs[k]
+		if !ok {
+			t.Fatalf("span %q missing attribute %q", spanName, k)
+		}
+		gotString := fmt.Sprint(got.AsInterface())
+		if gotString != v {
+			t.Fatalf("span %q attribute %q: expected %q, got %q", spanName, k, v, gotString)
+		}
+	}
+}
+
+// RequireNoSpanAttribute asserts that the most recently ended span named spanName does not have key.
+func RequireNoSpanAttribute(t testing.TB, sr *tracetest.SpanRecorder, spanName, key string) {
+	t.Helper()
+
+	attrs := spanAttributes(t, sr, spanName)
+	if _, ok := attrs[key]; ok {
+		t.Fatalf("span %q must not include attribute %q", spanName, key)
+	}
+}
+
+func spanAttributes(t testing.TB, sr *tracetest.SpanRecorder, spanName string) map[string]attribute.Value {
+	t.Helper()
+
+	spans := sr.Ended()
+	for _, v := range slices.Backward(spans) {
+		if v.Name() != spanName {
+			continue
+		}
+		out := make(map[string]attribute.Value, len(v.Attributes()))
+		for _, kv := range v.Attributes() {
+			out[string(kv.Key)] = kv.Value
+		}
+		return out
+	}
+
+	t.Fatalf("span %q not found in %d ended spans", spanName, len(spans))
+	return nil
+}

--- a/pkg/util/middleware/tracing_test.go
+++ b/pkg/util/middleware/tracing_test.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
+	co "github.com/trickstercache/trickster/v2/pkg/cache/options"
+	tc "github.com/trickstercache/trickster/v2/pkg/proxy/context"
+	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+	tu "github.com/trickstercache/trickster/v2/pkg/testutil"
+)
+
+func TestTraceAddsResourceAttributesToRequestSpan(t *testing.T) {
+	tr, sr := tu.NewRecordingTracer(t)
+	rsc := request.NewResources(
+		&bo.Options{Name: "origin-a", Provider: "prometheus"},
+		&po.Options{Path: "/api/v1/query", HandlerName: "proxycache"},
+		&co.Options{Name: "memory-cache", Provider: "memory"},
+		nil,
+		nil,
+		tr,
+	)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	handler := Trace(tr, next)
+
+	r := httptest.NewRequest(http.MethodGet, "http://example.com/api/v1/query?query=up", nil)
+	r = r.WithContext(tc.WithResources(r.Context(), rsc))
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	tu.RequireSpanAttributes(t, sr, "request", map[string]string{
+		"backend.name":     "origin-a",
+		"backend.provider": "prometheus",
+		"cache.name":       "memory-cache",
+		"cache.provider":   "memory",
+		"router.path":      "/api/v1/query",
+		"router.handler":   "proxycache",
+	})
+}


### PR DESCRIPTION
## Description
Related to #381.

This improves span quality for the core proxy/cache/fetch request flow without changing the tracing configuration shape or request behavior.

- factors low-cardinality backend/cache/router resource attributes into request resources
- attaches those resource attributes to request, cache, proxy, object-cache, delta-cache, and fetch spans when resources are available
- records `cache.status` on cache/proxy spans and `http.status_code` on proxy/fetch spans when a response is available
- updates the tracing documentation and adds span recorder tests for the emitted attributes

Validation run locally:

- `go test -count=1 ./pkg/proxy/request`
- `go test -count=1 ./pkg/util/middleware`
- `go test -count=1 ./pkg/testutil`
- `go test -count=1 ./pkg/proxy/engines`
- `go test -count=1 ./pkg/proxy/...`
- `go test -count=1 ./pkg/observability/tracing/...`
- `go test -count=1 ./pkg/util/middleware ./pkg/testutil`
- `go tool golangci-lint run --timeout 5m ./pkg/proxy/request ./pkg/util/middleware ./pkg/proxy/engines ./pkg/testutil ./pkg/observability/tracing/...`
- `git diff --check`
- `go test -run '^$' ./...`

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [ ] Bug fix
- - [x] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [x] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.