### PR TITLE
fix: batch high-cardinality tsm rank merges

### DIFF
--- a/pkg/backends/alb/mech/fanout/fanout.go
+++ b/pkg/backends/alb/mech/fanout/fanout.go
@@ -145,7 +145,7 @@ type Config struct {
 	// OnResult, if non-nil, is called inside the fanout goroutine after
 	// the member's handler returns and before the goroutine exits. Use
 	// this for per-slot side effects that should run in parallel with
-	// other in-flight members (e.g. TSM merges into a shared accumulator).
+	// other in-flight members (e.g. TSM decodes and stores a slot result).
 	// OnResult must be safe for concurrent invocation. The supplied
 	// Result is the same one that will appear in the All return slice.
 	OnResult func(idx int, r *Result)

--- a/pkg/backends/alb/mech/tsm/time_series_merge.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge.go
@@ -402,9 +402,10 @@ type gatherResult struct {
 }
 
 type gatherContribution struct {
-	data      any
-	mergeFunc merge.MergeFunc
-	member    int
+	data           any
+	mergeFunc      merge.MergeFunc
+	batchMergeFunc merge.BatchMergeFunc
+	member         int
 }
 
 // pickWinner chooses which member's RespondFunc and headers feed the outbound
@@ -503,44 +504,52 @@ func prepareGatherContribution(rsc *request.Resources, body []byte, member int,
 	} else {
 		return nil
 	}
-	return &gatherContribution{data: data, mergeFunc: rsc.MergeFunc, member: member}
+	return &gatherContribution{
+		data:           data,
+		mergeFunc:      rsc.MergeFunc,
+		batchMergeFunc: rsc.BatchMergeFunc,
+		member:         member,
+	}
 }
 
-// mergeGatherContributions preserves slot order while batching DataSet
-// contributions into one merge. Other mergeable response types retain their
-// existing MergeFunc behavior and are folded sequentially.
+// mergeGatherContributions preserves slot order and lets the backend-provided
+// batch function handle compatible inputs. Otherwise each contribution is
+// folded through its original MergeFunc.
 func mergeGatherContributions(accumulator *merge.Accumulator,
-	contributions []*gatherContribution, strategy dataset.MergeStrategy,
-	toleranceNanos int64,
+	contributions []*gatherContribution,
 ) []int {
-	datasets := make([]*dataset.DataSet, 0, len(contributions))
-	allDataSets := true
+	items := make([]merge.BatchItem, 0, len(contributions))
+	batchCompatible := true
+	var batchMergeFunc merge.BatchMergeFunc
 	for _, contribution := range contributions {
 		if contribution == nil {
 			continue
 		}
-		ds, ok := contribution.data.(*dataset.DataSet)
-		if !ok {
-			allDataSets = false
-			break
+		items = append(items, merge.BatchItem{
+			Data:   contribution.data,
+			Member: contribution.member,
+		})
+		if contribution.batchMergeFunc == nil {
+			batchCompatible = false
+		} else if batchMergeFunc == nil {
+			batchMergeFunc = contribution.batchMergeFunc
 		}
-		datasets = append(datasets, ds)
 	}
-	if allDataSets && len(datasets) > 0 {
-		if err := mergeDataSetContributions(accumulator, datasets, strategy,
-			toleranceNanos); err != nil {
+	if batchCompatible && batchMergeFunc != nil {
+		handled, err := mergeContributionBatch(accumulator, batchMergeFunc, items)
+		if err != nil {
 			logger.Warn("tsm gather batch merge failure", logging.Pairs{
-				"members": len(datasets), "error": err,
+				"members": len(items), "error": err,
 			})
-			failed := make([]int, 0, len(datasets))
-			for _, contribution := range contributions {
-				if contribution != nil {
-					failed = append(failed, contribution.member)
-				}
+			failed := make([]int, len(items))
+			for i, item := range items {
+				failed[i] = item.Member
 			}
 			return failed
 		}
-		return nil
+		if handled {
+			return nil
+		}
 	}
 
 	failed := make([]int, 0)
@@ -558,36 +567,15 @@ func mergeGatherContributions(accumulator *merge.Accumulator,
 	return failed
 }
 
-func mergeDataSetContributions(accumulator *merge.Accumulator, datasets []*dataset.DataSet,
-	strategy dataset.MergeStrategy, toleranceNanos int64,
-) (err error) {
+func mergeContributionBatch(accumulator *merge.Accumulator,
+	batchMergeFunc merge.BatchMergeFunc, items []merge.BatchItem,
+) (handled bool, err error) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			err = fmt.Errorf("panic while merging datasets: %v", recovered)
+			err = fmt.Errorf("panic while batch merging contributions: %v", recovered)
 		}
 	}()
-
-	base := datasets[0]
-	if len(datasets) > 1 {
-		rest := make([]timeseries.Timeseries, len(datasets)-1)
-		for i := 1; i < len(datasets); i++ {
-			rest[i-1] = datasets[i]
-		}
-		switch {
-		case strategy == dataset.MergeStrategyDedup && toleranceNanos == 0:
-			base.Merge(false, rest...)
-		case strategy == dataset.MergeStrategyAvg:
-			base.MergeWithStrategyTolerant(true, int(dataset.MergeStrategySum),
-				toleranceNanos, rest...)
-		default:
-			base.MergeWithStrategyTolerant(true, int(strategy), toleranceNanos, rest...)
-		}
-	}
-	accumulator.SetTSData(base)
-	if strategy != dataset.MergeStrategyDedup {
-		accumulator.MergeCount = len(datasets)
-	}
-	return nil
+	return batchMergeFunc(accumulator, items)
 }
 
 func mergeContribution(accumulator *merge.Accumulator,
@@ -695,8 +683,7 @@ func (h *handler) serveStandard(
 	for i := range results {
 		contributions[i] = results[i].contrib
 	}
-	for _, member := range mergeGatherContributions(accumulator, contributions,
-		mergeStrategy, dedupToleranceNanos) {
+	for _, member := range mergeGatherContributions(accumulator, contributions) {
 		results[member].failed = true
 	}
 
@@ -1018,12 +1005,10 @@ func (h *handler) serveWeightedAvg(
 	if err := eg.Wait(); err != nil {
 		logger.Warn("tsm avg gather failure", logging.Pairs{"error": err})
 	}
-	for _, member := range mergeGatherContributions(sumAccum, sumContributions,
-		dataset.MergeStrategySum, dedupToleranceNanos) {
+	for _, member := range mergeGatherContributions(sumAccum, sumContributions) {
 		results[member].failed = true
 	}
-	mergeGatherContributions(countAccum, countContributions,
-		dataset.MergeStrategySum, dedupToleranceNanos)
+	mergeGatherContributions(countAccum, countContributions)
 
 	// Finalize: divide sum totals by count totals to obtain the weighted
 	// average. If either side fanned out to zero usable responses the

--- a/pkg/backends/alb/mech/tsm/time_series_merge.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge.go
@@ -397,7 +397,14 @@ type gatherResult struct {
 	statusCode int
 	header     http.Header
 	mergeFunc  merge.RespondFunc
+	contrib    *gatherContribution
 	failed     bool
+}
+
+type gatherContribution struct {
+	data      any
+	mergeFunc merge.MergeFunc
+	member    int
 }
 
 // pickWinner chooses which member's RespondFunc and headers feed the outbound
@@ -465,11 +472,11 @@ func aggregateStatus(results []gatherResult) (status int, statusHeader string, h
 	return
 }
 
-func mergeGatherContribution(accumulator *merge.Accumulator, rsc *request.Resources,
-	body []byte, member int, stripKeys []string,
-) bool {
+func prepareGatherContribution(rsc *request.Resources, body []byte, member int,
+	stripKeys []string,
+) *gatherContribution {
 	if rsc == nil || rsc.MergeFunc == nil {
-		return false
+		return nil
 	}
 	ts := rsc.TS
 	if ts == nil && len(body) > 0 && rsc.TSUnmarshaler != nil && rsc.TimeRangeQuery != nil {
@@ -479,7 +486,7 @@ func mergeGatherContribution(accumulator *merge.Accumulator, rsc *request.Resour
 			logger.Warn("tsm gather timeseries decode failure", logging.Pairs{
 				"member": member, "error": err,
 			})
-			return false
+			return nil
 		}
 		rsc.TS = ts
 	}
@@ -494,15 +501,104 @@ func mergeGatherContribution(accumulator *merge.Accumulator, rsc *request.Resour
 	} else if len(body) > 0 {
 		data = body
 	} else {
-		return false
+		return nil
 	}
-	if err := rsc.MergeFunc(accumulator, data, member); err != nil {
-		logger.Warn("tsm gather merge failure", logging.Pairs{
-			"member": member, "error": err,
-		})
-		return false
+	return &gatherContribution{data: data, mergeFunc: rsc.MergeFunc, member: member}
+}
+
+// mergeGatherContributions preserves slot order while batching DataSet
+// contributions into one merge. Other mergeable response types retain their
+// existing MergeFunc behavior and are folded sequentially.
+func mergeGatherContributions(accumulator *merge.Accumulator,
+	contributions []*gatherContribution, strategy dataset.MergeStrategy,
+	toleranceNanos int64,
+) []int {
+	datasets := make([]*dataset.DataSet, 0, len(contributions))
+	allDataSets := true
+	for _, contribution := range contributions {
+		if contribution == nil {
+			continue
+		}
+		ds, ok := contribution.data.(*dataset.DataSet)
+		if !ok {
+			allDataSets = false
+			break
+		}
+		datasets = append(datasets, ds)
 	}
-	return true
+	if allDataSets && len(datasets) > 0 {
+		if err := mergeDataSetContributions(accumulator, datasets, strategy,
+			toleranceNanos); err != nil {
+			logger.Warn("tsm gather batch merge failure", logging.Pairs{
+				"members": len(datasets), "error": err,
+			})
+			failed := make([]int, 0, len(datasets))
+			for _, contribution := range contributions {
+				if contribution != nil {
+					failed = append(failed, contribution.member)
+				}
+			}
+			return failed
+		}
+		return nil
+	}
+
+	failed := make([]int, 0)
+	for _, contribution := range contributions {
+		if contribution == nil {
+			continue
+		}
+		if err := mergeContribution(accumulator, contribution); err != nil {
+			logger.Warn("tsm gather merge failure", logging.Pairs{
+				"member": contribution.member, "error": err,
+			})
+			failed = append(failed, contribution.member)
+		}
+	}
+	return failed
+}
+
+func mergeDataSetContributions(accumulator *merge.Accumulator, datasets []*dataset.DataSet,
+	strategy dataset.MergeStrategy, toleranceNanos int64,
+) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("panic while merging datasets: %v", recovered)
+		}
+	}()
+
+	base := datasets[0]
+	if len(datasets) > 1 {
+		rest := make([]timeseries.Timeseries, len(datasets)-1)
+		for i := 1; i < len(datasets); i++ {
+			rest[i-1] = datasets[i]
+		}
+		switch {
+		case strategy == dataset.MergeStrategyDedup && toleranceNanos == 0:
+			base.Merge(false, rest...)
+		case strategy == dataset.MergeStrategyAvg:
+			base.MergeWithStrategyTolerant(true, int(dataset.MergeStrategySum),
+				toleranceNanos, rest...)
+		default:
+			base.MergeWithStrategyTolerant(true, int(strategy), toleranceNanos, rest...)
+		}
+	}
+	accumulator.SetTSData(base)
+	if strategy != dataset.MergeStrategyDedup {
+		accumulator.MergeCount = len(datasets)
+	}
+	return nil
+}
+
+func mergeContribution(accumulator *merge.Accumulator,
+	contribution *gatherContribution,
+) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("panic while merging member %d: %v", contribution.member, recovered)
+		}
+	}()
+	return contribution.mergeFunc(accumulator, contribution.data, contribution.member)
 }
 
 // serveStandard handles the common scatter/gather path: each shard gets one
@@ -555,10 +651,10 @@ func (h *handler) serveStandard(
 			if rsc2.MergeFunc == nil || rsc2.MergeRespondFunc == nil {
 				logger.Warn("tsm gather failed due to nil func", nil)
 			}
-			var contributed bool
+			var contribution *gatherContribution
 			if rsc2.MergeFunc != nil {
 				if rsc2.TS != nil {
-					contributed = mergeGatherContribution(accumulator, rsc2, nil, i, stripKeys)
+					contribution = prepareGatherContribution(rsc2, nil, i, stripKeys)
 				} else {
 					body, derr := encoding.DecompressResponseBody(
 						fr.Capture.Header().Get(headers.NameContentEncoding),
@@ -572,7 +668,7 @@ func (h *handler) serveStandard(
 						return
 					}
 					if len(body) > 0 {
-						contributed = mergeGatherContribution(accumulator, rsc2, body, i, stripKeys)
+						contribution = prepareGatherContribution(rsc2, body, i, stripKeys)
 					}
 				}
 			}
@@ -584,7 +680,8 @@ func (h *handler) serveStandard(
 				statusCode: sc,
 				header:     fr.Capture.Header(),
 				mergeFunc:  rsc2.MergeRespondFunc,
-				failed:     !contributed,
+				contrib:    contribution,
+				failed:     contribution == nil,
 			}
 		},
 	})
@@ -593,6 +690,14 @@ func (h *handler) serveStandard(
 		if fr.Failed && !results[i].failed {
 			results[i].failed = true
 		}
+	}
+	contributions := make([]*gatherContribution, l)
+	for i := range results {
+		contributions[i] = results[i].contrib
+	}
+	for _, member := range mergeGatherContributions(accumulator, contributions,
+		mergeStrategy, dedupToleranceNanos) {
+		results[member].failed = true
 	}
 
 	// Surface goroutine-level failures (e.g. unsupported Content-Encoding,
@@ -806,6 +911,8 @@ func (h *handler) serveWeightedAvg(
 	// (status, headers, RespondFunc) comes from the sum side; count results
 	// affect the arithmetic, not the envelope.
 	results := make([]gatherResult, l)
+	sumContributions := make([]*gatherContribution, l)
+	countContributions := make([]*gatherContribution, l)
 
 	dedupToleranceNanos := h.dedupToleranceNanos()
 	resourcesFn := func(int) *request.Resources {
@@ -837,9 +944,9 @@ func (h *handler) serveWeightedAvg(
 					results[i].failed = true
 					return
 				}
-				var contributed bool
+				var contribution *gatherContribution
 				if rsc2.TS != nil {
-					contributed = mergeGatherContribution(sumAccum, rsc2, nil, i, stripKeys)
+					contribution = prepareGatherContribution(rsc2, nil, i, stripKeys)
 				} else if fr.Capture != nil {
 					body, derr := encoding.DecompressResponseBody(
 						fr.Capture.Header().Get(headers.NameContentEncoding),
@@ -852,8 +959,9 @@ func (h *handler) serveWeightedAvg(
 						results[i].failed = true
 						return
 					}
-					contributed = mergeGatherContribution(sumAccum, rsc2, body, i, stripKeys)
+					contribution = prepareGatherContribution(rsc2, body, i, stripKeys)
 				}
+				sumContributions[i] = contribution
 				sc := fr.Capture.StatusCode()
 				if rsc2.Response != nil && rsc2.Response.StatusCode > 0 {
 					sc = rsc2.Response.StatusCode
@@ -862,7 +970,8 @@ func (h *handler) serveWeightedAvg(
 					statusCode: sc,
 					header:     fr.Capture.Header(),
 					mergeFunc:  rsc2.MergeRespondFunc,
-					failed:     !contributed,
+					contrib:    contribution,
+					failed:     contribution == nil,
 				}
 			},
 		})
@@ -888,7 +997,7 @@ func (h *handler) serveWeightedAvg(
 					return
 				}
 				if rsc2.TS != nil {
-					mergeGatherContribution(countAccum, rsc2, nil, i, stripKeys)
+					countContributions[i] = prepareGatherContribution(rsc2, nil, i, stripKeys)
 				} else if fr.Capture != nil {
 					body, derr := encoding.DecompressResponseBody(
 						fr.Capture.Header().Get(headers.NameContentEncoding),
@@ -900,7 +1009,7 @@ func (h *handler) serveWeightedAvg(
 						})
 						return
 					}
-					mergeGatherContribution(countAccum, rsc2, body, i, stripKeys)
+					countContributions[i] = prepareGatherContribution(rsc2, body, i, stripKeys)
 				}
 			},
 		})
