### PR TITLE
fix: close demand probe response bodies

### DIFF
--- a/pkg/backends/healthcheck/target.go
+++ b/pkg/backends/healthcheck/target.go
@@ -315,6 +315,9 @@ func (t *target) notifyStatus(st int32, detail string) {
 func (t *target) demandProbe(w http.ResponseWriter) {
 	r := t.baseRequest.Clone(context.Background())
 	resp, err := t.httpClient.Do(r)
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
 	h := w.Header()
 	if err != nil {
 		if t.status != nil && t.status.Get() != StatusUnchecked {

--- a/pkg/backends/healthcheck/target_test.go
+++ b/pkg/backends/healthcheck/target_test.go
@@ -40,6 +40,16 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
+type closeTrackingBody struct {
+	io.Reader
+	closed bool
+}
+
+func (b *closeTrackingBody) Close() error {
+	b.closed = true
+	return nil
+}
+
 func okProbeResponse(req *http.Request) *http.Response {
 	return &http.Response{
 		StatusCode: http.StatusOK,
@@ -331,6 +341,31 @@ func TestDemandProbe(t *testing.T) {
 	if w.Code != 500 {
 		t.Error("expected 500 got ", w.Code)
 	}
+}
+
+func TestDemandProbeClosesUpstreamBody(t *testing.T) {
+	body := &closeTrackingBody{Reader: strings.NewReader("OK")}
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       body,
+			Request:    req,
+		}, nil
+	})}
+	r, err := http.NewRequest(http.MethodGet, "http://healthcheck.invalid/", nil)
+	require.NoError(t, err)
+	target := &target{
+		status:      &Status{},
+		baseRequest: r,
+		httpClient:  client,
+	}
+	w := httptest.NewRecorder()
+
+	target.demandProbe(w)
+
+	require.True(t, body.closed, "demand probe must close the upstream response body")
+	require.Equal(t, "OK", w.Body.String())
 }
 
 func newTestServer(responseCode int, responseBody string,


### PR DESCRIPTION
## Description

The on-demand healthcheck path copied an upstream response body to the caller but never closed it. That left response-body resources owned by the transport open after each demand probe and could prevent normal connection cleanup.

This closes a non-nil upstream body after forwarding completes. The regression test uses a tracking `ReadCloser` to verify both that the body is closed and that its content is still returned to the caller.

Validation:

- `go test ./pkg/backends/healthcheck/... ./pkg/proxy/handlers/health/... -count=1`
- `go test -race ./pkg/backends/healthcheck -run '^(TestDemandProbe|TestDemandProbeClosesUpstreamBody)$' -count=20`
- `go tool golangci-lint run --timeout 5m ./pkg/backends/healthcheck/...`
- `go test -run '^$' ./...`

Reviewer: @jranson

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Optimization
- [x] Test coverage
- [ ] Documentation
- [ ] Infrastructure

## AI Disclosure

- [ ] This contribution DOES NOT include AI-generated changes
- [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
