### PR TITLE
fix: merge proxy-only TSM responses

### DIFF
--- a/integration/alb_cache_test.go
+++ b/integration/alb_cache_test.go
@@ -376,4 +376,223 @@ func TestALBCache(t *testing.T) {
 			"mixed cache hit/miss across pool members did not surface phit in X-Trickster-Result=%q",
 			raw)
 	})
+
+	t.Run("V4 tsm merges proxy-only pool members", func(t *testing.T) {
+		var m1Hits, m2Hits atomic.Int64
+		mk := func(job string, hits *atomic.Int64) *httptest.Server {
+			return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == promstub.BuildInfoPath {
+					promstub.WriteBuildInfo(w)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = r.ParseForm()
+				start, _ := parseInt(r.Form.Get("start"))
+				end, _ := parseInt(r.Form.Get("end"))
+				step, _ := parseInt(r.Form.Get("step"))
+				if step == 0 {
+					step = 15
+				}
+				hits.Add(1)
+				var b strings.Builder
+				first := true
+				for ts := start; ts <= end; ts += step {
+					if !first {
+						b.WriteString(",")
+					}
+					first = false
+					fmt.Fprintf(&b, `[%d,"1"]`, ts)
+				}
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintf(w, `{"status":"success","data":{"resultType":"matrix","result":[`+
+					`{"metric":{"__name__":"up","job":%q},"values":[%s]}]}}`, job, b.String())
+			}))
+		}
+		up1 := mk("proxy-only-a", &m1Hits)
+		t.Cleanup(up1.Close)
+		up2 := mk("proxy-only-b", &m2Hits)
+		t.Cleanup(up2.Close)
+
+		frontPort := 18930
+		metricsPort := 18931
+		mgmtPort := 18932
+
+		yaml := fmt.Sprintf(albTestdata(t, "alb_cache/v4.yaml.tmpl"),
+			frontPort, metricsPort, mgmtPort, up1.URL, up2.URL)
+
+		cfgPath := filepath.Join(t.TempDir(), "trickster.yaml")
+		require.NoError(t, os.WriteFile(cfgPath, []byte(yaml), 0644))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		go startTrickster(t, ctx, expectedStartError{}, "-config", cfgPath)
+		waitForTrickster(t, fmt.Sprintf("127.0.0.1:%d", metricsPort))
+
+		client := &http.Client{Transport: &http.Transport{DisableCompression: true}}
+		now := time.Now()
+		end := now.Truncate(15 * time.Second)
+		start := end.Add(-2 * time.Minute)
+		params := url.Values{
+			"query": {fmt.Sprintf("up + 0*%d", now.UnixNano())},
+			"start": {fmt.Sprintf("%d", start.Unix())},
+			"end":   {fmt.Sprintf("%d", end.Unix())},
+			"step":  {"15"},
+		}
+		u := fmt.Sprintf("http://127.0.0.1:%d/alb-tsm-proxy-only/api/v1/query_range?%s",
+			frontPort, params.Encode())
+
+		var resp *http.Response
+		var body []byte
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			r, err := client.Get(u)
+			if !assert.NoError(c, err) {
+				return
+			}
+			b, _ := io.ReadAll(r.Body)
+			r.Body.Close()
+			resp, body = r, b
+			if !assert.Equal(c, http.StatusOK, r.StatusCode, "body=%s", string(b)) {
+				return
+			}
+			assert.GreaterOrEqual(c, m1Hits.Load(), int64(1),
+				"waiting for proxy-only member A to receive a request")
+			assert.GreaterOrEqual(c, m2Hits.Load(), int64(1),
+				"waiting for proxy-only member B to receive a request")
+		}, 10*time.Second, 250*time.Millisecond, "proxy-only TSM pool never merged both members")
+
+		t.Logf("status=%d X-Trickster-Result=%q m1Hits=%d m2Hits=%d body=%s",
+			resp.StatusCode, resp.Header.Get("X-Trickster-Result"), m1Hits.Load(), m2Hits.Load(), string(body))
+
+		var pr promResponse
+		require.NoError(t, json.Unmarshal(body, &pr),
+			"merged body must be valid prom JSON; status=%d body=%s", resp.StatusCode, string(body))
+		require.Equal(t, "success", pr.Status)
+		var qd promQueryData
+		require.NoError(t, json.Unmarshal(pr.Data, &qd))
+		var series []struct {
+			Metric map[string]string `json:"metric"`
+			Values [][]any           `json:"values"`
+		}
+		require.NoError(t, json.Unmarshal(qd.Result, &series))
+
+		jobs := map[string]bool{}
+		for _, s := range series {
+			jobs[s.Metric["job"]] = true
+			require.NotEmpty(t, s.Values, "series for job %q should include range points", s.Metric["job"])
+		}
+		require.True(t, jobs["proxy-only-a"], "merged body missing proxy-only member A: %s", string(body))
+		require.True(t, jobs["proxy-only-b"], "merged body missing proxy-only member B: %s", string(body))
+	})
+
+	t.Run("V5 tsm merges out-of-window proxy-only ranges without caching them", func(t *testing.T) {
+		var m1Hits, m2Hits atomic.Int64
+		mk := func(job string, hits *atomic.Int64) *httptest.Server {
+			return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == promstub.BuildInfoPath {
+					promstub.WriteBuildInfo(w)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = r.ParseForm()
+				start, _ := parseInt(r.Form.Get("start"))
+				end, _ := parseInt(r.Form.Get("end"))
+				step, _ := parseInt(r.Form.Get("step"))
+				if step == 0 {
+					step = 15
+				}
+				hits.Add(1)
+				var b strings.Builder
+				first := true
+				for ts := start; ts <= end; ts += step {
+					if !first {
+						b.WriteString(",")
+					}
+					first = false
+					fmt.Fprintf(&b, `[%d,"1"]`, ts)
+				}
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintf(w, `{"status":"success","data":{"resultType":"matrix","result":[`+
+					`{"metric":{"__name__":"up","job":%q},"values":[%s]}]}}`, job, b.String())
+			}))
+		}
+		up1 := mk("old-range-a", &m1Hits)
+		t.Cleanup(up1.Close)
+		up2 := mk("old-range-b", &m2Hits)
+		t.Cleanup(up2.Close)
+
+		frontPort := 18940
+		metricsPort := 18941
+		mgmtPort := 18942
+
+		yaml := fmt.Sprintf(albTestdata(t, "alb_cache/v5.yaml.tmpl"),
+			frontPort, metricsPort, mgmtPort, up1.URL, up2.URL)
+
+		cfgPath := filepath.Join(t.TempDir(), "trickster.yaml")
+		require.NoError(t, os.WriteFile(cfgPath, []byte(yaml), 0644))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		go startTrickster(t, ctx, expectedStartError{}, "-config", cfgPath)
+		waitForTrickster(t, fmt.Sprintf("127.0.0.1:%d", metricsPort))
+
+		client := &http.Client{Transport: &http.Transport{DisableCompression: true}}
+		end := time.Now().Add(-10 * time.Minute).Truncate(15 * time.Second)
+		start := end.Add(-2 * time.Minute)
+		params := url.Values{
+			"query": {fmt.Sprintf("up + 0*%d", time.Now().UnixNano())},
+			"start": {fmt.Sprintf("%d", start.Unix())},
+			"end":   {fmt.Sprintf("%d", end.Unix())},
+			"step":  {"15"},
+		}
+		u := fmt.Sprintf("http://127.0.0.1:%d/alb-tsm-old-ranges/api/v1/query_range?%s",
+			frontPort, params.Encode())
+
+		var body []byte
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			r, err := client.Get(u)
+			if !assert.NoError(c, err) {
+				return
+			}
+			b, _ := io.ReadAll(r.Body)
+			r.Body.Close()
+			body = b
+			if !assert.Equal(c, http.StatusOK, r.StatusCode, "body=%s", string(b)) {
+				return
+			}
+			assert.GreaterOrEqual(c, m1Hits.Load(), int64(1),
+				"waiting for old-range member A to receive a request")
+			assert.GreaterOrEqual(c, m2Hits.Load(), int64(1),
+				"waiting for old-range member B to receive a request")
+		}, 10*time.Second, 250*time.Millisecond, "out-of-window TSM query never merged both members")
+
+		var pr promResponse
+		require.NoError(t, json.Unmarshal(body, &pr),
+			"merged body must be valid prom JSON; body=%s", string(body))
+		require.Equal(t, "success", pr.Status)
+		var qd promQueryData
+		require.NoError(t, json.Unmarshal(pr.Data, &qd))
+		var series []struct {
+			Metric map[string]string `json:"metric"`
+			Values [][]any           `json:"values"`
+		}
+		require.NoError(t, json.Unmarshal(qd.Result, &series))
+		jobs := map[string]bool{}
+		for _, s := range series {
+			jobs[s.Metric["job"]] = true
+			require.NotEmpty(t, s.Values, "series for job %q should include range points", s.Metric["job"])
+		}
+		require.True(t, jobs["old-range-a"], "merged body missing old-range member A: %s", string(body))
+		require.True(t, jobs["old-range-b"], "merged body missing old-range member B: %s", string(body))
+
+		beforeA, beforeB := m1Hits.Load(), m2Hits.Load()
+		r, err := client.Get(u)
+		require.NoError(t, err)
+		_, _ = io.ReadAll(r.Body)
+		r.Body.Close()
+		require.Equal(t, http.StatusOK, r.StatusCode)
+		require.Greater(t, m1Hits.Load(), beforeA,
+			"out-of-window member A response should remain proxy-only, not cache hit")
+		require.Greater(t, m2Hits.Load(), beforeB,
+			"out-of-window member B response should remain proxy-only, not cache hit")
+	})
 }