@@ -909,6 +1018,12 @@ func (h *handler) serveWeightedAvg(
 	if err := eg.Wait(); err != nil {
 		logger.Warn("tsm avg gather failure", logging.Pairs{"error": err})
 	}
+	for _, member := range mergeGatherContributions(sumAccum, sumContributions,
+		dataset.MergeStrategySum, dedupToleranceNanos) {
+		results[member].failed = true
+	}
+	mergeGatherContributions(countAccum, countContributions,
+		dataset.MergeStrategySum, dedupToleranceNanos)
 
 	// Finalize: divide sum totals by count totals to obtain the weighted
 	// average. If either side fanned out to zero usable responses the

--- a/pkg/backends/alb/mech/tsm/time_series_merge_batch_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_batch_test.go
@@ -49,16 +49,20 @@ func batchContributionDataSet(value int) *dataset.DataSet {
 
 func TestMergeGatherContributionsBatchesDataSets(t *testing.T) {
 	mergeFunc := merge.TimeseriesMergeFuncWithStrategy(nil, int(dataset.MergeStrategySum))
+	batchMergeFunc := merge.TimeseriesBatchMergeFuncWithStrategy(
+		int(dataset.MergeStrategySum))
 	contributions := []*gatherContribution{
-		{data: batchContributionDataSet(1), mergeFunc: mergeFunc, member: 0},
+		{data: batchContributionDataSet(1), mergeFunc: mergeFunc,
+			batchMergeFunc: batchMergeFunc, member: 0},
 		nil,
-		{data: batchContributionDataSet(2), mergeFunc: mergeFunc, member: 2},
-		{data: batchContributionDataSet(3), mergeFunc: mergeFunc, member: 3},
+		{data: batchContributionDataSet(2), mergeFunc: mergeFunc,
+			batchMergeFunc: batchMergeFunc, member: 2},
+		{data: batchContributionDataSet(3), mergeFunc: mergeFunc,
+			batchMergeFunc: batchMergeFunc, member: 3},
 	}
 	accumulator := merge.NewAccumulator()
 
-	if failed := mergeGatherContributions(accumulator, contributions,
-		dataset.MergeStrategySum, 0); len(failed) != 0 {
+	if failed := mergeGatherContributions(accumulator, contributions); len(failed) != 0 {
 		t.Fatalf("unexpected merge failures: %v", failed)
 	}
 
@@ -79,6 +83,18 @@ func TestMergeGatherContributionsBatchesDataSets(t *testing.T) {
 }
 
 func TestMergeGatherContributionsFallbackReportsMember(t *testing.T) {
+	var batchMembers []int
+	batchMergeFunc := func(accumulator *merge.Accumulator,
+		items []merge.BatchItem,
+	) (bool, error) {
+		if accumulator.GetGeneric() != nil {
+			t.Fatal("batch fallback contract requires an untouched accumulator")
+		}
+		for _, item := range items {
+			batchMembers = append(batchMembers, item.Member)
+		}
+		return false, nil
+	}
 	mergeFunc := func(accumulator *merge.Accumulator, _ any, member int) error {
 		if member == 1 {
 			panic("merge panic")
@@ -91,20 +107,50 @@ func TestMergeGatherContributionsFallbackReportsMember(t *testing.T) {
 		return nil
 	}
 	contributions := []*gatherContribution{
-		{data: "first", mergeFunc: mergeFunc, member: 0},
-		{data: "panic", mergeFunc: mergeFunc, member: 1},
-		{data: "bad", mergeFunc: mergeFunc, member: 2},
-		{data: "last", mergeFunc: mergeFunc, member: 3},
+		{data: "first", mergeFunc: mergeFunc, batchMergeFunc: batchMergeFunc, member: 0},
+		{data: "panic", mergeFunc: mergeFunc, batchMergeFunc: batchMergeFunc, member: 1},
+		{data: "bad", mergeFunc: mergeFunc, batchMergeFunc: batchMergeFunc, member: 2},
+		{data: "last", mergeFunc: mergeFunc, batchMergeFunc: batchMergeFunc, member: 3},
 	}
 	accumulator := merge.NewAccumulator()
 
-	failed := mergeGatherContributions(accumulator, contributions,
-		dataset.MergeStrategyDedup, 0)
+	failed := mergeGatherContributions(accumulator, contributions)
+	if !reflect.DeepEqual(batchMembers, []int{0, 1, 2, 3}) {
+		t.Fatalf("batch member order got %v want [0 1 2 3]", batchMembers)
+	}
 	if !reflect.DeepEqual(failed, []int{1, 2}) {
 		t.Fatalf("failed members got %v want [1 2]", failed)
 	}
 	if got := accumulator.GetGeneric(); !reflect.DeepEqual(got, []int{0, 3}) {
 		t.Fatalf("merge order got %v want [0 3]", got)
+	}
+}
+
+func TestMergeGatherContributionsRequiresEveryBatchFunc(t *testing.T) {
+	var batchCalled bool
+	batchMergeFunc := func(*merge.Accumulator, []merge.BatchItem) (bool, error) {
+		batchCalled = true
+		return true, nil
+	}
+	mergeFunc := func(accumulator *merge.Accumulator, _ any, member int) error {
+		members, _ := accumulator.GetGeneric().([]int)
+		accumulator.SetGeneric(append(members, member))
+		return nil
+	}
+	contributions := []*gatherContribution{
+		{data: "first", mergeFunc: mergeFunc, batchMergeFunc: batchMergeFunc, member: 0},
+		{data: "second", mergeFunc: mergeFunc, member: 1},
+	}
+	accumulator := merge.NewAccumulator()
+
+	if failed := mergeGatherContributions(accumulator, contributions); len(failed) != 0 {
+		t.Fatalf("unexpected merge failures: %v", failed)
+	}
+	if batchCalled {
+		t.Fatal("batch merge must require every contribution to opt in")
+	}
+	if got := accumulator.GetGeneric(); !reflect.DeepEqual(got, []int{0, 1}) {
+		t.Fatalf("merge order got %v want [0 1]", got)
 	}
 }
 
@@ -114,14 +160,15 @@ func TestMergeGatherContributionsRecoversBatchPanic(t *testing.T) {
 		panic("dataset merge panic")
 	}
 	mergeFunc := merge.TimeseriesMergeFunc(nil)
+	batchMergeFunc := merge.TimeseriesBatchMergeFunc()
 	contributions := []*gatherContribution{
-		{data: first, mergeFunc: mergeFunc, member: 0},
-		{data: batchContributionDataSet(2), mergeFunc: mergeFunc, member: 1},
+		{data: first, mergeFunc: mergeFunc, batchMergeFunc: batchMergeFunc, member: 0},
+		{data: batchContributionDataSet(2), mergeFunc: mergeFunc,
+			batchMergeFunc: batchMergeFunc, member: 1},
 	}
 	accumulator := merge.NewAccumulator()
 
-	failed := mergeGatherContributions(accumulator, contributions,
-		dataset.MergeStrategyDedup, 0)
+	failed := mergeGatherContributions(accumulator, contributions)
 	if !reflect.DeepEqual(failed, []int{0, 1}) {
 		t.Fatalf("failed members got %v want [0 1]", failed)
 	}

--- a/pkg/backends/alb/mech/tsm/time_series_merge_batch_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_batch_test.go
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tsm
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/epoch"
+)
+
+func batchContributionDataSet(value int) *dataset.DataSet {
+	points := dataset.Points{{Epoch: epoch.Epoch(1), Values: []any{strconv.Itoa(value)}}}
+	return &dataset.DataSet{
+		Results: dataset.Results{{
+			StatementID: 0,
+			SeriesList: dataset.SeriesList{{
+				Header: dataset.SeriesHeader{
+					Name:           "requests",
+					Tags:           dataset.Tags{"service": "api"},
+					QueryStatement: "sum by (service) (requests)",
+				},
+				Points:    points,
+				PointSize: points.Size(),
+			}},
+		}},
+	}
+}
+
+func TestMergeGatherContributionsBatchesDataSets(t *testing.T) {
+	mergeFunc := merge.TimeseriesMergeFuncWithStrategy(nil, int(dataset.MergeStrategySum))
+	contributions := []*gatherContribution{
+		{data: batchContributionDataSet(1), mergeFunc: mergeFunc, member: 0},
+		nil,
+		{data: batchContributionDataSet(2), mergeFunc: mergeFunc, member: 2},
+		{data: batchContributionDataSet(3), mergeFunc: mergeFunc, member: 3},
+	}
+	accumulator := merge.NewAccumulator()
+
+	if failed := mergeGatherContributions(accumulator, contributions,
+		dataset.MergeStrategySum, 0); len(failed) != 0 {
+		t.Fatalf("unexpected merge failures: %v", failed)
+	}
+
+	got, ok := accumulator.GetTSData().(*dataset.DataSet)
+	if !ok || got == nil {
+		t.Fatal("expected a merged dataset")
+	}
+	if accumulator.MergeCount != 3 {
+		t.Fatalf("merge count got %d want 3", accumulator.MergeCount)
+	}
+	if len(got.Results) != 1 || len(got.Results[0].SeriesList) != 1 ||
+		len(got.Results[0].SeriesList[0].Points) != 1 {
+		t.Fatalf("unexpected merged shape: %#v", got.Results)
+	}
+	if value := fmt.Sprint(got.Results[0].SeriesList[0].Points[0].Values[0]); value != "6" {
+		t.Fatalf("merged value got %q want 6", value)
+	}
+}
+
+func TestMergeGatherContributionsFallbackReportsMember(t *testing.T) {
+	mergeFunc := func(accumulator *merge.Accumulator, _ any, member int) error {
+		if member == 1 {
+			panic("merge panic")
+		}
+		if member == 2 {
+			return errors.New("merge failed")
+		}
+		members, _ := accumulator.GetGeneric().([]int)
+		accumulator.SetGeneric(append(members, member))
+		return nil
+	}
+	contributions := []*gatherContribution{
+		{data: "first", mergeFunc: mergeFunc, member: 0},
+		{data: "panic", mergeFunc: mergeFunc, member: 1},
+		{data: "bad", mergeFunc: mergeFunc, member: 2},
+		{data: "last", mergeFunc: mergeFunc, member: 3},
+	}
+	accumulator := merge.NewAccumulator()
+
+	failed := mergeGatherContributions(accumulator, contributions,
+		dataset.MergeStrategyDedup, 0)
+	if !reflect.DeepEqual(failed, []int{1, 2}) {
+		t.Fatalf("failed members got %v want [1 2]", failed)
+	}
+	if got := accumulator.GetGeneric(); !reflect.DeepEqual(got, []int{0, 3}) {
+		t.Fatalf("merge order got %v want [0 3]", got)
+	}
+}
+
+func TestMergeGatherContributionsRecoversBatchPanic(t *testing.T) {
+	first := batchContributionDataSet(1)
+	first.Merger = func(bool, ...timeseries.Timeseries) {
+		panic("dataset merge panic")
+	}
+	mergeFunc := merge.TimeseriesMergeFunc(nil)
+	contributions := []*gatherContribution{
+		{data: first, mergeFunc: mergeFunc, member: 0},
+		{data: batchContributionDataSet(2), mergeFunc: mergeFunc, member: 1},
+	}
+	accumulator := merge.NewAccumulator()
+
+	failed := mergeGatherContributions(accumulator, contributions,
+		dataset.MergeStrategyDedup, 0)
+	if !reflect.DeepEqual(failed, []int{0, 1}) {
+		t.Fatalf("failed members got %v want [0 1]", failed)
+	}
+	if accumulator.GetTSData() != nil {
+		t.Fatal("panicked batch must not publish a partial accumulator")
+	}
+}

--- a/pkg/backends/alb/mech/tsm/time_series_merge_body_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_body_test.go
@@ -34,7 +34,10 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
 )
 
-var mergeFn = merge.TimeseriesMergeFunc(nil)
+var (
+	mergeFn      = merge.TimeseriesMergeFunc(nil)
+	batchMergeFn = merge.TimeseriesBatchMergeFunc()
+)
 
 func stubMergeHandler(marker string, status int) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -42,6 +45,7 @@ func stubMergeHandler(marker string, status int) http.Handler {
 		if rsc != nil {
 			rsc.TS = newMarkerDataSet(marker)
 			rsc.MergeFunc = mergeFn
+			rsc.BatchMergeFunc = batchMergeFn
 			rsc.MergeRespondFunc = markerRespondFunc
 		}
 		w.Header().Set(headers.NameTricksterResult, "engine=none")
@@ -200,6 +204,7 @@ func TestTSMMergeProxyOnlyBodyUsesTimeRangeQuery(t *testing.T) {
 				rsc.TimeRangeQuery = trq.Clone()
 				rsc.TSUnmarshaler = m.WireUnmarshaler
 				rsc.MergeFunc = merge.TimeseriesMergeFunc(m.WireUnmarshaler)
+				rsc.BatchMergeFunc = merge.TimeseriesBatchMergeFunc()
 				rsc.MergeRespondFunc = merge.TimeseriesRespondFunc(m.WireMarshalWriter, &timeseries.RequestOptions{})
 			}
 			w.Header().Set(headers.NameContentType, "application/json")

--- a/pkg/backends/alb/mech/tsm/time_series_merge_dedup_tolerance_chain_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_dedup_tolerance_chain_test.go
@@ -50,6 +50,8 @@ func tolerantStubHandler(epochNs int64, value, marker string) http.Handler {
 				}},
 			}
 			rsc.MergeFunc = merge.TimeseriesMergeFuncTolerant(nil, rsc.TSDedupToleranceNanos)
+			rsc.BatchMergeFunc = merge.TimeseriesBatchMergeFuncTolerant(
+				rsc.TSDedupToleranceNanos)
 			rsc.MergeRespondFunc = tolerantRespondFunc(marker)
 		}
 		w.Header().Set(headers.NameTricksterResult, "engine=none")

--- a/pkg/backends/alb/mech/tsm/time_series_merge_serve_weighted_avg_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_serve_weighted_avg_test.go
@@ -184,6 +184,8 @@ func weightedAvgMemberHandler(spec weightedAvgMemberSpec) http.Handler {
 		if rsc != nil {
 			rsc.TS = weightedAvgDataSet(val)
 			rsc.MergeFunc = merge.TimeseriesMergeFuncWithStrategy(nil, rsc.TSMergeStrategy)
+			rsc.BatchMergeFunc = merge.TimeseriesBatchMergeFuncWithStrategy(
+				rsc.TSMergeStrategy)
 			rsc.MergeRespondFunc = weightedAvgRespondFunc
 		}
 		w.Header().Set(headers.NameTricksterResult, "engine=none")
@@ -209,6 +211,8 @@ func weightedAvgEmptySideHandler(failCount bool) http.Handler {
 			}
 			rsc.TS = weightedAvgDataSet(val)
 			rsc.MergeFunc = merge.TimeseriesMergeFuncWithStrategy(nil, rsc.TSMergeStrategy)
+			rsc.BatchMergeFunc = merge.TimeseriesBatchMergeFuncWithStrategy(
+				rsc.TSMergeStrategy)
 		}
 		w.WriteHeader(http.StatusOK)
 	})

