### PR TITLE
fix: enable TSM context cancellation

### DIFF
--- a/pkg/backends/alb/mech/fanout/fanout.go
+++ b/pkg/backends/alb/mech/fanout/fanout.go
@@ -98,11 +98,11 @@ type Result struct {
 	Capture *capture.CaptureResponseWriter
 	// Failed is true when the slot did not produce a usable response.
 	// Reasons: clone error, panic in the member's handler, or capture
-	// truncation (the upstream exceeded MaxCaptureBytes). Mechanism code
-	// uses this to surface partial-failure signals.
+	// truncation (the upstream exceeded MaxCaptureBytes), or parent-context
+	// cancellation. Mechanism code uses this to surface partial-failure signals.
 	Failed bool
-	// Err carries a clone or transport error, if any. A recovered panic
-	// is reflected only in Failed; the panic value is logged + metered
+	// Err carries a clone, transport, or context error, if any. A recovered
+	// panic is reflected only in Failed; the panic value is logged + metered
 	// inside the fanout goroutine.
 	Err error
 }
@@ -143,11 +143,11 @@ type Config struct {
 	// most mechanisms can leave it nil.
 	Context func(parent context.Context) context.Context
 	// OnResult, if non-nil, is called inside the fanout goroutine after
-	// the member's handler returns and before the goroutine exits. Use
-	// this for per-slot side effects that should run in parallel with
-	// other in-flight members (e.g. TSM decodes and stores a slot result).
-	// OnResult must be safe for concurrent invocation. The supplied
-	// Result is the same one that will appear in the All return slice.
+	// the member's handler returns and before the goroutine exits. It is
+	// skipped when the handler returns after the fanout context is canceled.
+	// Use this for per-slot side effects that run with other in-flight members.
+	// OnResult must be safe for concurrent invocation. The supplied Result
+	// is the same one that will appear in the All return slice.
 	OnResult func(idx int, r *Result)
 }
 