--- a/integration/testdata/alb_cache/v4.yaml.tmpl
+++ b/integration/testdata/alb_cache/v4.yaml.tmpl
@@ -1,0 +1,46 @@
+frontend:
+  listen_port: %d
+metrics:
+  listen_port: %d
+mgmt:
+  listen_port: %d
+logging:
+  log_level: error
+caches:
+  mem1:
+    provider: memory
+  mem2:
+    provider: memory
+backends:
+  prom-po1:
+    provider: prometheus
+    origin_url: %s
+    cache_name: mem1
+    proxy_only: true
+    healthcheck:
+      path: /api/v1/status/buildinfo
+      query: ""
+      interval: 100ms
+      timeout: 500ms
+      failure_threshold: 1
+      recovery_threshold: 1
+  prom-po2:
+    provider: prometheus
+    origin_url: %s
+    cache_name: mem2
+    proxy_only: true
+    healthcheck:
+      path: /api/v1/status/buildinfo
+      query: ""
+      interval: 100ms
+      timeout: 500ms
+      failure_threshold: 1
+      recovery_threshold: 1
+  alb-tsm-proxy-only:
+    provider: alb
+    alb:
+      mechanism: tsm
+      output_format: prometheus
+      pool:
+        - prom-po1
+        - prom-po2