--- a/pkg/backends/prometheus/handler_query.go
+++ b/pkg/backends/prometheus/handler_query.go
@@ -65,11 +65,14 @@ func (c *Client) QueryHandler(w http.ResponseWriter, r *http.Request) {
 					if rsc.TSMergeStrategy != 0 {
 						rsc.MergeFunc = merge.TimeseriesMergeFuncWithStrategyTolerant(
 							m.WireUnmarshaler, rsc.TSMergeStrategy, rsc.TSDedupToleranceNanos)
+						rsc.BatchMergeFunc = merge.TimeseriesBatchMergeFuncWithStrategyTolerant(
+							rsc.TSMergeStrategy, rsc.TSDedupToleranceNanos)
 						// Instant queries marshal as vector, not matrix
 						// (WireMarshalWriter always emits matrix shape).
 						rsc.MergeRespondFunc = merge.TimeseriesRespondFuncWithStrategy(vectorInstantMarshalWriter, nil, rsc.TSMergeStrategy)
 					} else {
 						rsc.MergeFunc = model.MergeAndWriteVectorMergeFunc(m.WireUnmarshaler)
+						rsc.BatchMergeFunc = merge.TimeseriesBatchMergeFunc()
 						rsc.MergeRespondFunc = model.MergeAndWriteVectorRespondFunc(m.WireMarshalWriter)
 					}
 				}

