### PR TITLE
fix: ensure host header promotion works consistently

### DIFF
--- a/pkg/proxy/headers/headers.go
+++ b/pkg/proxy/headers/headers.go
@@ -199,21 +199,23 @@ func UpdateHeaders(headers http.Header, updates map[string]string) {
 		return
 	}
 	for k, v := range updates {
-		if k == "" {
-			continue
-		}
-		if k[0:1] == "-" {
-			k = k[1:]
-			headers.Del(k)
-			continue
-		}
-		if k[0:1] == "+" {
-			k = k[1:]
-			headers.Add(k, v)
-			continue
-		}
-		headers.Set(k, v)
+		updateHeader(headers, k, v)
 	}
+}
+
+func updateHeader(headers http.Header, name, value string) {
+	if name == "" {
+		return
+	}
+	if name[0:1] == "-" {
+		headers.Del(name[1:])
+		return
+	}
+	if name[0:1] == "+" {
+		headers.Add(name[1:], value)
+		return
+	}
+	headers.Set(name, value)
 }
 
 // UpdateRequestHeaders updates r's headers with the provided updates
@@ -234,9 +236,13 @@ func UpdateRequestHeaders(r *http.Request, updates map[string]string) {
 	// promote Host header from r.Header to r.Host if present
 	if hhVal != "" {
 		r.Host = hhVal
-		delete(updates, hhName)
 	}
-	UpdateHeaders(r.Header, updates)
+	for k, v := range updates {
+		if hhVal != "" && k == hhName {
+			continue
+		}
+		updateHeader(r.Header, k, v)
+	}
 }
 
 // ExtractHeader returns the value for the provided header name, and a boolean indicating if the header was present

--- a/pkg/proxy/headers/headers_test.go
+++ b/pkg/proxy/headers/headers_test.go
@@ -74,6 +74,45 @@ func TestUpdateHeaders(t *testing.T) {
 	}
 }
 
+func TestUpdateRequestHeadersPreservesHostUpdate(t *testing.T) {
+	for _, hostHeaderName := range []string{NameHost, "host"} {
+		t.Run(hostHeaderName, func(t *testing.T) {
+			updates := map[string]string{
+				hostHeaderName: "client.example.com",
+				"X-Test":       "value",
+			}
+			expectedUpdates := map[string]string{
+				hostHeaderName: "client.example.com",
+				"X-Test":       "value",
+			}
+
+			for i := 0; i < 2; i++ {
+				r := &http.Request{
+					Header: make(http.Header),
+					Host:   "origin.example.com",
+				}
+
+				UpdateRequestHeaders(r, updates)
+
+				if r.Host != "client.example.com" {
+					t.Errorf("request %d: expected Host %q, got %q", i+1,
+						"client.example.com", r.Host)
+				}
+				if got := r.Header.Get("X-Test"); got != "value" {
+					t.Errorf("request %d: expected X-Test %q, got %q", i+1, "value", got)
+				}
+				if got := r.Header.Get(NameHost); got != "" {
+					t.Errorf("request %d: Host was not promoted from Header: %q", i+1, got)
+				}
+				if !reflect.DeepEqual(updates, expectedUpdates) {
+					t.Fatalf("request %d mutated updates: expected %v, got %v",
+						i+1, expectedUpdates, updates)
+				}
+			}
+		})
+	}
+}
+
 func TestRemoveClientHeaders(t *testing.T) {
 	headers := http.Header{}
 	headers.Set(NameAcceptEncoding, "test")


### PR DESCRIPTION
## Description
This fixes a defect introduced in commit a2a1bc34 where a configured `Host` header in a backend path's `request-headers` block only injects on the first request against the matched path. httpproxy.go L205 sends the path options map to `headers.UpdateRequestHeaders`, and UpdateRequestHeaders was explicitly deleting the host header from the passed headers map post-injection, causing the host header to fail to inject on subsequent requests. This fix removes the errant map delete, moves the header mutation logic into a shared helper function and adds a test to verify proper header mutation.

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [x] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