--- a/integration/testdata/alb_cache/v5.yaml.tmpl
+++ b/integration/testdata/alb_cache/v5.yaml.tmpl
@@ -1,0 +1,48 @@
+frontend:
+  listen_port: %d
+metrics:
+  listen_port: %d
+mgmt:
+  listen_port: %d
+logging:
+  log_level: error
+caches:
+  mem1:
+    provider: memory
+  mem2:
+    provider: memory
+backends:
+  prom-old1:
+    provider: prometheus
+    origin_url: %s
+    cache_name: mem1
+    timeseries_retention_factor: 2
+    timeseries_eviction_method: oldest
+    healthcheck:
+      path: /api/v1/status/buildinfo
+      query: ""
+      interval: 100ms
+      timeout: 500ms
+      failure_threshold: 1
+      recovery_threshold: 1
+  prom-old2:
+    provider: prometheus
+    origin_url: %s
+    cache_name: mem2
+    timeseries_retention_factor: 2
+    timeseries_eviction_method: oldest
+    healthcheck:
+      path: /api/v1/status/buildinfo
+      query: ""
+      interval: 100ms
+      timeout: 500ms
+      failure_threshold: 1
+      recovery_threshold: 1
+  alb-tsm-old-ranges:
+    provider: alb
+    alb:
+      mechanism: tsm
+      output_format: prometheus
+      pool:
+        - prom-old1
+        - prom-old2