@@ -167,10 +167,11 @@ type Config struct {
 //
 // All returns when every spawned goroutine has finished. The returned
 // slice has len(targets) entries; results[i].Index == i. The error is the
-// first non-nil error from any goroutine (typically a clone failure); per-
-// slot errors are also recorded in results[i].Err. The primitive logs +
-// meters every failure regardless; callers can use the returned error to
-// propagate through their own errgroup, render a fatal response, etc.
+// first non-nil error from any goroutine (typically a clone failure), or the
+// parent context error when fanout is canceled; per-slot errors are also
+// recorded in results[i].Err. The primitive logs + meters non-cancellation
+// failures regardless; callers can use the returned error to propagate
+// through their own errgroup, render a fatal response, etc.
 func All(ctx context.Context, parent *http.Request, targets pool.Targets, cfg Config) ([]Result, error) {
 	return scatter(ctx, parent, targets, cfg, nil)
 }
@@ -290,8 +291,9 @@ func scatterInto(ctx context.Context, parent *http.Request, targets pool.Targets
 	}
 
 	var eg errgroup.Group
+	var slots chan struct{}
 	if cfg.ConcurrencyLimit > 0 {
-		eg.SetLimit(cfg.ConcurrencyLimit)
+		slots = make(chan struct{}, cfg.ConcurrencyLimit)
 	}
 
 	// Aggregate capture-buffer budget across all slots. Each dispatched slot
@@ -307,7 +309,19 @@ func scatterInto(ctx context.Context, parent *http.Request, targets pool.Targets
 	}
 	perSlotReserve := perSlotReserveBytes(cfg)
 
+	var dispatchErr error
+	markUndispatched := func(start int, err error) {
+		for i := start; i < l; i++ {
+			results[i] = Result{Index: i, Failed: true, Err: err}
+		}
+	}
+
 	for i := range l {
+		if err := ctx.Err(); err != nil {
+			dispatchErr = err
+			markUndispatched(i, err)
+			break
+		}
 		if targets[i] == nil {
 			results[i] = Result{Index: i, Failed: true}
 			continue
@@ -317,7 +331,30 @@ func scatterInto(ctx context.Context, parent *http.Request, targets pool.Targets
 			metrics.ALBFanoutFailures.WithLabelValues(cfg.Mechanism, cfg.Variant, "aggregate_cap").Inc()
 			continue
 		}
+		if slots != nil {
+			select {
+			case slots <- struct{}{}:
+			case <-ctx.Done():
+				dispatchErr = ctx.Err()
+				markUndispatched(i, dispatchErr)
+				break
+			}
+			if dispatchErr != nil {
+				break
+			}
+			// A slot and cancellation can become ready together. Do not start a
+			// handler after cancellation merely because select chose the slot.
+			if err := ctx.Err(); err != nil {
+				<-slots
+				dispatchErr = err
+				markUndispatched(i, err)
+				break
+			}
+		}
 		eg.Go(func() error {
+			if slots != nil {
+				defer func() { <-slots }()
+			}
 			results[i].Index = i
 			defer mech.RecoverFanoutPanic(cfg.Mechanism, cfg.Variant, i, func() {
 				results[i].Failed = true
@@ -335,6 +372,14 @@ func scatterInto(ctx context.Context, parent *http.Request, targets pool.Targets
 			results[i].Capture = crw
 
 			targets[i].Handler().ServeHTTP(crw, r2)
+			if err := ctx.Err(); err != nil {
+				results[i].Failed = true
+				results[i].Err = err
+				if perSlot != nil {
+					perSlot(i, &results[i])
+				}
+				return nil
+			}
 			// short_read wins over truncated; both can be true for the same
 			// slot and double-counting distorts dashboards.
 			if capt := request.GetUpstreamShortReadCapture(r2.Context()); capt != nil && capt.Tripped() {
@@ -357,7 +402,13 @@ func scatterInto(ctx context.Context, parent *http.Request, targets pool.Targets
 	}
 
 	err := eg.Wait()
-	if err != nil {
+	if err == nil {
+		err = dispatchErr
+	}
+	if err == nil {
+		err = ctx.Err()
+	}
+	if err != nil && ctx.Err() == nil {
 		logger.Warn("alb fanout gather failure", logging.Pairs{
 			"mech": cfg.Mechanism, "error": err,
 		})

--- a/pkg/backends/alb/mech/fanout/fanout.go
+++ b/pkg/backends/alb/mech/fanout/fanout.go
@@ -337,7 +337,6 @@ func scatterInto(ctx context.Context, parent *http.Request, targets pool.Targets
 			case <-ctx.Done():
 				dispatchErr = ctx.Err()
 				markUndispatched(i, dispatchErr)
-				break
 			}
 			if dispatchErr != nil {
 				break

--- a/pkg/backends/alb/mech/fanout/fanout_test.go
+++ b/pkg/backends/alb/mech/fanout/fanout_test.go
@@ -96,6 +96,64 @@ func TestAllCtxCancelPropagation(t *testing.T) {
 	}
 }
 
+func TestAllCancellationStopsQueuedDispatchAndResultProcessing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	firstStarted := make(chan struct{})
+	var queuedStarted atomic.Int32
+	var onResultCalls atomic.Int32
+
+	first, _ := albpool.Target(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		close(firstStarted)
+		<-r.Context().Done()
+	}))
+	queuedHandler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		queuedStarted.Add(1)
+	})
+	second, _ := albpool.Target(queuedHandler)
+	third, _ := albpool.Target(queuedHandler)
+	targets := pool.Targets{first, second, third}
+	parent := albpool.NewParentGET(t)
+
+	type outcome struct {
+		results []Result
+		err     error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		results, err := All(ctx, parent, targets, Config{
+			Mechanism:        "test",
+			ConcurrencyLimit: 1,
+			OnResult: func(int, *Result) {
+				onResultCalls.Add(1)
+			},
+		})
+		done <- outcome{results: results, err: err}
+	}()
+
+	select {
+	case <-firstStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first handler never started")
+	}
+	cancel()
+
+	select {
+	case got := <-done:
+		require.ErrorIs(t, got.err, context.Canceled)
+		require.Len(t, got.results, len(targets))
+		for i := range got.results {
+			require.Equal(t, i, got.results[i].Index)
+			require.True(t, got.results[i].Failed, "slot %d should be canceled", i)
+			require.ErrorIs(t, got.results[i].Err, context.Canceled)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("All did not return after context cancellation")
+	}
+
+	require.Zero(t, queuedStarted.Load(), "queued handlers started after cancellation")
+	require.Zero(t, onResultCalls.Load(), "OnResult ran after cancellation")
+}
+
 func TestAllPanicRecovered(t *testing.T) {
 	t0, _ := albpool.Target(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("ok-0"))

--- a/pkg/backends/alb/mech/tsm/time_series_merge.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge.go
@@ -17,6 +17,7 @@
 package tsm
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"net/http"
@@ -473,10 +474,10 @@ func aggregateStatus(results []gatherResult) (status int, statusHeader string, h
 	return
 }
 
-func prepareGatherContribution(rsc *request.Resources, body []byte, member int,
+func prepareGatherContribution(ctx context.Context, rsc *request.Resources, body []byte, member int,
 	stripKeys []string,
 ) *gatherContribution {
-	if rsc == nil || rsc.MergeFunc == nil {
+	if ctx.Err() != nil || rsc == nil || rsc.MergeFunc == nil {
 		return nil
 	}
 	ts := rsc.TS
@@ -490,6 +491,9 @@ func prepareGatherContribution(rsc *request.Resources, body []byte, member int,
 			return nil
 		}
 		rsc.TS = ts
+	}
+	if ctx.Err() != nil {
+		return nil
 	}
 	if len(stripKeys) > 0 && ts != nil {
 		if ds, ok := ts.(*dataset.DataSet); ok {
@@ -515,13 +519,16 @@ func prepareGatherContribution(rsc *request.Resources, body []byte, member int,
 // mergeGatherContributions preserves slot order and lets the backend-provided
 // batch function handle compatible inputs. Otherwise each contribution is
 // folded through its original MergeFunc.
-func mergeGatherContributions(accumulator *merge.Accumulator,
+func mergeGatherContributions(ctx context.Context, accumulator *merge.Accumulator,
 	contributions []*gatherContribution,
 ) []int {
 	items := make([]merge.BatchItem, 0, len(contributions))
 	batchCompatible := true
 	var batchMergeFunc merge.BatchMergeFunc
 	for _, contribution := range contributions {
+		if ctx.Err() != nil {
+			return nil
+		}
 		if contribution == nil {
 			continue
 		}
@@ -536,6 +543,9 @@ func mergeGatherContributions(accumulator *merge.Accumulator,
 		}
 	}
 	if batchCompatible && batchMergeFunc != nil {
+		if ctx.Err() != nil {
+			return nil
+		}
 		handled, err := mergeContributionBatch(accumulator, batchMergeFunc, items)
 		if err != nil {
 			logger.Warn("tsm gather batch merge failure", logging.Pairs{
@@ -554,6 +564,9 @@ func mergeGatherContributions(accumulator *merge.Accumulator,
 
 	failed := make([]int, 0)
 	for _, contribution := range contributions {
+		if ctx.Err() != nil {
+			return failed
+		}
 		if contribution == nil {
 			continue
 		}
@@ -611,9 +624,10 @@ func (h *handler) serveStandard(
 		failures.HandleBadGateway(w, r)
 		return
 	}
+	parentCtx := r.Context()
 
 	dedupToleranceNanos := h.dedupToleranceNanos()
-	fanoutResults, _ := fanout.All(r.Context(), r, hl, fanout.Config{
+	fanoutResults, _ := fanout.All(parentCtx, r, hl, fanout.Config{
 		Mechanism:             names.MechanismTSM,
 		ConcurrencyLimit:      h.tsmOptions.ConcurrencyOptions.GetQueryConcurrencyLimit(),
 		MaxCaptureBytes:       h.maxCaptureBytes,
@@ -627,6 +641,10 @@ func (h *handler) serveStandard(
 			}
 		},
 		OnResult: func(i int, fr *fanout.Result) {
+			if parentCtx.Err() != nil {
+				results[i].failed = true
+				return
+			}
 			if fr.Failed || fr.Request == nil || fr.Capture == nil {
 				results[i].failed = true
 				return
@@ -642,7 +660,7 @@ func (h *handler) serveStandard(
 			var contribution *gatherContribution
 			if rsc2.MergeFunc != nil {
 				if rsc2.TS != nil {
-					contribution = prepareGatherContribution(rsc2, nil, i, stripKeys)
+					contribution = prepareGatherContribution(parentCtx, rsc2, nil, i, stripKeys)
 				} else {
 					body, derr := encoding.DecompressResponseBody(
 						fr.Capture.Header().Get(headers.NameContentEncoding),
@@ -656,7 +674,7 @@ func (h *handler) serveStandard(
 						return
 					}
 					if len(body) > 0 {
-						contribution = prepareGatherContribution(rsc2, body, i, stripKeys)
+						contribution = prepareGatherContribution(parentCtx, rsc2, body, i, stripKeys)
 					}
 				}
 			}
@@ -673,6 +691,9 @@ func (h *handler) serveStandard(
 			}
 		},
 	})
+	if parentCtx.Err() != nil {
+		return
+	}
 
 	for i, fr := range fanoutResults {
 		if fr.Failed && !results[i].failed {
@@ -683,8 +704,11 @@ func (h *handler) serveStandard(
 	for i := range results {
 		contributions[i] = results[i].contrib
 	}
-	for _, member := range mergeGatherContributions(accumulator, contributions) {
+	for _, member := range mergeGatherContributions(parentCtx, accumulator, contributions) {
 		results[member].failed = true
+	}
+	if parentCtx.Err() != nil {
+		return
 	}
 
 	// Surface goroutine-level failures (e.g. unsupported Content-Encoding,
@@ -715,8 +739,14 @@ func (h *handler) serveStandard(
 		}
 	}
 
+	if parentCtx.Err() != nil {
+		return
+	}
 	if finalizer != nil {
 		finalizer.FinalizeTSMMerge(query, accumulator.GetTSData())
+	}
+	if parentCtx.Err() != nil {
+		return
 	}
 
 	// If every fanout slot failed at the dispatch level (panics, transport
@@ -922,6 +952,10 @@ func (h *handler) serveWeightedAvg(
 			MaxFanoutCaptureBytes: h.maxFanoutCaptureBytes,
 			Resources:             resourcesFn,
 			OnResult: func(i int, fr *fanout.Result) {
+				if parentCtx.Err() != nil {
+					results[i].failed = true
+					return
+				}
 				if fr.Failed || fr.Request == nil || fr.Capture == nil {
 					results[i].failed = true
 					return
@@ -933,7 +967,7 @@ func (h *handler) serveWeightedAvg(
 				}
 				var contribution *gatherContribution
 				if rsc2.TS != nil {
-					contribution = prepareGatherContribution(rsc2, nil, i, stripKeys)
+					contribution = prepareGatherContribution(parentCtx, rsc2, nil, i, stripKeys)
 				} else if fr.Capture != nil {
 					body, derr := encoding.DecompressResponseBody(
 						fr.Capture.Header().Get(headers.NameContentEncoding),
@@ -946,7 +980,7 @@ func (h *handler) serveWeightedAvg(
 						results[i].failed = true
 						return
 					}
-					contribution = prepareGatherContribution(rsc2, body, i, stripKeys)
+					contribution = prepareGatherContribution(parentCtx, rsc2, body, i, stripKeys)
 				}
 				sumContributions[i] = contribution
 				sc := fr.Capture.StatusCode()
@@ -976,7 +1010,7 @@ func (h *handler) serveWeightedAvg(
 				// Count-side intentionally does not touch results[i]: the
 				// sum-side owns the response envelope. Panics in this slot
 				// are already recovered + countered by fanout.All.
-				if fr.Failed || fr.Request == nil {
+				if parentCtx.Err() != nil || fr.Failed || fr.Request == nil {
 					return
 				}
 				rsc2 := request.GetResources(fr.Request)
@@ -984,7 +1018,7 @@ func (h *handler) serveWeightedAvg(
 					return
 				}
 				if rsc2.TS != nil {
-					countContributions[i] = prepareGatherContribution(rsc2, nil, i, stripKeys)
+					countContributions[i] = prepareGatherContribution(parentCtx, rsc2, nil, i, stripKeys)
 				} else if fr.Capture != nil {
 					body, derr := encoding.DecompressResponseBody(
 						fr.Capture.Header().Get(headers.NameContentEncoding),
@@ -996,19 +1030,28 @@ func (h *handler) serveWeightedAvg(
 						})
 						return
 					}
-					countContributions[i] = prepareGatherContribution(rsc2, body, i, stripKeys)
+					countContributions[i] = prepareGatherContribution(parentCtx, rsc2, body, i, stripKeys)
 				}
 			},
 		})
 		return err
 	})
-	if err := eg.Wait(); err != nil {
+	if err := eg.Wait(); err != nil && parentCtx.Err() == nil {
 		logger.Warn("tsm avg gather failure", logging.Pairs{"error": err})
 	}
-	for _, member := range mergeGatherContributions(sumAccum, sumContributions) {
+	if parentCtx.Err() != nil {
+		return
+	}
+	for _, member := range mergeGatherContributions(parentCtx, sumAccum, sumContributions) {
 		results[member].failed = true
 	}
-	mergeGatherContributions(countAccum, countContributions)
+	if parentCtx.Err() != nil {
+		return
+	}
+	mergeGatherContributions(parentCtx, countAccum, countContributions)
+	if parentCtx.Err() != nil {
+		return
+	}
 
 	// Finalize: divide sum totals by count totals to obtain the weighted
 	// average. If either side fanned out to zero usable responses the
@@ -1026,6 +1069,9 @@ func (h *handler) serveWeightedAvg(
 		if sumDS, ok := sumTS.(*dataset.DataSet); ok {
 			if countDS, ok := countTS.(*dataset.DataSet); ok {
 				pruneUnpairedWeightedAvgSeries(sumDS, countDS, query)
+				if parentCtx.Err() != nil {
+					return
+				}
 				sumDS.FinalizeWeightedAvg(countDS, query)
 			}
 		}
@@ -1044,8 +1090,14 @@ func (h *handler) serveWeightedAvg(
 		sumAccum.SetTSData(countTS)
 	}
 
+	if parentCtx.Err() != nil {
+		return
+	}
 	if finalizer != nil {
 		finalizer.FinalizeTSMMerge(query, sumAccum.GetTSData())
+	}
+	if parentCtx.Err() != nil {
+		return
 	}
 
 	// Aggregate status and headers from sum-query results (count results are

--- a/pkg/backends/alb/mech/tsm/time_series_merge_batch_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_batch_test.go
@@ -17,6 +17,7 @@
 package tsm
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -62,7 +63,7 @@ func TestMergeGatherContributionsBatchesDataSets(t *testing.T) {
 	}
 	accumulator := merge.NewAccumulator()
 
-	if failed := mergeGatherContributions(accumulator, contributions); len(failed) != 0 {
+	if failed := mergeGatherContributions(context.Background(), accumulator, contributions); len(failed) != 0 {
 		t.Fatalf("unexpected merge failures: %v", failed)
 	}
 
@@ -79,6 +80,30 @@ func TestMergeGatherContributionsBatchesDataSets(t *testing.T) {
 	}
 	if value := fmt.Sprint(got.Results[0].SeriesList[0].Points[0].Values[0]); value != "6" {
 		t.Fatalf("merged value got %q want 6", value)
+	}
+}
+
+func TestMergeGatherContributionsStopsAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var merged []int
+	mergeFunc := func(_ *merge.Accumulator, _ any, member int) error {
+		merged = append(merged, member)
+		if member == 0 {
+			cancel()
+		}
+		return nil
+	}
+	contributions := []*gatherContribution{
+		{data: "first", mergeFunc: mergeFunc, member: 0},
+		{data: "second", mergeFunc: mergeFunc, member: 1},
+	}
+
+	failed := mergeGatherContributions(ctx, merge.NewAccumulator(), contributions)
+	if len(failed) != 0 {
+		t.Fatalf("unexpected merge failures: %v", failed)
+	}
+	if !reflect.DeepEqual(merged, []int{0}) {
+		t.Fatalf("merged members got %v want [0]", merged)
 	}
 }
 
@@ -114,7 +139,7 @@ func TestMergeGatherContributionsFallbackReportsMember(t *testing.T) {
 	}
 	accumulator := merge.NewAccumulator()
 
-	failed := mergeGatherContributions(accumulator, contributions)
+	failed := mergeGatherContributions(context.Background(), accumulator, contributions)
 	if !reflect.DeepEqual(batchMembers, []int{0, 1, 2, 3}) {
 		t.Fatalf("batch member order got %v want [0 1 2 3]", batchMembers)
 	}
@@ -143,7 +168,7 @@ func TestMergeGatherContributionsRequiresEveryBatchFunc(t *testing.T) {
 	}
 	accumulator := merge.NewAccumulator()
 
-	if failed := mergeGatherContributions(accumulator, contributions); len(failed) != 0 {
+	if failed := mergeGatherContributions(context.Background(), accumulator, contributions); len(failed) != 0 {
 		t.Fatalf("unexpected merge failures: %v", failed)
 	}
 	if batchCalled {
@@ -168,7 +193,7 @@ func TestMergeGatherContributionsRecoversBatchPanic(t *testing.T) {
 	}
 	accumulator := merge.NewAccumulator()
 
-	failed := mergeGatherContributions(accumulator, contributions)
+	failed := mergeGatherContributions(context.Background(), accumulator, contributions)
 	if !reflect.DeepEqual(failed, []int{0, 1}) {
 		t.Fatalf("failed members got %v want [0 1]", failed)
 	}

--- a/pkg/backends/alb/mech/tsm/time_series_merge_finalizer_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_finalizer_test.go
@@ -17,18 +17,22 @@
 package tsm
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends/alb/pool"
 	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/params"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
 )
@@ -199,5 +203,88 @@ func TestServeStandardRewritesRankFanoutToInnerQuery(t *testing.T) {
 		if got != innerQuery {
 			t.Fatalf("fanout query got %q want %q (all queries: %v)", got, innerQuery, queries)
 		}
+	}
+}
+
+func TestServeStandardRankRewritePropagatesCancellationAndSkipsMerge(t *testing.T) {
+	logger.SetLogger(testLogger)
+
+	const (
+		outerQuery = "topk(1, sum by (service) (requests))"
+		innerQuery = "sum by (service) (requests)"
+	)
+	be := &rankRewriteFinalizerStubBackend{innerQuery: innerQuery}
+	started := make(chan struct{}, 2)
+	var canceled atomic.Int32
+	var merged atomic.Int32
+
+	blockingHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		started <- struct{}{}
+		<-r.Context().Done()
+		canceled.Add(1)
+
+		// Populate a valid contribution after cancellation. Fanout/TSM must
+		// discard it instead of doing result or finalizer work for a caller
+		// that is no longer present.
+		rsc := request.GetResources(r)
+		rsc.TS = newMarkerDataSet("late")
+		rsc.MergeFunc = func(*merge.Accumulator, any, int) error {
+			merged.Add(1)
+			return nil
+		}
+		rsc.MergeRespondFunc = markerRespondFunc
+		w.WriteHeader(http.StatusOK)
+	})
+
+	targets := make(pool.Targets, 2)
+	for i := range targets {
+		st := &healthcheck.Status{}
+		st.Set(healthcheck.StatusPassing)
+		targets[i] = pool.NewTarget(blockingHandler, st, be)
+	}
+	p := pool.New(targets, -1)
+	defer p.Stop()
+	p.RefreshHealthy()
+
+	limit := 2
+	h := &handler{mergePaths: []string{"/"}}
+	h.tsmOptions.ConcurrencyOptions.QueryConcurrencyLimit = &limit
+	h.SetPool(p)
+
+	req := newTestMergeRequest(t)
+	req.URL.RawQuery = "query=" + url.QueryEscape(outerQuery)
+	rsc := request.GetResources(req)
+	rsc.TimeRangeQuery = &timeseries.TimeRangeQuery{Statement: outerQuery}
+	ctx, cancel := context.WithCancel(req.Context())
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		h.ServeHTTP(httptest.NewRecorder(), req)
+		close(done)
+	}()
+
+	for range 2 {
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+			t.Fatal("fanout member did not start")
+		}
+	}
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("TSM request did not return after caller cancellation")
+	}
+	if got := canceled.Load(); got != 2 {
+		t.Fatalf("canceled fanout members = %d, want 2", got)
+	}
+	if got := merged.Load(); got != 0 {
+		t.Fatalf("merge calls after cancellation = %d, want 0", got)
+	}
+	if got := be.Query(); got != "" {
+		t.Fatalf("finalizer ran after cancellation with query %q", got)
 	}
 }

--- a/pkg/backends/alb/mech/tsm/time_series_merge_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_test.go
@@ -103,7 +103,7 @@ func TestTSMNonMergePathUsesFirstLiveMember(t *testing.T) {
 	h := &handler{mergePaths: []string{"/api/v1/query_range"}}
 	h.SetPool(p)
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodGet, "https://trickstercache.org/api/v1/query?query=up", nil)
 		h.ServeHTTP(w, r)

--- a/pkg/backends/prometheus/tsm_provider_test.go
+++ b/pkg/backends/prometheus/tsm_provider_test.go
@@ -18,11 +18,13 @@ package prometheus
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/params"
@@ -230,6 +232,8 @@ func TestRewriteForTSMMergeRankAggregationPOST(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost,
 		"http://example.com/api/v1/query_range",
 		io.NopCloser(bytes.NewBufferString(origBody)))
+	ctx, cancel := context.WithCancel(r.Context())
+	r = r.WithContext(ctx)
 	r.Header.Set(headers.NameContentType, headers.ValueXFormURLEncoded)
 	r = request.SetResources(r, &request.Resources{RequestBody: []byte(origBody)})
 
@@ -268,6 +272,16 @@ func TestRewriteForTSMMergeRankAggregationPOST(t *testing.T) {
 	}
 	if q := gotCache.Get("query"); q != wantQ {
 		t.Errorf("rsc.RequestBody query param: got %q, want %q", q, wantQ)
+	}
+
+	cancel()
+	select {
+	case <-rewritten.Context().Done():
+		if err := rewritten.Context().Err(); err != context.Canceled {
+			t.Fatalf("rewritten context error got %v want %v", err, context.Canceled)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("rewritten request did not observe source cancellation")
 	}
 }
 

--- a/pkg/proxy/headers/headers_test.go
+++ b/pkg/proxy/headers/headers_test.go
@@ -86,7 +86,7 @@ func TestUpdateRequestHeadersPreservesHostUpdate(t *testing.T) {
 				"X-Test":       "value",
 			}
 
-			for i := 0; i < 2; i++ {
+			for i := range 2 {
 				r := &http.Request{
 					Header: make(http.Header),
 					Host:   "origin.example.com",

--- a/pkg/proxy/request/request.go
+++ b/pkg/proxy/request/request.go
@@ -25,8 +25,8 @@ import (
 	tctx "github.com/trickstercache/trickster/v2/pkg/proxy/context"
 )
 
-// Clone wraps the builtin Clone to use a deep clone of both the request body
-// reader (when present) and the Trickster context data
+// Clone wraps the builtin Clone, preserving the source request's context while
+// deep-cloning both the body reader (when present) and Trickster Resources.
 func Clone(r *http.Request) (*http.Request, error) {
 	if r == nil {
 		return nil, nil
@@ -35,7 +35,7 @@ func Clone(r *http.Request) (*http.Request, error) {
 	if rsc != nil {
 		rsc = rsc.Clone()
 	}
-	ctx := context.Background()
+	ctx := r.Context()
 	if rsc != nil {
 		ctx = tctx.WithResources(ctx, rsc)
 	}

--- a/pkg/proxy/request/resources_test.go
+++ b/pkg/proxy/request/resources_test.go
@@ -104,6 +104,43 @@ func TestClone(t *testing.T) {
 		}
 	})
 
+	t.Run("preserves context values deadline and cancellation", func(t *testing.T) {
+		type contextKey struct{}
+		deadline := time.Now().Add(time.Hour)
+		ctx := context.WithValue(context.Background(), contextKey{}, "preserved")
+		ctx, deadlineCancel := context.WithDeadline(ctx, deadline)
+		defer deadlineCancel()
+		ctx, cancel := context.WithCancel(ctx)
+
+		r, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://127.0.0.1/", nil)
+		rsc := NewResources(nil, nil, nil, nil, nil, nil)
+		r = SetResources(r, rsc)
+		out, err := Clone(r)
+		if err != nil {
+			t.Fatal("unexpected error:", err)
+		}
+		if got := out.Context().Value(contextKey{}); got != "preserved" {
+			t.Fatalf("context value = %v, want preserved", got)
+		}
+		gotDeadline, ok := out.Context().Deadline()
+		if !ok || !gotDeadline.Equal(deadline) {
+			t.Fatalf("deadline = %v, %t; want %v, true", gotDeadline, ok, deadline)
+		}
+		if GetResources(out) == rsc {
+			t.Fatal("Clone should still use independent Resources while preserving context")
+		}
+
+		cancel()
+		select {
+		case <-out.Context().Done():
+			if err := out.Context().Err(); err != context.Canceled {
+				t.Fatalf("context error = %v, want %v", err, context.Canceled)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("clone did not observe source context cancellation")
+		}
+	})
+
 	t.Run("cloned resources are independent", func(t *testing.T) {
 		rsc := NewResources(nil, nil, nil, nil, nil, nil)
 		rsc.AlternateCacheTTL = time.Minute


### PR DESCRIPTION
## Description
This change addresses #1059:
- preserves the original request context while deep-cloning resources.
- ALB fanouts now stop queued dispatches when context is canceled.
- Skips OnResult processing after cancellation.
- Returns context cancellation errors.
- TSM checks cancellation at all appropriate boundaries.

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [x] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