--- a/pkg/backends/prometheus/handler_query_range.go
+++ b/pkg/backends/prometheus/handler_query_range.go
@@ -40,9 +40,13 @@ func (c *Client) QueryRangeHandler(w http.ResponseWriter, r *http.Request) {
 				if rsc.TSMergeStrategy != 0 {
 					rsc.MergeFunc = merge.TimeseriesMergeFuncWithStrategyTolerant(
 						m.WireUnmarshaler, rsc.TSMergeStrategy, rsc.TSDedupToleranceNanos)
+					rsc.BatchMergeFunc = merge.TimeseriesBatchMergeFuncWithStrategyTolerant(
+						rsc.TSMergeStrategy, rsc.TSDedupToleranceNanos)
 					rsc.MergeRespondFunc = merge.TimeseriesRespondFuncWithStrategy(m.WireMarshalWriter, rsc.TSReqestOptions, rsc.TSMergeStrategy)
 				} else {
 					rsc.MergeFunc = merge.TimeseriesMergeFuncTolerant(m.WireUnmarshaler, rsc.TSDedupToleranceNanos)
+					rsc.BatchMergeFunc = merge.TimeseriesBatchMergeFuncTolerant(
+						rsc.TSDedupToleranceNanos)
 					rsc.MergeRespondFunc = merge.TimeseriesRespondFunc(m.WireMarshalWriter, rsc.TSReqestOptions)
 				}
 			}