--- a/pkg/backends/alb/mech/tsm/time_series_merge.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge.go
@@ -473,6 +473,46 @@ func aggregateStatus(results []gatherResult) (status int, statusHeader string, h
 	return
 }
 
+func mergeGatherContribution(accumulator *merge.Accumulator, rsc *request.Resources,
+	body []byte, member int, stripKeys []string,
+) bool {
+	if rsc == nil || rsc.MergeFunc == nil {
+		return false
+	}
+	ts := rsc.TS
+	if ts == nil && len(body) > 0 && rsc.TSUnmarshaler != nil && rsc.TimeRangeQuery != nil {
+		var err error
+		ts, err = rsc.TSUnmarshaler(body, rsc.TimeRangeQuery)
+		if err != nil {
+			logger.Warn("tsm gather timeseries decode failure", logging.Pairs{
+				"member": member, "error": err,
+			})
+			return false
+		}
+		rsc.TS = ts
+	}
+	if len(stripKeys) > 0 && ts != nil {
+		if ds, ok := ts.(*dataset.DataSet); ok {
+			ds.StripTags(stripKeys)
+		}
+	}
+	var data any
+	if ts != nil {
+		data = ts
+	} else if len(body) > 0 {
+		data = body
+	} else {
+		return false
+	}
+	if err := rsc.MergeFunc(accumulator, data, member); err != nil {
+		logger.Warn("tsm gather merge failure", logging.Pairs{
+			"member": member, "error": err,
+		})
+		return false
+	}
+	return true
+}
+
 // serveStandard handles the common scatter/gather path: each shard gets one
 // request, results are merged with mergeStrategy, and an optional warning is
 // appended to the accumulated dataset before writing the response.
@@ -523,16 +563,10 @@ func (h *handler) serveStandard(
 			if rsc2.MergeFunc == nil || rsc2.MergeRespondFunc == nil {
 				logger.Warn("tsm gather failed due to nil func", nil)
 			}
-			if len(stripKeys) > 0 && rsc2.TS != nil {
-				if ds, ok := rsc2.TS.(*dataset.DataSet); ok {
-					ds.StripTags(stripKeys)
-				}
-			}
 			var contributed bool
 			if rsc2.MergeFunc != nil {
 				if rsc2.TS != nil {
-					rsc2.MergeFunc(accumulator, rsc2.TS, i)
-					contributed = true
+					contributed = mergeGatherContribution(accumulator, rsc2, nil, i, stripKeys)
 				} else {
 					body, derr := encoding.DecompressResponseBody(
 						fr.Capture.Header().Get(headers.NameContentEncoding),
@@ -546,8 +580,7 @@ func (h *handler) serveStandard(
 						return
 					}
 					if len(body) > 0 {
-						rsc2.MergeFunc(accumulator, body, i)
-						contributed = true
+						contributed = mergeGatherContribution(accumulator, rsc2, body, i, stripKeys)
 					}
 				}
 			}
@@ -812,13 +845,22 @@ func (h *handler) serveWeightedAvg(
 					results[i].failed = true
 					return
 				}
-				if len(stripKeys) > 0 && rsc2.TS != nil {
-					if ds, ok := rsc2.TS.(*dataset.DataSet); ok {
-						ds.StripTags(stripKeys)
+				var contributed bool
+				if rsc2.TS != nil {
+					contributed = mergeGatherContribution(sumAccum, rsc2, nil, i, stripKeys)
+				} else if fr.Capture != nil {
+					body, derr := encoding.DecompressResponseBody(
+						fr.Capture.Header().Get(headers.NameContentEncoding),
+						fr.Capture.Body(),
+					)
+					if derr != nil {
+						logger.Warn("tsm avg sum gather decode failure", logging.Pairs{
+							"member": i, "error": derr,
+						})
+						results[i].failed = true
+						return
 					}
-				}
-				if rsc2.MergeFunc != nil && rsc2.TS != nil {
-					rsc2.MergeFunc(sumAccum, rsc2.TS, i)
+					contributed = mergeGatherContribution(sumAccum, rsc2, body, i, stripKeys)
 				}
 				sc := fr.Capture.StatusCode()
 				if rsc2.Response != nil && rsc2.Response.StatusCode > 0 {
@@ -828,6 +870,7 @@ func (h *handler) serveWeightedAvg(
 					statusCode: sc,
 					header:     fr.Capture.Header(),
 					mergeFunc:  rsc2.MergeRespondFunc,
+					failed:     !contributed,
 				}
 			},
 		})
@@ -852,13 +895,20 @@ func (h *handler) serveWeightedAvg(
 				if rsc2 == nil {
 					return
 				}
-				if len(stripKeys) > 0 && rsc2.TS != nil {
-					if ds, ok := rsc2.TS.(*dataset.DataSet); ok {
-						ds.StripTags(stripKeys)
+				if rsc2.TS != nil {
+					mergeGatherContribution(countAccum, rsc2, nil, i, stripKeys)
+				} else if fr.Capture != nil {
+					body, derr := encoding.DecompressResponseBody(
+						fr.Capture.Header().Get(headers.NameContentEncoding),
+						fr.Capture.Body(),
+					)
+					if derr != nil {
+						logger.Warn("tsm avg count gather decode failure", logging.Pairs{
+							"member": i, "error": derr,
+						})
+						return
 					}
-				}
-				if rsc2.MergeFunc != nil && rsc2.TS != nil {
-					rsc2.MergeFunc(countAccum, rsc2.TS, i)
+					mergeGatherContribution(countAccum, rsc2, body, i, stripKeys)
 				}
 			},
 		})

--- a/pkg/backends/alb/mech/tsm/time_series_merge_body_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_body_test.go
@@ -17,16 +17,20 @@
 package tsm
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	prommodel "github.com/trickstercache/trickster/v2/pkg/backends/prometheus/model"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
 	"github.com/trickstercache/trickster/v2/pkg/testutil/albpool"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
 )
 
@@ -176,4 +180,53 @@ func TestHandleResponseMergeBody(t *testing.T) {
 			t.Fatalf("status: want %d got %d body=%q", http.StatusBadGateway, w.Code, w.Body.String())
 		}
 	})
