### PR TITLE
fix: propagate trace context to origins

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -15,6 +15,10 @@ Trickster allows the operator to configure multiple tracing configurations, whic
 
 The [example config](https://github.com/trickstercache/trickster/blob/v1.1.2/examples/conf/example.full.yaml#L508) has exhaustive examples of configuring Trickster for distributed tracing.
 
+## Context Propagation
+
+When tracing is enabled for a Backend, Trickster uses the W3C Trace Context and Baggage propagators. It extracts incoming `traceparent`, `tracestate`, and `baggage` headers from client requests and injects the active outbound origin request span into the proxied request. This lets downstream Origins continue the same distributed trace instead of starting an unrelated trace.
+
 ## Span List
 
 Trickster can insert several spans to the traces that it captures, depending upon the type and cacheability of the inbound client request, as described in the table below.

--- a/pkg/observability/tracing/registry/registry.go
+++ b/pkg/observability/tracing/registry/registry.go
@@ -111,10 +111,18 @@ func GetTracer(options *options.Options,
 	switch options.Provider {
 	case providers.Stdout.String():
 		logTracerRegistration()
-		return stdout.New(options)
+		tracer, err := stdout.New(options)
+		if err == nil && tracer != nil {
+			tracing.ConfigurePropagators()
+		}
+		return tracer, err
 	case providers.OTLP.String():
 		logTracerRegistration()
-		return otlp.New(options)
+		tracer, err := otlp.New(options)
+		if err == nil && tracer != nil {
+			tracing.ConfigurePropagators()
+		}
+		return tracer, err
 	}
 
 	return nil, nil

--- a/pkg/observability/tracing/registry/registry_test.go
+++ b/pkg/observability/tracing/registry/registry_test.go
@@ -17,6 +17,9 @@
 package registry
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/trickstercache/trickster/v2/pkg/config"
@@ -24,6 +27,9 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/level"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing/options"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestRegisterAll(t *testing.T) {
@@ -117,5 +123,40 @@ func TestGetTracer(t *testing.T) {
 	tr, _ := GetTracer(nil, true)
 	if tr != nil {
 		t.Error("expected nil tracer")
+	}
+}
+
+func TestGetTracerInstallsTraceContextPropagator(t *testing.T) {
+	previous := otel.GetTextMapPropagator()
+	t.Cleanup(func() { otel.SetTextMapPropagator(previous) })
+
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator())
+
+	opts := options.New()
+	opts.Name = "test"
+	opts.Provider = "stdout"
+	tracer, err := GetTracer(opts, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tracer == nil {
+		t.Fatal("expected tracer")
+	}
+
+	traceID := trace.TraceID{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+	spanID := trace.SpanID{2, 2, 2, 2, 2, 2, 2, 2}
+	ctx := trace.ContextWithSpanContext(context.Background(),
+		trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: trace.FlagsSampled,
+		}))
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
+
+	want := "00-" + traceID.String() + "-" + spanID.String() + "-01"
+	if got := req.Header.Get("traceparent"); got != want {
+		t.Fatalf("traceparent: expected %q, got %q", want, got)
 	}
 }

--- a/pkg/observability/tracing/span/span.go
+++ b/pkg/observability/tracing/span/span.go
@@ -81,6 +81,25 @@ func NewChildSpan(ctx context.Context, tr *tracing.Tracer,
 	return ctx, span
 }
 
+// PrepareOutgoingRequest attaches HTTP client tracing hooks and injects the
+// active trace context into an outbound request.
+func PrepareOutgoingRequest(ctx context.Context, r *http.Request,
+	tr *tracing.Tracer,
+) (context.Context, *http.Request) {
+	if r == nil || tr == nil || tr.Tracer == nil {
+		return ctx, r
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if tctx.HealthCheckFlag(ctx) {
+		return ctx, r
+	}
+	ctx, r = otelhttptrace.W3C(ctx, r)
+	otelhttptrace.Inject(ctx, r)
+	return ctx, r
+}
+
 // SetAttributes safely sets attributes on a span, unless they are in the omit list
 func SetAttributes(tr *tracing.Tracer, span trace.Span, kvs ...attribute.KeyValue) {
 	l := len(kvs)

--- a/pkg/observability/tracing/tracing.go
+++ b/pkg/observability/tracing/tracing.go
@@ -23,8 +23,10 @@ import (
 	"net/http"
 
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing/options"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -44,6 +46,21 @@ type Tracers map[string]*Tracer
 
 // Tags represents a collection of Tags
 type Tags map[string]string
+
+// ConfigurePropagators installs Trickster's default distributed-tracing
+// propagators for inbound extraction and outbound origin request injection.
+func ConfigurePropagators() {
+	otel.SetTextMapPropagator(DefaultPropagators())
+}
+
+// DefaultPropagators returns the W3C propagators Trickster uses for trace
+// context and baggage across proxy boundaries.
+func DefaultPropagators() propagation.TextMapPropagator {
+	return propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	)
+}
 
 // HTTPToCode translates an HTTP status code into a GRPC code
 func HTTPToCode(status int) codes.Code {

--- a/pkg/observability/tracing/tracing_test.go
+++ b/pkg/observability/tracing/tracing_test.go
@@ -17,12 +17,18 @@
 package tracing
 
 import (
+	"context"
 	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"testing"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestHTTPToCode(t *testing.T) {
@@ -85,5 +91,63 @@ func TestTags(t *testing.T) {
 	attrs = t1.ToAttr()
 	if len(attrs) != 3 {
 		t.Errorf("expected %d got %d", 3, len(attrs))
+	}
+}
+
+func TestConfigurePropagatorsInstallsTraceContextAndBaggage(t *testing.T) {
+	previous := otel.GetTextMapPropagator()
+	t.Cleanup(func() { otel.SetTextMapPropagator(previous) })
+
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator())
+
+	traceID := trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	spanID := trace.SpanID{17, 18, 19, 20, 21, 22, 23, 24}
+	spanCtx := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+	})
+	bg, err := baggage.Parse("tenant=alpha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := baggage.ContextWithBaggage(
+		trace.ContextWithSpanContext(context.Background(), spanCtx),
+		bg,
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
+	if got := req.Header.Get("traceparent"); got != "" {
+		t.Fatalf("expected empty traceparent before ConfigurePropagators, got %q", got)
+	}
+
+	ConfigurePropagators()
+
+	req = httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
+
+	wantTraceparent := "00-" + traceID.String() + "-" + spanID.String() + "-01"
+	if got := req.Header.Get("traceparent"); got != wantTraceparent {
+		t.Fatalf("traceparent: expected %q, got %q", wantTraceparent, got)
+	}
+	if got := req.Header.Get("baggage"); got != "tenant=alpha" {
+		t.Fatalf("baggage: expected %q, got %q", "tenant=alpha", got)
+	}
+
+	extracted := otel.GetTextMapPropagator().Extract(
+		context.Background(),
+		propagation.HeaderCarrier(req.Header),
+	)
+	gotSpanCtx := trace.SpanContextFromContext(extracted)
+	if !gotSpanCtx.IsRemote() {
+		t.Fatal("expected extracted span context to be remote")
+	}
+	if gotSpanCtx.TraceID() != traceID || gotSpanCtx.SpanID() != spanID {
+		t.Fatalf("extracted span context = %s/%s, want %s/%s",
+			gotSpanCtx.TraceID(), gotSpanCtx.SpanID(), traceID, spanID)
+	}
+	if got := baggage.FromContext(extracted).Member("tenant").Value(); got != "alpha" {
+		t.Fatalf("extracted baggage tenant: expected %q, got %q", "alpha", got)
 	}
 }

--- a/pkg/proxy/engines/httpproxy.go
+++ b/pkg/proxy/engines/httpproxy.go
@@ -42,7 +42,6 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/proxy/params"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
-	othttptrace "go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -63,9 +62,10 @@ func DoProxy(w io.Writer, r *http.Request, closeResponse bool) *http.Response {
 
 	start := time.Now()
 
-	_, span := tspan.NewChildSpan(r.Context(), rsc.Tracer, "ProxyRequest")
+	ctx, span := tspan.NewChildSpan(r.Context(), rsc.Tracer, "ProxyRequest")
 	if span != nil {
 		defer span.End()
+		r = r.WithContext(ctx)
 	}
 	setResourceSpanAttributes(rsc, span)
 
@@ -216,18 +216,14 @@ func PrepareFetchReader(r *http.Request) (io.ReadCloser, *http.Response, int64) 
 	r.Close = false
 	r.RequestURI = ""
 
-	if rsc.Tracer != nil {
-		// Processing traces for proxies
-		// https://www.w3.org/TR/trace-context-1/#alternative-processing
-		ctx, r = othttptrace.W3C(ctx, r)
-		othttptrace.Inject(ctx, r)
-	}
-
-	_, doSpan := tspan.NewChildSpan(r.Context(), rsc.Tracer, "ProxyRequest")
+	ctx, doSpan := tspan.NewChildSpan(r.Context(), rsc.Tracer, "ProxyRequest")
 	if doSpan != nil {
 		defer doSpan.End()
+		r = r.WithContext(ctx)
 	}
 	setResourceSpanAttributes(rsc, doSpan)
+
+	_, r = tspan.PrepareOutgoingRequest(r.Context(), r, rsc.Tracer)
 
 	if ep := profile.FromContext(r.Context()); ep != nil && ep.SupportedHeaderVal != "" {
 		r.Header.Set(headers.NameAcceptEncoding, ep.SupportedHeaderVal)

--- a/pkg/proxy/engines/tracing_test.go
+++ b/pkg/proxy/engines/tracing_test.go
@@ -28,13 +28,20 @@ import (
 
 	cr "github.com/trickstercache/trickster/v2/pkg/cache/registry"
 	"github.com/trickstercache/trickster/v2/pkg/config"
+	otracing "github.com/trickstercache/trickster/v2/pkg/observability/tracing"
+	tspan "github.com/trickstercache/trickster/v2/pkg/observability/tracing/span"
 	tc "github.com/trickstercache/trickster/v2/pkg/proxy/context"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 	tu "github.com/trickstercache/trickster/v2/pkg/testutil"
 	"github.com/trickstercache/trickster/v2/pkg/util/sets"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestCacheSpansIncludeResourceAttributesAndStatus(t *testing.T) {
@@ -139,6 +146,86 @@ func TestPrepareFetchReaderErrorSpansIncludeBadGatewayStatus(t *testing.T) {
 	tu.RequireSpanAttributes(t, sr, "ProxyRequest", want)
 }
 
+func TestPrepareFetchReaderPropagatesIncomingTraceContextToOrigin(t *testing.T) {
+	previous := otel.GetTextMapPropagator()
+	t.Cleanup(func() { otel.SetTextMapPropagator(previous) })
+	otracing.ConfigurePropagators()
+
+	rt := &mockRoundTripper{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(bytes.NewReader([]byte("ok"))),
+		},
+	}
+	r, rsc, sr := newTracingFetchRequest(t, rt)
+
+	incomingTraceID := trace.TraceID{1, 3, 5, 7, 9, 11, 13, 15, 2, 4, 6, 8, 10, 12, 14, 16}
+	incomingSpanID := trace.SpanID{8, 7, 6, 5, 4, 3, 2, 1}
+	r.Header.Set("traceparent", "00-"+incomingTraceID.String()+"-"+incomingSpanID.String()+"-01")
+	r.Header.Set("baggage", "tenant=alpha")
+
+	r, requestSpan := tspan.PrepareRequest(r, rsc.Tracer)
+	if requestSpan == nil {
+		t.Fatal("expected request span")
+	}
+	defer requestSpan.End()
+	r = request.SetResources(r, rsc)
+
+	reader, resp, _ := PrepareFetchReader(r)
+	if resp == nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status %d, got %#v", http.StatusOK, resp)
+	}
+	if reader != nil {
+		_, _ = io.ReadAll(reader)
+		reader.Close()
+	}
+
+	if len(rt.reqs) != 1 {
+		t.Fatalf("expected 1 upstream request, got %d", len(rt.reqs))
+	}
+	upstream := rt.reqs[0]
+	if got := upstream.Header.Get("traceparent"); got == "" {
+		t.Fatal("expected upstream traceparent header")
+	}
+	if got := upstream.Header.Get("baggage"); got != "tenant=alpha" {
+		t.Fatalf("expected upstream baggage %q, got %q", "tenant=alpha", got)
+	}
+
+	extracted := otracing.DefaultPropagators().Extract(
+		context.Background(),
+		propagation.HeaderCarrier(upstream.Header),
+	)
+	upstreamSpanCtx := trace.SpanContextFromContext(extracted)
+	if !upstreamSpanCtx.IsRemote() {
+		t.Fatal("expected propagated span context to extract as remote")
+	}
+	if upstreamSpanCtx.TraceID() != incomingTraceID {
+		t.Fatalf("upstream trace id = %s, want %s", upstreamSpanCtx.TraceID(), incomingTraceID)
+	}
+	if upstreamSpanCtx.SpanID() == incomingSpanID {
+		t.Fatal("upstream traceparent must use Trickster's outbound span, not the incoming parent span")
+	}
+	if got := baggage.FromContext(extracted).Member("tenant").Value(); got != "alpha" {
+		t.Fatalf("extracted baggage tenant: expected %q, got %q", "alpha", got)
+	}
+
+	proxySpan := latestEndedSpan(t, sr, "ProxyRequest")
+	if upstreamSpanCtx.SpanID() != proxySpan.SpanContext().SpanID() {
+		t.Fatalf("upstream parent span id = %s, want outbound ProxyRequest span id %s",
+			upstreamSpanCtx.SpanID(), proxySpan.SpanContext().SpanID())
+	}
+	if proxySpan.SpanContext().TraceID() != incomingTraceID {
+		t.Fatalf("ProxyRequest trace id = %s, want %s",
+			proxySpan.SpanContext().TraceID(), incomingTraceID)
+	}
+
+	if proxySpan.Parent().TraceID() != incomingTraceID {
+		t.Fatalf("ProxyRequest parent trace id = %s, want %s",
+			proxySpan.Parent().TraceID(), incomingTraceID)
+	}
+}
+
 func TestObjectProxyCacheRequestSpanIncludesResourceStatusAttributes(t *testing.T) {
 	hdrs := map[string]string{"Cache-Control": "max-age=60"}
 	ts, _, r, rsc, err := setupTestHarnessOPC("", "test", http.StatusPartialContent, hdrs)
@@ -195,4 +282,16 @@ func resourceAttributeStrings(rsc *request.Resources) map[string]string {
 		out[string(kv.Key)] = kv.Value.AsString()
 	}
 	return out
+}
+
+func latestEndedSpan(t testing.TB, sr *tracetest.SpanRecorder, name string) sdktrace.ReadOnlySpan {
+	t.Helper()
+	spans := sr.Ended()
+	for i := len(spans) - 1; i >= 0; i-- {
+		if spans[i].Name() == name {
+			return spans[i]
+		}
+	}
+	t.Fatalf("span %q not found in %d ended spans", name, len(spans))
+	return nil
 }


### PR DESCRIPTION
## Description
Related to #381.

This continues the OTLP/distributed tracing work by making trace-context propagation explicit and functional across the proxy boundary. When a concrete tracer is registered, Trickster now installs W3C Trace Context plus Baggage propagators, so inbound `traceparent`, `tracestate`, and `baggage` headers can be extracted and outbound origin requests can carry the active trace context.

The fetch path now uses a shared tracing helper for outbound request preparation and injects the context from the actual outbound `ProxyRequest` span. That means downstream origins continue the same distributed trace with the origin request span as their parent, instead of relying on a no-op/default propagator or a less precise preparation span.

This keeps the tracing configuration shape unchanged. It only makes the existing tracing behavior work as expected when a backend has tracing enabled.

Validation run:

```powershell
go test ./pkg/observability/tracing/... -count=1
go test ./pkg/proxy/engines -run TestPrepareFetchReaderPropagatesIncomingTraceContextToOrigin|TestPrepareFetchReaderSpansIncludeResourceStatusAttributes|TestDoProxySpanIncludesResourceStatusAttributes -count=1
go test -count=1 ./pkg/observability/... ./pkg/util/middleware ./pkg/proxy/request ./pkg/proxy/engines
go tool golangci-lint run --timeout 5m ./pkg/observability/... ./pkg/util/middleware ./pkg/proxy/request ./pkg/proxy/engines
go test -count=1 ./pkg/proxy/...
go test -run '^$' ./...
go test -race ./pkg/proxy/engines -run TestPrepareFetchReaderPropagatesIncomingTraceContextToOrigin -count=1
go test -race ./pkg/observability/tracing/... -run TestConfigurePropagatorsInstallsTraceContextAndBaggage|TestGetTracerInstallsTraceContextPropagator -count=1
git diff --check
```

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [x] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [x] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.