### PR TITLE
fix: return 500 on internal failures

### DIFF
--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -62,6 +62,13 @@ const (
 	errorBodyCap = 1 << 20
 )
 
+func dpcProxyErrorStatusCode(statusCode int) int {
+	if statusCode == 0 || (statusCode >= http.StatusOK && statusCode < http.StatusMultipleChoices) {
+		return http.StatusInternalServerError
+	}
+	return statusCode
+}
+
 // fetchFastForward executes a fast-forward request and merges the result into rts.
 // Returns the fast-forward status string ("off", "hit", "miss", or "err").
 func fetchFastForward(
@@ -301,7 +308,7 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request, modeler *tim
 			// buildErrorResult constructs a dpcResult for error responses.
 			buildErrorResult := func(sc int, h http.Header, body []byte, fext timeseries.ExtentList) *dpcResult {
 				return &dpcResult{
-					statusCode:    sc,
+					statusCode:    dpcProxyErrorStatusCode(sc),
 					headers:       h,
 					body:          body,
 					elapsed:       float64(time.Since(now).Seconds()),
@@ -577,9 +584,10 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request, modeler *tim
 	cts, doc, elapsed, failedExts, severeFault = fetchTimeseries(pr, trq, client, modeler)
 	if len(failedExts) > 0 && severeFault {
 		h := doc.SafeHeaderClone()
-		recordDPCResult(r, status.LookupStatusProxyError, doc.StatusCode,
+		sc := dpcProxyErrorStatusCode(doc.StatusCode)
+		recordDPCResult(r, status.LookupStatusProxyError, sc,
 			r.URL.Path, "", elapsed.Seconds(), nil, failedExts, h)
-		Respond(w, doc.StatusCode, h, bytes.NewReader(doc.Body))
+		Respond(w, sc, h, bytes.NewReader(doc.Body))
 		return
 	}
 	rts = cts.Clone()

--- a/pkg/proxy/engines/deltaproxycache_chunk_test.go
+++ b/pkg/proxy/engines/deltaproxycache_chunk_test.go
@@ -1348,7 +1348,7 @@ func TestDeltaProxyCacheRequestCacheMissUnmarshalFailedChunks(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = testStatusCodeMatch(resp.StatusCode, http.StatusOK)
+	err = testStatusCodeMatch(resp.StatusCode, http.StatusInternalServerError)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/proxy/engines/deltaproxycache_test.go
+++ b/pkg/proxy/engines/deltaproxycache_test.go
@@ -1397,7 +1397,7 @@ func TestDeltaProxyCacheRequestCacheMissUnmarshalFailed(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = testStatusCodeMatch(resp.StatusCode, http.StatusOK)
+	err = testStatusCodeMatch(resp.StatusCode, http.StatusInternalServerError)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2136,12 +2136,14 @@ func TestDPCSingleflightBadPayload(t *testing.T) {
 		t.Errorf("expected 1 origin request, got %d", hits)
 	}
 
-	// all callers should get a proxy-error cache status (the unmarshaling failure
-	// triggers buildErrorResult inside the singleflight closure).
-	// the HTTP status is 200 because that's what the origin returned, but the
-	// Trickster-Result header indicates the error.
+	// all callers should get a proxy-error cache status and an Internal Server Error
+	// response (the unmarshaling failure triggers buildErrorResult inside the
+	// singleflight closure).
 	for i, rec := range recorders {
 		resp := rec.Result()
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Errorf("request %d: expected status 500, got %d", i, resp.StatusCode)
+		}
 		hdr := resp.Header.Get(headers.NameTricksterResult)
 		if !strings.Contains(hdr, "status=proxy-error") {
 			t.Errorf("request %d: expected proxy-error in result header, got %q", i, hdr)


### PR DESCRIPTION
## Description
This fixes the remaining cases outlined in #1018 - when a 200 response is received from a backend but trickster internally fails to handle the request (e.g., unmarshal failure). Other cases where a 200 was being returned instead of 5xx are already addressed. With this change, instead of proxying the 200 response to the caller on internal failures, the response code is now changed to 500 Internal Server Error before responding. When the internal failure is on one or more shards of a TSM operation, the TSM handles the failure(s) the same as if the failure came from the remote origin.  Related tests are updated with the new expectation.

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [x] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