+}
+
+func TestTSMMergeProxyOnlyBodyUsesTimeRangeQuery(t *testing.T) {
+	logger.SetLogger(testLogger)
+
+	trq := &timeseries.TimeRangeQuery{
+		Extent: timeseries.Extent{
+			Start: time.Unix(1700000000, 0),
+			End:   time.Unix(1700000030, 0),
+		},
+		Step: 15 * time.Second,
+	}
+	m := prommodel.NewModeler()
+	bodyOnlyHandler := func(job string) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			rsc := request.GetResources(r)
+			if rsc != nil {
+				rsc.TimeRangeQuery = trq.Clone()
+				rsc.TSUnmarshaler = m.WireUnmarshaler
+				rsc.MergeFunc = merge.TimeseriesMergeFunc(m.WireUnmarshaler)
+				rsc.MergeRespondFunc = merge.TimeseriesRespondFunc(m.WireMarshalWriter, &timeseries.RequestOptions{})
+			}
+			w.Header().Set(headers.NameContentType, "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"status":"success","data":{"resultType":"matrix","result":[`+
+				`{"metric":{"__name__":"up","job":%q},"values":[[%d,"1"],[%d,"1"]]}]}}`,
+				job, trq.Extent.Start.Unix(), trq.Extent.End.Unix())
+		})
+	}
+
+	p, _, _ := albpool.NewHealthy([]http.Handler{
+		bodyOnlyHandler("proxy-only-a"),
+		bodyOnlyHandler("proxy-only-b"),
+	})
+	defer p.Stop()
+	h := &handler{mergePaths: []string{"/"}}
+	h.SetPool(p)
+	p.RefreshHealthy()
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newTestMergeRequest(t))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: want %d got %d body=%q", http.StatusOK, w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "proxy-only-a") || !strings.Contains(body, "proxy-only-b") {
+		t.Fatalf("body: want both proxy-only member series, got %q", body)
+	}
 }