--- a/pkg/backends/prometheus/handler_query_range_test.go
+++ b/pkg/backends/prometheus/handler_query_range_test.go
@@ -48,6 +48,9 @@ func TestQueryRangeHandler(t *testing.T) {
 	rsc.IsMergeMember = true
 
 	client.QueryRangeHandler(w, r)
+	if rsc.BatchMergeFunc == nil {
+		t.Error("expected query range merge member to configure BatchMergeFunc")
+	}
 
 	resp := w.Result()
 

--- a/pkg/backends/prometheus/handler_query_test.go
+++ b/pkg/backends/prometheus/handler_query_test.go
@@ -89,6 +89,9 @@ func TestQueryHandler(t *testing.T) {
 
 	w = httptest.NewRecorder()
 	client.QueryHandler(w, r)
+	if rsc.BatchMergeFunc == nil {
+		t.Error("expected instant query merge member to configure BatchMergeFunc")
+	}
 
 	resp = w.Result()
 

--- a/pkg/backends/prometheus/tsm_rank_finalize.go
+++ b/pkg/backends/prometheus/tsm_rank_finalize.go
@@ -17,6 +17,8 @@
 package prometheus
 
 import (
+	"cmp"
+	"container/heap"
 	"math"
 	"slices"
 	"strconv"
@@ -41,7 +43,75 @@ type rankCandidate struct {
 	series   *dataset.Series
 	pointIdx int
 	value    float64
-	tagsJSON string
+	order    int
+}
+
+type rankCandidateHeap struct {
+	items    []rankCandidate
+	operator string
+	tagsJSON map[*dataset.Series]string
+}
+
+func (h *rankCandidateHeap) Len() int { return len(h.items) }
+
+// Less keeps the worst selected candidate at the root so a better incoming
+// candidate can replace it in O(log k).
+func (h *rankCandidateHeap) Less(i, j int) bool {
+	return h.compare(h.items[i], h.items[j]) > 0
+}
+
+func (h *rankCandidateHeap) Swap(i, j int) {
+	h.items[i], h.items[j] = h.items[j], h.items[i]
+}
+
+func (h *rankCandidateHeap) Push(value any) {
+	h.items = append(h.items, value.(rankCandidate))
+}
+
+func (h *rankCandidateHeap) Pop() any {
+	last := len(h.items) - 1
+	value := h.items[last]
+	h.items = h.items[:last]
+	return value
+}
+
+func (h *rankCandidateHeap) consider(candidate rankCandidate, limit int) {
+	if limit <= 0 {
+		return
+	}
+	if len(h.items) < limit {
+		heap.Push(h, candidate)
+		return
+	}
+	if h.compare(candidate, h.items[0]) < 0 {
+		h.items[0] = candidate
+		heap.Fix(h, 0)
+	}
+}
+
+func (h *rankCandidateHeap) compare(a, b rankCandidate) int {
+	if c := compareRankCandidateValues(a, b, h.operator); c != 0 {
+		return c
+	}
+	if c := strings.Compare(h.tags(a), h.tags(b)); c != 0 {
+		return c
+	}
+	return cmp.Compare(a.order, b.order)
+}
+
+func (h *rankCandidateHeap) tags(candidate rankCandidate) string {
+	if candidate.series == nil {
+		return ""
+	}
+	if tags, ok := h.tagsJSON[candidate.series]; ok {
+		return tags
+	}
+	if h.tagsJSON == nil {
+		h.tagsJSON = make(map[*dataset.Series]string)
+	}
+	tags := candidate.series.Header.Tags.JSON()
+	h.tagsJSON[candidate.series] = tags
+	return tags
 }
 
 // FinalizeTSMMerge applies Prometheus-only merge finalization after TSM fanout
@@ -67,33 +137,37 @@ func finalizeRankAggregation(ds *dataset.DataSet, spec promql.RankAggregation) {
 		if result == nil || len(result.SeriesList) == 0 {
 			continue
 		}
-		buckets := make(map[rankBucketKey][]rankCandidate)
+		buckets := make(map[rankBucketKey]*rankCandidateHeap)
+		var order int
 		for _, series := range result.SeriesList {
 			if series == nil {
 				continue
 			}
 			group := rankGroupKey(series.Header.Tags, spec.Grouping)
-			tagsJSON := series.Header.Tags.JSON()
 			for i, point := range series.Points {
 				value, ok := rankPointValue(point)
 				if !ok {
 					continue
 				}
 				key := rankBucketKey{epoch: int64(point.Epoch), group: group}
-				buckets[key] = append(buckets[key], rankCandidate{
+				bucket := buckets[key]
+				if bucket == nil {
+					bucket = &rankCandidateHeap{operator: spec.Operator}
+					buckets[key] = bucket
+				}
+				bucket.consider(rankCandidate{
 					series:   series,
 					pointIdx: i,
 					value:    value,
-					tagsJSON: tagsJSON,
-				})
+					order:    order,
+				}, spec.K)
+				order++
 			}
 		}
 
 		selected := make(map[*dataset.Series]map[int]struct{})
 		for _, candidates := range buckets {
-			sortRankCandidates(candidates, spec.Operator)
-			limit := min(spec.K, len(candidates))
-			for _, candidate := range candidates[:limit] {
+			for _, candidate := range candidates.items {
 				if selected[candidate.series] == nil {
 					selected[candidate.series] = make(map[int]struct{})
 				}
@@ -120,16 +194,14 @@ func rankPointValue(point dataset.Point) (float64, bool) {
 	return f, true
 }
 
-func sortRankCandidates(candidates []rankCandidate, operator string) {
-	slices.SortStableFunc(candidates, func(a, b rankCandidate) int {
-		if rankValueLess(a.value, b.value, operator) {
-			return -1
-		}
-		if rankValueLess(b.value, a.value, operator) {
-			return 1
-		}
-		return strings.Compare(a.tagsJSON, b.tagsJSON)
-	})
+func compareRankCandidateValues(a, b rankCandidate, operator string) int {
+	if rankValueLess(a.value, b.value, operator) {
+		return -1
+	}
+	if rankValueLess(b.value, a.value, operator) {
+		return 1
+	}
+	return 0
 }
 
 func rankValueLess(a, b float64, operator string) bool {

--- a/pkg/backends/prometheus/tsm_rank_finalize_test.go
+++ b/pkg/backends/prometheus/tsm_rank_finalize_test.go
@@ -17,6 +17,12 @@
 package prometheus
 
 import (
+	"cmp"
+	"math"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
@@ -113,6 +119,61 @@ func TestFinalizeTSMMergeRankAggregation(t *testing.T) {
 	})
 }
 
+func TestRankCandidateHeapMatchesFullSort(t *testing.T) {
+	values := []float64{4, 1, math.NaN(), 9, 9, -2, math.Inf(1), math.Inf(-1), 4, 7}
+	candidates := make([]rankCandidate, len(values))
+	for i, value := range values {
+		candidates[i] = rankCandidate{
+			series: &dataset.Series{Header: dataset.SeriesHeader{Tags: dataset.Tags{
+				"rank": []string{"c", "a", "nan", "b", "a", "z", "inf", "ninf", "c", "d"}[i],
+			}}},
+			value: value,
+			order: i,
+		}
+	}
+
+	for _, operator := range []string{rankOperatorTopK, rankOperatorBottomK} {
+		for _, limit := range []int{0, 1, 3, len(candidates), len(candidates) + 2} {
+			name := operator + "/" + strconv.Itoa(limit)
+			t.Run(name, func(t *testing.T) {
+				wantCandidates := append([]rankCandidate(nil), candidates...)
+				sortRankCandidatesReference(wantCandidates, operator)
+				wantCandidates = wantCandidates[:min(limit, len(wantCandidates))]
+
+				h := &rankCandidateHeap{operator: operator}
+				for _, candidate := range candidates {
+					h.consider(candidate, limit)
+				}
+				gotCandidates := append([]rankCandidate(nil), h.items...)
+				sortRankCandidatesReference(gotCandidates, operator)
+
+				orders := func(input []rankCandidate) []int {
+					out := make([]int, len(input))
+					for i := range input {
+						out[i] = input[i].order
+					}
+					return out
+				}
+				if got, want := orders(gotCandidates), orders(wantCandidates); !reflect.DeepEqual(got, want) {
+					t.Fatalf("selected orders got %v want %v", got, want)
+				}
+			})
+		}
+	}
+}
+
+func sortRankCandidatesReference(candidates []rankCandidate, operator string) {
+	slices.SortStableFunc(candidates, func(a, b rankCandidate) int {
+		if c := compareRankCandidateValues(a, b, operator); c != 0 {
+			return c
+		}
+		if c := strings.Compare(a.series.Header.Tags.JSON(), b.series.Header.Tags.JSON()); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.order, b.order)
+	})
+}
+
 func rankDataSet(series ...*dataset.Series) *dataset.DataSet {
 	return &dataset.DataSet{
 		Results: dataset.Results{{
@@ -194,4 +255,18 @@ func equalStringSlicesByKey(a, b map[string][]string) bool {
 		}
 	}
 	return true
+}
+
+func BenchmarkFinalizeTSMMergeTopK(b *testing.B) {
+	for range b.N {
+		b.StopTimer()
+		series := make([]*dataset.Series, 64_000)
+		for i := range series {
+			name := strconv.Itoa(i)
+			series[i] = rankSeries(name, strconv.Itoa(i), 100)
+		}
+		ds := rankDataSet(series...)
+		b.StartTimer()
+		(&Client{}).FinalizeTSMMerge("sort_desc(topk(20, up))", ds)
+	}
 }

--- a/pkg/backends/prometheus/tsm_rank_finalize_test.go
+++ b/pkg/backends/prometheus/tsm_rank_finalize_test.go
@@ -258,7 +258,7 @@ func equalStringSlicesByKey(a, b map[string][]string) bool {
 }
 
 func BenchmarkFinalizeTSMMergeTopK(b *testing.B) {
-	for range b.N {
+	for b.Loop() {
 		b.StopTimer()
 		series := make([]*dataset.Series, 64_000)
 		for i := range series {

--- a/pkg/proxy/request/resources.go
+++ b/pkg/proxy/request/resources.go
@@ -49,6 +49,7 @@ type Resources struct {
 	IsMergeMember     bool
 	RequestBody       []byte
 	MergeFunc         merge.MergeFunc
+	BatchMergeFunc    merge.BatchMergeFunc
 	MergeRespondFunc  merge.RespondFunc
 	TSUnmarshaler     timeseries.UnmarshalerFunc
 	TSMarshaler       timeseries.MarshalWriterFunc
@@ -81,6 +82,7 @@ func (r *Resources) Clone() *Resources {
 		IsMergeMember:         r.IsMergeMember,
 		RequestBody:           slices.Clone(r.RequestBody),
 		MergeFunc:             r.MergeFunc,
+		BatchMergeFunc:        r.BatchMergeFunc,
 		MergeRespondFunc:      r.MergeRespondFunc,
 		TSUnmarshaler:         r.TSUnmarshaler,
 		TSMarshaler:           r.TSMarshaler,
@@ -157,6 +159,7 @@ func (r *Resources) Merge(r2 *Resources) {
 	r.IsMergeMember = r.IsMergeMember || r2.IsMergeMember
 	r.AlreadyEncoded = r.AlreadyEncoded || r2.AlreadyEncoded
 	r.MergeFunc = r2.MergeFunc
+	r.BatchMergeFunc = r2.BatchMergeFunc
 	r.MergeRespondFunc = r2.MergeRespondFunc
 	r.Cancelable = r.Cancelable || r2.Cancelable
 }

--- a/pkg/proxy/request/resources_test.go
+++ b/pkg/proxy/request/resources_test.go
@@ -28,15 +28,22 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/level"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	tc "github.com/trickstercache/trickster/v2/pkg/proxy/context"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
 )
 
 func TestNewAndCloneResources(t *testing.T) {
 	logger.SetLogger(logging.ConsoleLogger(level.Error))
 	r := NewResources(nil, nil, nil, nil, nil, nil)
 	r.AlternateCacheTTL = time.Duration(1) * time.Second
+	r.BatchMergeFunc = func(*merge.Accumulator, []merge.BatchItem) (bool, error) {
+		return true, nil
+	}
 	r2 := r.Clone()
 	if r2.AlternateCacheTTL != r.AlternateCacheTTL {
 		t.Errorf("expected %s got %s", r.AlternateCacheTTL.String(), r2.AlternateCacheTTL.String())
+	}
+	if r2.BatchMergeFunc == nil {
+		t.Error("expected clone to preserve BatchMergeFunc")
 	}
 }
 
@@ -194,8 +201,14 @@ func TestMergeResources(t *testing.T) {
 		t.Errorf("nil merge shouldn't set anything in subject resources")
 	}
 	r2 := NewResources(nil, nil, nil, nil, nil, nil)
+	r2.BatchMergeFunc = func(*merge.Accumulator, []merge.BatchItem) (bool, error) {
+		return true, nil
+	}
 	r1.Merge(r2)
 	if r1.AlternateCacheTTL != 0 {
 		t.Errorf("merge should override subject resources")
+	}
+	if r1.BatchMergeFunc == nil {
+		t.Error("merge should propagate BatchMergeFunc")
 	}
 }

--- a/pkg/proxy/response/merge/merge.go
+++ b/pkg/proxy/response/merge/merge.go
@@ -29,6 +29,17 @@ import (
 // conforming to Mergeable[T]), and index, and returns an error
 type MergeFunc func(*Accumulator, any, int) error
 
+// BatchItem is one slot-ordered contribution to a batch merge.
+type BatchItem struct {
+	Data   any
+	Member int
+}
+
+// BatchMergeFunc attempts to merge several contributions in one operation.
+// When handled is false, the accumulator must remain unchanged so callers can
+// safely fall back to the corresponding MergeFunc for each item.
+type BatchMergeFunc func(*Accumulator, []BatchItem) (handled bool, err error)
+
 // RespondFunc is a function type that writes the merged result to the response writer
 // It takes the response writer, request, accumulator, and status code
 type RespondFunc func(http.ResponseWriter, *http.Request, *Accumulator, int)

--- a/pkg/proxy/response/merge/timeseries.go
+++ b/pkg/proxy/response/merge/timeseries.go
@@ -66,6 +66,48 @@ func TimeseriesMergeFuncTolerant(unmarshaler timeseries.UnmarshalerFunc, toleran
 	}
 }
 
+// TimeseriesBatchMergeFunc creates a BatchMergeFunc for decoded timeseries
+// data. Inputs that still require unmarshaling are left to the sequential
+// MergeFunc fallback.
+func TimeseriesBatchMergeFunc() BatchMergeFunc {
+	return TimeseriesBatchMergeFuncTolerant(0)
+}
+
+// TimeseriesBatchMergeFuncTolerant is TimeseriesBatchMergeFunc with an opt-in
+// dedup tolerance window.
+func TimeseriesBatchMergeFuncTolerant(toleranceNanos int64) BatchMergeFunc {
+	return func(accum *Accumulator, items []BatchItem) (bool, error) {
+		collection, ok := batchTimeseries(items)
+		if !ok {
+			return false, nil
+		}
+
+		accum.mu.Lock()
+		defer accum.mu.Unlock()
+		base := accum.tsdata
+		start := 0
+		if base == nil {
+			base = collection[0]
+			start = 1
+		}
+		if start < len(collection) {
+			rest := collection[start:]
+			if toleranceNanos > 0 {
+				if om, ok := base.(optsMerger); ok {
+					// strategy=0 == dataset.MergeStrategyDedup
+					om.MergeWithStrategyTolerant(true, 0, toleranceNanos, rest...)
+				} else {
+					base.Merge(false, rest...)
+				}
+			} else {
+				base.Merge(false, rest...)
+			}
+		}
+		accum.tsdata = base
+		return true, nil
+	}
+}
+
 // strategyMerger is implemented by types that support strategy-aware merging
 // (e.g., *dataset.DataSet). Using an interface avoids importing the dataset
 // package, which would create an import cycle.
@@ -147,6 +189,76 @@ func TimeseriesMergeFuncWithStrategyTolerant(unmarshaler timeseries.UnmarshalerF
 		}
 		return nil
 	}
+}
+
+// TimeseriesBatchMergeFuncWithStrategy creates a strategy-aware BatchMergeFunc
+// for decoded timeseries data.
+func TimeseriesBatchMergeFuncWithStrategy(strategy int) BatchMergeFunc {
+	return TimeseriesBatchMergeFuncWithStrategyTolerant(strategy, 0)
+}
+
+// TimeseriesBatchMergeFuncWithStrategyTolerant batches the same strategy and
+// tolerance semantics as TimeseriesMergeFuncWithStrategyTolerant.
+func TimeseriesBatchMergeFuncWithStrategyTolerant(strategy int,
+	toleranceNanos int64,
+) BatchMergeFunc {
+	pairwiseStrategy := strategy
+	if strategy == mergeStrategyAvg {
+		pairwiseStrategy = mergeStrategySum
+	}
+	return func(accum *Accumulator, items []BatchItem) (bool, error) {
+		collection, ok := batchTimeseries(items)
+		if !ok {
+			return false, nil
+		}
+
+		accum.mu.Lock()
+		defer accum.mu.Unlock()
+		base := accum.tsdata
+		mergeCount := accum.MergeCount
+		start := 0
+		if base == nil {
+			base = collection[0]
+			mergeCount = 1
+			start = 1
+		}
+		if start < len(collection) {
+			rest := collection[start:]
+			if toleranceNanos > 0 {
+				if om, ok := base.(optsMerger); ok {
+					om.MergeWithStrategyTolerant(true, pairwiseStrategy,
+						toleranceNanos, rest...)
+				} else if sm, ok := base.(strategyMerger); ok {
+					sm.MergeWithStrategy(true, pairwiseStrategy, rest...)
+				} else {
+					base.Merge(false, rest...)
+				}
+			} else if sm, ok := base.(strategyMerger); ok {
+				sm.MergeWithStrategy(true, pairwiseStrategy, rest...)
+			} else {
+				base.Merge(false, rest...)
+			}
+			mergeCount += len(rest)
+		}
+		accum.tsdata = base
+		accum.MergeCount = mergeCount
+		return true, nil
+	}
+}
+
+func batchTimeseries(items []BatchItem) ([]timeseries.Timeseries, bool) {
+	if len(items) == 0 {
+		return nil, false
+	}
+	collection := make([]timeseries.Timeseries, len(items))
+	for i, item := range items {
+		ts, ok := item.Data.(timeseries.Timeseries)
+		if !ok || ts == nil {
+			return nil, false
+		}
+		collection[i] = ts
+	}
+	return collection, true
 }
 
 // TimeseriesMergeFuncFromBytes creates a MergeFunc that accepts []byte and unmarshals it

--- a/pkg/proxy/response/merge/timeseries_tolerant_test.go
+++ b/pkg/proxy/response/merge/timeseries_tolerant_test.go
@@ -185,3 +185,50 @@ func TestTimeseriesMergeFuncWithStrategyTolerant(t *testing.T) {
 		require.NotNil(t, accum.GetTSData())
 	})
 }
+
+func TestTimeseriesBatchMergeFuncTolerant(t *testing.T) {
+	t.Run("batches decoded timeseries with tolerance", func(t *testing.T) {
+		accum := NewAccumulator()
+		items := []BatchItem{
+			{Data: makeTestDataSet(0, "up", nil, []int64{1000}, []string{"1"}), Member: 0},
+			{Data: makeTestDataSet(0, "up", nil, []int64{1003}, []string{"2"}), Member: 1},
+		}
+
+		handled, err := TimeseriesBatchMergeFuncTolerant(5)(accum, items)
+		require.NoError(t, err)
+		require.True(t, handled)
+		ds, ok := accum.GetTSData().(*dataset.DataSet)
+		require.True(t, ok)
+		require.Len(t, ds.Results[0].SeriesList[0].Points, 1)
+	})
+
+	t.Run("incompatible input leaves accumulator untouched", func(t *testing.T) {
+		accum := NewAccumulator()
+		seed := makeTestDataSet(0, "up", nil, []int64{1000}, []string{"1"})
+		accum.SetTSData(seed)
+
+		handled, err := TimeseriesBatchMergeFunc()(accum, []BatchItem{{Data: []byte("wire")}})
+		require.NoError(t, err)
+		require.False(t, handled)
+		require.Same(t, seed, accum.GetTSData())
+		require.Len(t, seed.Results[0].SeriesList[0].Points, 1)
+	})
+}
+
+func TestTimeseriesBatchMergeFuncWithStrategyTolerant(t *testing.T) {
+	accum := NewAccumulator()
+	items := []BatchItem{
+		{Data: makeTestDataSet(0, "latency", nil, []int64{100}, []string{"10"}), Member: 0},
+		{Data: makeTestDataSet(0, "latency", nil, []int64{100}, []string{"30"}), Member: 1},
+		{Data: makeTestDataSet(0, "latency", nil, []int64{100}, []string{"20"}), Member: 2},
+	}
+
+	handled, err := TimeseriesBatchMergeFuncWithStrategyTolerant(
+		int(dataset.MergeStrategyAvg), 0)(accum, items)
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, 3, accum.MergeCount)
+	ds, ok := accum.GetTSData().(*dataset.DataSet)
+	require.True(t, ok)
+	require.Equal(t, "60", ds.Results[0].SeriesList[0].Points[0].Values[0])
+}

--- a/pkg/timeseries/dataset/dataset.go
+++ b/pkg/timeseries/dataset/dataset.go
@@ -230,61 +230,7 @@ func (ds *DataSet) Merge(sortPoints bool, collection ...timeseries.Timeseries) {
 func (ds *DataSet) DefaultMerger(sortPoints bool, collection ...timeseries.Timeseries) {
 	ds.UpdateLock.Lock()
 	defer ds.UpdateLock.Unlock()
-
-	rl := make(ResultsLookup)
-	for _, r := range ds.Results {
-		if r == nil {
-			continue
-		}
-		rl[r.StatementID] = r
-	}
-	dl := make(DataSets, 0, 32)
-	k := len(ds.Results)
-	rlen := k
-	for _, ts := range collection {
-		if ts == nil {
-			continue
-		}
-		ds2, ok := ts.(*DataSet)
-		if !ok || ds2 == nil {
-			continue
-		}
-		dl = append(dl, ds2)
-		rlen += len(ds2.Results)
-	}
-	rs := make(Results, rlen)
-	copy(rs, ds.Results)
-	for _, ds2 := range dl {
-		ds.ExtentList = ds.ExtentList.Merge(ds2.ExtentList, ds.Step())
-		// Preserve per-shard Warnings: operators expect to see every warning
-		// emitted by any backend (e.g. Prometheus partial-result warnings).
-		if len(ds2.Warnings) > 0 {
-			ds.Warnings = append(ds.Warnings, ds2.Warnings...)
-		}
-		// Status priority mirrors prometheus model.Envelope.Merge: success wins
-		// over error (error text is already surfaced via Warnings on upgrade).
-		if ds.Status == "" || (ds.Status != "success" && ds2.Status == "success") {
-			ds.Status = ds2.Status
-		}
-		for _, r2 := range ds2.Results {
-			if r2 == nil || len(r2.SeriesList) == 0 {
-				continue
-			}
-			r1, ok := rl[r2.StatementID]
-			if !ok {
-				rl[r2.StatementID] = r2
-				rs[k] = r2
-				k++
-				continue
-			}
-			if len(r1.SeriesList) == 0 {
-				r1.SeriesList = r2.SeriesList.Clone()
-				continue
-			}
-			r1.SeriesList = r1.SeriesList.Merge(r2.SeriesList, sortPoints)
-		}
-	}
-	ds.Results = rs[:k]
+	ds.mergeDataSets(collection, MergeOpts{SortPoints: sortPoints}, true)
 }
 
 // MergeWithStrategy merges the provided Timeseries list into the base DataSet
@@ -318,7 +264,20 @@ func (ds *DataSet) MergeWithOpts(opts MergeOpts, collection ...timeseries.Timese
 	}
 	ds.UpdateLock.Lock()
 	defer ds.UpdateLock.Unlock()
+	ds.mergeDataSets(collection, opts, false)
+}
 
+type resultMergeGroup struct {
+	result *Result
+	lists  []SeriesList
+}
+
+// mergeDataSets merges all member datasets in one pass. The caller must hold
+// ds.UpdateLock. mergeEnvelope preserves DefaultMerger's warning and status
+// handling; strategy merges retain their existing data-only behavior.
+func (ds *DataSet) mergeDataSets(collection []timeseries.Timeseries, opts MergeOpts,
+	mergeEnvelope bool,
+) {
 	rl := make(ResultsLookup)
 	for _, r := range ds.Results {
 		if r == nil {
@@ -342,8 +301,22 @@ func (ds *DataSet) MergeWithOpts(opts MergeOpts, collection ...timeseries.Timese
 	}
 	rs := make(Results, rlen)
 	copy(rs, ds.Results)
+	groups := make([]resultMergeGroup, 0)
+	groupIndex := make(map[*Result]int)
 	for _, ds2 := range dl {
 		ds.ExtentList = ds.ExtentList.Merge(ds2.ExtentList, ds.Step())
+		if mergeEnvelope {
+			// Preserve per-shard Warnings: operators expect to see every warning
+			// emitted by any backend (e.g. Prometheus partial-result warnings).
+			if len(ds2.Warnings) > 0 {
+				ds.Warnings = append(ds.Warnings, ds2.Warnings...)
+			}
+			// Status priority mirrors prometheus model.Envelope.Merge: success wins
+			// over error (error text is already surfaced via Warnings on upgrade).
+			if ds.Status == "" || (ds.Status != "success" && ds2.Status == "success") {
+				ds.Status = ds2.Status
+			}
+		}
 		for _, r2 := range ds2.Results {
 			if r2 == nil || len(r2.SeriesList) == 0 {
 				continue
@@ -355,12 +328,17 @@ func (ds *DataSet) MergeWithOpts(opts MergeOpts, collection ...timeseries.Timese
 				k++
 				continue
 			}
-			if len(r1.SeriesList) == 0 {
-				r1.SeriesList = r2.SeriesList.Clone()
-				continue
+			gi, ok := groupIndex[r1]
+			if !ok {
+				gi = len(groups)
+				groupIndex[r1] = gi
+				groups = append(groups, resultMergeGroup{result: r1})
 			}
-			r1.SeriesList = r1.SeriesList.MergeWithOpts(r2.SeriesList, opts)
+			groups[gi].lists = append(groups[gi].lists, r2.SeriesList)
 		}
+	}
+	for _, group := range groups {
+		group.result.SeriesList = group.result.SeriesList.mergeCollection(group.lists, opts)
 	}
 	ds.Results = rs[:k]
 }

--- a/pkg/timeseries/dataset/dataset_batch_merge_test.go
+++ b/pkg/timeseries/dataset/dataset_batch_merge_test.go
@@ -192,7 +192,7 @@ func BenchmarkFanoutDataSetMerge(b *testing.B) {
 			name = "overlap"
 		}
 		b.Run(name+"/sequential", func(b *testing.B) {
-			for range b.N {
+			for b.Loop() {
 				b.StopTimer()
 				inputs := benchmarkMergeFixture(64, 1000, overlap)
 				b.StartTimer()
@@ -202,7 +202,7 @@ func BenchmarkFanoutDataSetMerge(b *testing.B) {
 			}
 		})
 		b.Run(name+"/batch", func(b *testing.B) {
-			for range b.N {
+			for b.Loop() {
 				b.StopTimer()
 				inputs := benchmarkMergeFixture(64, 1000, overlap)
 				collection := make([]timeseries.Timeseries, len(inputs)-1)

--- a/pkg/timeseries/dataset/dataset_batch_merge_test.go
+++ b/pkg/timeseries/dataset/dataset_batch_merge_test.go
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataset
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/epoch"
+)
+
+func batchMergeSeries(name, host string, values ...string) *Series {
+	points := make(Points, len(values))
+	for i, value := range values {
+		points[i] = Point{
+			Epoch:  epoch.Epoch((i + 1) * int(timeseries.Second)),
+			Values: []any{value},
+		}
+	}
+	return &Series{
+		Header: SeriesHeader{
+			Name:           name,
+			Tags:           Tags{"host": host},
+			QueryStatement: "fixture",
+		},
+		Points:    points,
+		PointSize: points.Size(),
+	}
+}
+
+func batchMergeFixture() []*DataSet {
+	step := 15 * time.Second
+	makeDataSet := func(status, warning string, series ...*Series) *DataSet {
+		return &DataSet{
+			Status:         status,
+			Warnings:       []string{warning},
+			TimeRangeQuery: &timeseries.TimeRangeQuery{Step: step},
+			ExtentList: timeseries.ExtentList{{
+				Start: time.Unix(0, 0),
+				End:   time.Unix(60, 0),
+			}},
+			Results: Results{{StatementID: 0, SeriesList: series}},
+		}
+	}
+	return []*DataSet{
+		makeDataSet("error", "member-0",
+			batchMergeSeries("cpu", "a", "1", "2"),
+			batchMergeSeries("cpu", "base-only", "7")),
+		makeDataSet("success", "member-1",
+			batchMergeSeries("cpu", "a", "3", "4"),
+			batchMergeSeries("cpu", "b", "5"),
+			// Repeated hashes within one member are ignored by the existing merge.
+			batchMergeSeries("cpu", "b", "999")),
+		makeDataSet("success", "member-2",
+			batchMergeSeries("cpu", "a", "6", "8"),
+			batchMergeSeries("cpu", "c", "9")),
+		makeDataSet("success", "member-3",
+			batchMergeSeries("cpu", "b", "10"),
+			batchMergeSeries("cpu", "d", "11")),
+	}
+}
+
+func batchMergeSnapshot(ds *DataSet) []string {
+	out := make([]string, 0, ds.SeriesCount())
+	for _, result := range ds.Results {
+		if result == nil {
+			continue
+		}
+		for _, series := range result.SeriesList {
+			if series == nil {
+				continue
+			}
+			out = append(out, fmt.Sprintf("%d:%s", result.StatementID, series.String()))
+		}
+	}
+	return out
+}
+
+func TestBatchMergeMatchesSequentialMerge(t *testing.T) {
+	tests := []struct {
+		name string
+		opts MergeOpts
+	}{
+		{name: "dedup", opts: MergeOpts{SortPoints: true}},
+		{name: "dedup_with_tolerance", opts: MergeOpts{
+			SortPoints: true, Strategy: MergeStrategyDedup, ToleranceNanos: 1,
+		}},
+		{name: "sum", opts: MergeOpts{SortPoints: true, Strategy: MergeStrategySum}},
+		{name: "min", opts: MergeOpts{SortPoints: true, Strategy: MergeStrategyMin}},
+		{name: "max", opts: MergeOpts{SortPoints: true, Strategy: MergeStrategyMax}},
+		{name: "avg", opts: MergeOpts{SortPoints: true, Strategy: MergeStrategyAvg}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sequentialInputs := batchMergeFixture()
+			sequential := sequentialInputs[0]
+			for _, next := range sequentialInputs[1:] {
+				sequential.MergeWithOpts(test.opts, next)
+			}
+
+			batchInputs := batchMergeFixture()
+			batch := batchInputs[0]
+			collection := make([]timeseries.Timeseries, len(batchInputs)-1)
+			for i := 1; i < len(batchInputs); i++ {
+				collection[i-1] = batchInputs[i]
+			}
+			batch.MergeWithOpts(test.opts, collection...)
+
+			if got, want := batchMergeSnapshot(batch), batchMergeSnapshot(sequential); !reflect.DeepEqual(got, want) {
+				t.Fatalf("batch result differs from sequential merge\ngot:  %v\nwant: %v", got, want)
+			}
+			if !reflect.DeepEqual(batch.ExtentList, sequential.ExtentList) {
+				t.Fatalf("extent list differs: got %v want %v", batch.ExtentList, sequential.ExtentList)
+			}
+			if test.opts.Strategy == MergeStrategyDedup && test.opts.ToleranceNanos == 0 {
+				if batch.Status != sequential.Status {
+					t.Fatalf("status differs: got %q want %q", batch.Status, sequential.Status)
+				}
+				if !reflect.DeepEqual(batch.Warnings, sequential.Warnings) {
+					t.Fatalf("warnings differ: got %v want %v", batch.Warnings, sequential.Warnings)
+				}
+			}
+		})
+	}
+}
+
+func TestBatchMergePreservesAliasedSeriesOrder(t *testing.T) {
+	merge := func(batch bool) []string {
+		shared := batchMergeSeries("cpu", "shared", "2")
+		base := &DataSet{Results: Results{{StatementID: 0, SeriesList: SeriesList{shared}}}}
+		members := []timeseries.Timeseries{
+			&DataSet{Results: Results{{StatementID: 0, SeriesList: SeriesList{shared}}}},
+			&DataSet{Results: Results{{StatementID: 0, SeriesList: SeriesList{shared}}}},
+		}
+		if batch {
+			base.MergeWithStrategy(true, int(MergeStrategySum), members...)
+		} else {
+			for _, member := range members {
+				base.MergeWithStrategy(true, int(MergeStrategySum), member)
+			}
+		}
+		return batchMergeSnapshot(base)
+	}
+
+	if got, want := merge(true), merge(false); !reflect.DeepEqual(got, want) {
+		t.Fatalf("aliased batch result differs\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+func benchmarkMergeFixture(members, seriesPerMember int, overlap bool) []*DataSet {
+	out := make([]*DataSet, members)
+	for member := range members {
+		series := make(SeriesList, seriesPerMember)
+		for i := range seriesPerMember {
+			id := i
+			if !overlap {
+				id += member * seriesPerMember
+			}
+			series[i] = batchMergeSeries("metric", strconv.Itoa(id), strconv.Itoa(member+1))
+		}
+		out[member] = &DataSet{
+			TimeRangeQuery: &timeseries.TimeRangeQuery{Step: 15 * time.Second},
+			Results:        Results{{StatementID: 0, SeriesList: series}},
+		}
+	}
+	return out
+}
+
+func BenchmarkFanoutDataSetMerge(b *testing.B) {
+	for _, overlap := range []bool{false, true} {
+		name := "disjoint"
+		if overlap {
+			name = "overlap"
+		}
+		b.Run(name+"/sequential", func(b *testing.B) {
+			for range b.N {
+				b.StopTimer()
+				inputs := benchmarkMergeFixture(64, 1000, overlap)
+				b.StartTimer()
+				for _, next := range inputs[1:] {
+					inputs[0].MergeWithStrategy(true, int(MergeStrategySum), next)
+				}
+			}
+		})
+		b.Run(name+"/batch", func(b *testing.B) {
+			for range b.N {
+				b.StopTimer()
+				inputs := benchmarkMergeFixture(64, 1000, overlap)
+				collection := make([]timeseries.Timeseries, len(inputs)-1)
+				for i := 1; i < len(inputs); i++ {
+					collection[i-1] = inputs[i]
+				}
+				b.StartTimer()
+				inputs[0].MergeWithStrategy(true, int(MergeStrategySum), collection...)
+			}
+		})
+	}
+}

--- a/pkg/timeseries/dataset/series_list.go
+++ b/pkg/timeseries/dataset/series_list.go
@@ -195,7 +195,118 @@ func (sl SeriesList) MergeWithOpts(sl2 SeriesList, opts MergeOpts) SeriesList {
 	return out
 }
 
+// mergeCollection merges several member lists while preserving the same
+// member order as repeated MergeWithOpts calls. Building the series lookup and
+// sorting once avoids repeating both operations for every fanout member.
+func (sl SeriesList) mergeCollection(collection []SeriesList, opts MergeOpts) SeriesList {
+	nonEmpty := make([]SeriesList, 0, len(collection))
+	for _, next := range collection {
+		if len(next) > 0 {
+			nonEmpty = append(nonEmpty, next)
+		}
+	}
+	if len(nonEmpty) == 0 {
+		return sl.Clone()
+	}
+	if len(nonEmpty) == 1 {
+		return sl.MergeWithOpts(nonEmpty[0], opts)
+	}
+
+	// Repeated merges clone the first incoming list when the receiver is
+	// empty. Preserve that ownership rule before processing the remainder.
+	if len(sl) == 0 {
+		sl = nonEmpty[0].Clone()
+		nonEmpty = nonEmpty[1:]
+		if len(nonEmpty) == 0 {
+			return sl
+		}
+	}
+
+	total := len(sl)
+	for _, next := range nonEmpty {
+		total += len(next)
+	}
+	out := make(SeriesList, total)
+	seriesByHash := make(map[Hash]*Series, total)
+	var k int
+	for _, s := range sl {
+		if s == nil {
+			continue
+		}
+		h := s.Header.CalculateHash()
+		if _, ok := seriesByHash[h]; ok {
+			continue
+		}
+		out[k] = s
+		seriesByHash[h] = s
+		k++
+	}
+
+	type mergeJob struct {
+		target *Series
+		series []*Series
+	}
+	jobs := make([]mergeJob, 0)
+	jobByHash := make(map[Hash]int)
+	seen := make(sets.Set[Hash])
+	for _, next := range nonEmpty {
+		clear(seen)
+		for _, s := range next {
+			if s == nil {
+				continue
+			}
+			h := s.Header.CalculateHash()
+			if seen.Contains(h) {
+				continue
+			}
+			seen.Set(h)
+			target, ok := seriesByHash[h]
+			if !ok {
+				out[k] = s
+				seriesByHash[h] = s
+				k++
+				continue
+			}
+			jobIndex, ok := jobByHash[h]
+			if !ok {
+				jobIndex = len(jobs)
+				jobByHash[h] = jobIndex
+				jobs = append(jobs, mergeJob{target: target})
+			}
+			jobs[jobIndex].series = append(jobs[jobIndex].series, s)
+		}
+	}
+
+	eg := errgroup.Group{}
+	eg.SetLimit(runtime.GOMAXPROCS(0))
+	for _, job := range jobs {
+		eg.Go(func() error {
+			points := job.target.Points
+			for _, next := range job.series {
+				points = MergePointsWithOpts(points, next.Points, opts)
+				job.target.Points = points
+			}
+			job.target.PointSize = points.Size()
+			return nil
+		})
+	}
+	_ = eg.Wait()
+
+	out = out[:k]
+	out.SortByTags()
+	return out
+}
+
 func (sl SeriesList) SortByTags() {
+	if len(sl) < 2 {
+		return
+	}
+	tagsJSON := make(map[*Series]string, len(sl))
+	for _, series := range sl {
+		if series != nil {
+			tagsJSON[series] = series.Header.Tags.JSON()
+		}
+	}
 	slices.SortFunc(sl, func(a, b *Series) int {
 		if a == nil && b == nil {
 			return 0
@@ -206,7 +317,7 @@ func (sl SeriesList) SortByTags() {
 		if b == nil {
 			return -1
 		}
-		if c := strings.Compare(a.Header.Tags.JSON(), b.Header.Tags.JSON()); c != 0 {
+		if c := strings.Compare(tagsJSON[a], tagsJSON[b]); c != 0 {
 			return c
 		}
 		return strings.Compare(a.Header.Name, b.Header.Name)


### PR DESCRIPTION
## Description

Fixes #1056.

TSM removes an outer `topk`/`bottomk` before fanout so the rank is computed from globally merged values. That exposes each member's full result, and the gather path was then merging every response inside its fanout callback under one accumulator lock. With high-cardinality responses, the lock serialized the merges while the series lookup and tag ordering were rebuilt for every member.

This change keeps the global rank semantics and removes that bottleneck:

- fanout callbacks decode and store contributions by member slot; after fanout, TSM invokes an optional backend-supplied `BatchMergeFunc` carried through `request.Resources`, or falls back to each configured `MergeFunc` in slot order;
- Prometheus opts into the batch path for query and query-range responses, where series from all members share one hash-index pass and one tag sort while preserving the configured strategy and dedup tolerance;
- tag sort keys are computed once per series;
- rank finalization keeps only `k` candidates per timestamp/group in a bounded heap and computes label tie-break keys lazily;
- non-DataSet merge functions retain the existing fallback behavior and panic isolation.

The member-side query remains unranked and the original rank operation is still applied after the global merge. This does not use the local-`topk` diagnostic shortcut from the issue.

A 64-member, 1,000-series-per-member benchmark on the same host measured:

| Series distribution | Sequential merge | Batch merge |
| --- | ---: | ---: |
| Disjoint | 2.16 s | 107 ms |
| Fully overlapping | 110 ms | 31 ms |

For a 64,000-series `topk(20)` result, bounded rank finalization measured about 14 ms with 7.7 KB allocated.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Optimization
- [x] Test coverage
- [ ] Documentation
- [ ] Infrastructure

## AI Disclosure

- [ ] This contribution DOES NOT include AI-generated changes
- [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
