### PR TITLE
fix: honor parent trace sampling

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -19,6 +19,10 @@ The [example config](https://github.com/trickstercache/trickster/blob/v1.1.2/exa
 
 When tracing is enabled for a Backend, Trickster uses the W3C Trace Context and Baggage propagators. It extracts incoming `traceparent`, `tracestate`, and `baggage` headers from client requests and injects the active outbound origin request span into the proxied request. This lets downstream Origins continue the same distributed trace instead of starting an unrelated trace.
 
+## Sampling
+
+Trickster uses parent-based sampling for traced requests. The configured `sample_rate` controls root traces that Trickster starts when there is no sampled upstream trace context. When an incoming request already has a remote parent trace, Trickster follows the parent's sampling decision so sampled upstream traces continue across the proxy boundary and unsampled upstream traces remain unsampled.
+
 ## Span List
 
 Trickster can insert several spans to the traces that it captures, depending upon the type and cacheability of the inbound client request, as described in the table below.

--- a/examples/conf/example.full.yaml
+++ b/examples/conf/example.full.yaml
@@ -650,7 +650,8 @@ backends:
 #     # default is false
 #     disable_compression: false
 
-#     # sample_rate sets the probability that a span will be recorded.
+#     # sample_rate sets the probability that a root trace started by Trickster will be recorded.
+#     # when a request already has remote trace context, Trickster follows the parent's sampling decision.
 #     # A floating point value of 0.0 to 1.0 (inclusive) is permitted
 #     # default is 1.0 (meaning 100% of requests are recorded)
 #     sample_rate: 1.0

--- a/pkg/observability/tracing/exporters/otlp/otlp.go
+++ b/pkg/observability/tracing/exporters/otlp/otlp.go
@@ -38,16 +38,6 @@ func New(o *options.Options) (*tracing.Tracer, error) {
 	if o == nil {
 		return nil, errs.ErrNoTracerOptions
 	}
-	var sampler sdktrace.Sampler
-	o.SanitizeSampleRate()
-	switch *o.SampleRate {
-	case 0:
-		sampler = sdktrace.NeverSample()
-	case 1:
-		sampler = sdktrace.AlwaysSample()
-	default:
-		sampler = sdktrace.TraceIDRatioBased(*o.SampleRate)
-	}
 
 	tags := make([]attribute.KeyValue, 1, len(o.Tags)+1)
 	tags[0] = attribute.String("service.name", o.ServiceName)
@@ -89,7 +79,7 @@ func New(o *options.Options) (*tracing.Tracer, error) {
 	}
 
 	tracerOpts := make([]sdktrace.TracerProviderOption, 0, 3)
-	tracerOpts = append(tracerOpts, sdktrace.WithSampler(sampler))
+	tracerOpts = append(tracerOpts, sdktrace.WithSampler(tracing.Sampler(o)))
 	tracerOpts = append(tracerOpts,
 		sdktrace.WithResource(resource.NewWithAttributes("", tags...)))
 	tracerOpts = append(tracerOpts, sdktrace.WithBatcher(exporter))

--- a/pkg/observability/tracing/exporters/otlp/otlp_test.go
+++ b/pkg/observability/tracing/exporters/otlp/otlp_test.go
@@ -28,6 +28,7 @@ import (
 
 	errs "github.com/trickstercache/trickster/v2/pkg/observability/tracing/errors"
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing/options"
+	"go.opentelemetry.io/otel/trace"
 	collectortracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"google.golang.org/protobuf/proto"
 )
@@ -217,6 +218,68 @@ func TestNewAppliesResourceAttributes(t *testing.T) {
 	}
 }
 
+func TestNewContinuesSampledRemoteParent(t *testing.T) {
+	payloads := make(chan *collectortracepb.ExportTraceServiceRequest, 10)
+	handlerErrs := make(chan error, 10)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			handlerErrs <- err
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		var req collectortracepb.ExportTraceServiceRequest
+		if err := proto.Unmarshal(body, &req); err != nil {
+			handlerErrs <- err
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		payloads <- &req
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Setenv("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "1")
+
+	sampleRate := 0.0
+	opt := options.New()
+	opt.Endpoint = srv.URL + "/v1/traces"
+	opt.SampleRate = &sampleRate
+	opt.DisableCompression = true
+	opt.Timeout = time.Second
+
+	tr, err := New(opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	traceID := trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	parent := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     trace.SpanID{17, 18, 19, 20, 21, 22, 23, 24},
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	_, span := tr.Start(
+		trace.ContextWithRemoteSpanContext(context.Background(), parent),
+		"sampled-remote-child",
+	)
+	span.End()
+
+	req := waitForOTLPRequest(t, payloads, handlerErrs)
+	if !hasSpanName(req, "sampled-remote-child") {
+		t.Fatalf("expected sampled-remote-child span in OTLP request")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err = tr.ShutdownFunc(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func waitForOTLPRequest(t *testing.T, payloads <-chan *collectortracepb.ExportTraceServiceRequest,
 	handlerErrs <-chan error) *collectortracepb.ExportTraceServiceRequest {
 	t.Helper()
@@ -239,4 +302,17 @@ func resourceAttributeValues(req *collectortracepb.ExportTraceServiceRequest) ma
 		}
 	}
 	return out
+}
+
+func hasSpanName(req *collectortracepb.ExportTraceServiceRequest, name string) bool {
+	for _, rs := range req.GetResourceSpans() {
+		for _, ss := range rs.GetScopeSpans() {
+			for _, span := range ss.GetSpans() {
+				if span.GetName() == name {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }

--- a/pkg/observability/tracing/exporters/stdout/stdout.go
+++ b/pkg/observability/tracing/exporters/stdout/stdout.go
@@ -52,17 +52,6 @@ func New(opts *options.Options) (*tracing.Tracer, error) {
 		return nil, err
 	}
 
-	var sampler sdktrace.Sampler
-
-	switch *opts.SampleRate {
-	case 0:
-		sampler = sdktrace.NeverSample()
-	case 1:
-		sampler = sdktrace.AlwaysSample()
-	default:
-		sampler = sdktrace.TraceIDRatioBased(*opts.SampleRate)
-	}
-
 	serviceKey := attribute.String("service.name", opts.ServiceName)
 
 	var tags []attribute.KeyValue
@@ -77,7 +66,7 @@ func New(opts *options.Options) (*tracing.Tracer, error) {
 	}
 
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp),
-		sdktrace.WithSampler(sampler),
+		sdktrace.WithSampler(tracing.Sampler(opts)),
 		sdktrace.WithResource(resource.NewWithAttributes("", tags...)),
 	)
 

--- a/pkg/observability/tracing/tracing.go
+++ b/pkg/observability/tracing/tracing.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -60,6 +61,26 @@ func DefaultPropagators() propagation.TextMapPropagator {
 		propagation.TraceContext{},
 		propagation.Baggage{},
 	)
+}
+
+// Sampler returns a parent-based sampler for the provided tracing options.
+// SampleRate controls root traces started by Trickster, while sampled upstream
+// parent traces continue through Trickster's proxy boundary.
+func Sampler(o *options.Options) sdktrace.Sampler {
+	if o == nil {
+		return sdktrace.ParentBased(sdktrace.AlwaysSample())
+	}
+	o.SanitizeSampleRate()
+	var root sdktrace.Sampler
+	switch *o.SampleRate {
+	case 0:
+		root = sdktrace.NeverSample()
+	case 1:
+		root = sdktrace.AlwaysSample()
+	default:
+		root = sdktrace.TraceIDRatioBased(*o.SampleRate)
+	}
+	return sdktrace.ParentBased(root)
 }
 
 // HTTPToCode translates an HTTP status code into a GRPC code

--- a/pkg/observability/tracing/tracing_test.go
+++ b/pkg/observability/tracing/tracing_test.go
@@ -23,11 +23,13 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/trickstercache/trickster/v2/pkg/observability/tracing/options"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -149,5 +151,50 @@ func TestConfigurePropagatorsInstallsTraceContextAndBaggage(t *testing.T) {
 	}
 	if got := baggage.FromContext(extracted).Member("tenant").Value(); got != "alpha" {
 		t.Fatalf("extracted baggage tenant: expected %q, got %q", "alpha", got)
+	}
+}
+
+func TestSamplerHonorsRemoteParentSampling(t *testing.T) {
+	traceID := trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	spanID := trace.SpanID{17, 18, 19, 20, 21, 22, 23, 24}
+	sampleRate := 0.0
+	sampler := Sampler(&options.Options{SampleRate: &sampleRate})
+
+	root := sampler.ShouldSample(sdktrace.SamplingParameters{
+		ParentContext: context.Background(),
+		TraceID:       traceID,
+		Name:          "root",
+	})
+	if root.Decision != sdktrace.Drop {
+		t.Fatalf("root decision = %v, want Drop", root.Decision)
+	}
+
+	sampledParent := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	sampledChild := sampler.ShouldSample(sdktrace.SamplingParameters{
+		ParentContext: trace.ContextWithRemoteSpanContext(context.Background(), sampledParent),
+		TraceID:       traceID,
+		Name:          "sampled-child",
+	})
+	if sampledChild.Decision != sdktrace.RecordAndSample {
+		t.Fatalf("sampled remote parent decision = %v, want RecordAndSample", sampledChild.Decision)
+	}
+
+	unsampledParent := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: traceID,
+		SpanID:  spanID,
+		Remote:  true,
+	})
+	unsampledChild := sampler.ShouldSample(sdktrace.SamplingParameters{
+		ParentContext: trace.ContextWithRemoteSpanContext(context.Background(), unsampledParent),
+		TraceID:       traceID,
+		Name:          "unsampled-child",
+	})
+	if unsampledChild.Decision != sdktrace.Drop {
+		t.Fatalf("unsampled remote parent decision = %v, want Drop", unsampledChild.Decision)
 	}
 }


### PR DESCRIPTION
## Description
Related to #381.

This updates Trickster's tracing sampler to be parent-based for the stdout and OTLP exporters. The configured `sample_rate` still controls root traces started by Trickster, but incoming remote parent trace decisions are now honored so sampled upstream traces continue through Trickster and unsampled upstream traces remain unsampled.

This keeps the existing tracing configuration shape intact and updates the tracing docs and example config comments to describe the parent-based sampling behavior.

Validation:

- `go test ./pkg/observability/tracing/... -count=1`
- `go test -race ./pkg/observability/tracing/... -run 'TestSamplerHonorsRemoteParentSampling|TestNewContinuesSampledRemoteParent' -count=1`
- `go test -count=1 ./pkg/observability/...`
- `go test -run '^$' ./...`
- `go tool golangci-lint run --timeout 5m ./pkg/observability/tracing/...`
- `git diff --check`

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [x] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [x] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.