--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -181,15 +181,14 @@ func finalizeDPCResponse(
 // request while caching the results for subsequent requests of the same data
 func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request, modeler *timeseries.Modeler) {
 	rsc := request.GetResources(r)
-	o := rsc.BackendOptions
-	if o == nil || o.ProxyOnly {
-		DoProxy(w, r, true)
-		return
-	}
-
 	if modeler != nil {
 		rsc.TSMarshaler = modeler.WireMarshalWriter
 		rsc.TSUnmarshaler = modeler.WireUnmarshaler
+	}
+	o := rsc.BackendOptions
+	if o == nil {
+		DoProxy(w, r, true)
+		return
 	}
 	ctx, span := tspan.NewChildSpan(r.Context(), rsc.Tracer, "DeltaProxyCacheRequest")
 	if span != nil {
@@ -209,6 +208,13 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request, modeler *tim
 	rsc.TSReqestOptions = rlo
 	rsc.Unlock()
 	if err != nil {
+		if o.ProxyOnly {
+			if trq != nil && trq.OriginalBody != nil {
+				request.SetBody(r, trq.OriginalBody)
+			}
+			DoProxy(w, r, true)
+			return
+		}
 		if canOPC {
 			logger.Debug("could not parse time range query, using object proxy cache",
 				logging.Pairs{"error": err.Error()})
@@ -218,6 +224,13 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request, modeler *tim
 		}
 		// err may simply mean incompatible query (e.g., non-select), so just proxy
 		if trq != nil && trq.OriginalBody != nil {
+			request.SetBody(r, trq.OriginalBody)
+		}
+		DoProxy(w, r, true)
+		return
+	}
+	if o.ProxyOnly {
+		if trq.OriginalBody != nil {
 			request.SetBody(r, trq.OriginalBody)
 		}
 		DoProxy(w, r, true)

--- a/pkg/proxy/engines/deltaproxycache_test.go
+++ b/pkg/proxy/engines/deltaproxycache_test.go
@@ -1924,6 +1924,12 @@ func TestDPCProxyOnly(t *testing.T) {
 	if !strings.Contains(hdr, "engine=HTTPProxy") {
 		t.Errorf("expected HTTPProxy engine in result header, got %q", hdr)
 	}
+	if rsc.TimeRangeQuery == nil {
+		t.Fatal("expected proxy-only DPC metadata to include TimeRangeQuery")
+	}
+	if rsc.TSUnmarshaler == nil {
+		t.Fatal("expected proxy-only DPC metadata to include TSUnmarshaler")
+	}
 }
 
 // TestDPCNoCacheBypass verifies that requests with Cache-Control: no-cache


### PR DESCRIPTION
## Description
Fixes #1040.

TSM can now merge proxy-only time-series responses instead of treating them as unusable fanout contributions. When a merge member falls back to HTTP proxying, the gather path now decodes the captured body with the member's `TimeRangeQuery` before merging, so Prometheus range responses do not fail unmarshalling with a missing time range. DPC also preserves timeseries modeler and request metadata before `proxy_only` fallback, so proxy-only backend configs have the same merge metadata as cacheable DPC requests.

This keeps cache retention semantics unchanged: very old ranges still are not written to cache. The new integration coverage verifies both proxy-only pool members and out-of-window oldest-retention ranges merge successfully through TSM, and that old ranges remain proxy-only on repeat requests.

Validation run:

- `go test ./pkg/backends/alb/mech/tsm -run "TestTSMMergeProxyOnlyBodyUsesTimeRangeQuery|TestHandleResponseMergeBody" -count=1`
- `go test ./pkg/proxy/engines -run TestDPCProxyOnly -count=1`
- `go test -count=1 ./pkg/backends/alb/... ./pkg/proxy/engines ./pkg/backends/prometheus/...`
- `go test -count=1 ./pkg/proxy/...`
- `go tool golangci-lint run --timeout 5m ./pkg/backends/alb/... ./pkg/proxy/engines ./pkg/backends/prometheus/...`
- `go test -run '^$' ./...`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c -o $TEMP/trickster-integration.test` from `integration/`
- `git diff --check` (only Windows line-ending warnings)

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [x] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
