### PR TITLE
fix: merge aggregations through prometheus sort wrappers

### DIFF
--- a/pkg/backends/alb/mech/tsm/time_series_merge_finalizer_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_finalizer_test.go
@@ -17,6 +17,7 @@
 package tsm
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -26,11 +27,15 @@ import (
 
 	"github.com/trickstercache/trickster/v2/pkg/backends/alb/pool"
 	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
+	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
+	"github.com/trickstercache/trickster/v2/pkg/backends/prometheus"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/params"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/epoch"
 )
 
 type finalizerStubBackend struct {
@@ -71,6 +76,12 @@ type rankRewriteFinalizerStubBackend struct {
 	innerQuery string
 }
 
+type prometheusSortBackend struct {
+	*prometheus.Client
+}
+
+func (b *prometheusSortBackend) Configuration() *bo.Options { return nil }
+
 func (b *rankRewriteFinalizerStubBackend) ClassifyMerge(string) (int, bool, string) {
 	return int(dataset.MergeStrategySum), false, ""
 }
@@ -109,6 +120,60 @@ func recordingMergeHandler(marker string, qr *queryRecorder) http.Handler {
 		qr.Append(qp.Get("query"))
 		stubMergeHandler(marker, http.StatusOK).ServeHTTP(w, r)
 	})
+}
+
+func aggregationMergeHandler(values map[string]string, qr *queryRecorder) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		qp, _, _ := params.GetRequestValues(r)
+		query := qp.Get("query")
+		qr.Append(query)
+
+		seriesList := make(dataset.SeriesList, 0, len(values))
+		for service, value := range values {
+			seriesList = append(seriesList, &dataset.Series{
+				Header: dataset.SeriesHeader{
+					Name:           "count",
+					Tags:           dataset.Tags{"service": service},
+					QueryStatement: query,
+				},
+				Points: dataset.Points{{
+					Epoch:  epoch.Epoch(100),
+					Values: []any{value},
+				}},
+			})
+		}
+
+		rsc := request.GetResources(r)
+		if rsc != nil {
+			rsc.TS = &dataset.DataSet{Results: dataset.Results{{SeriesList: seriesList}}}
+			rsc.MergeFunc = merge.TimeseriesMergeFuncWithStrategy(nil, rsc.TSMergeStrategy)
+			rsc.BatchMergeFunc = merge.TimeseriesBatchMergeFuncWithStrategy(rsc.TSMergeStrategy)
+			rsc.MergeRespondFunc = aggregationRespondFunc
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func aggregationRespondFunc(w http.ResponseWriter, _ *http.Request,
+	accum *merge.Accumulator, statusCode int,
+) {
+	if statusCode == 0 {
+		statusCode = http.StatusOK
+	}
+	w.WriteHeader(statusCode)
+	ds, _ := accum.GetTSData().(*dataset.DataSet)
+	if ds == nil || len(ds.Results) == 0 || ds.Results[0] == nil {
+		return
+	}
+	parts := make([]string, 0, len(ds.Results[0].SeriesList))
+	for _, series := range ds.Results[0].SeriesList {
+		if series == nil || len(series.Points) == 0 || len(series.Points[0].Values) == 0 {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s=%v", series.Header.Tags["service"],
+			series.Points[0].Values[0]))
+	}
+	_, _ = w.Write([]byte(strings.Join(parts, ",")))
 }
 
 func TestServeStandardCallsMergeFinalizer(t *testing.T) {
@@ -190,6 +255,56 @@ func TestServeStandardRewritesRankFanoutToInnerQuery(t *testing.T) {
 
 	if got := be.Query(); got != outerQuery {
 		t.Fatalf("finalizer query got %q want %q", got, outerQuery)
+	}
+	queries := qr.Queries()
+	if len(queries) != 2 {
+		t.Fatalf("recorded queries got %v want two entries", queries)
+	}
+	for _, got := range queries {
+		if got != innerQuery {
+			t.Fatalf("fanout query got %q want %q (all queries: %v)", got, innerQuery, queries)
+		}
+	}
+}
+
+func TestServeStandardMergesThroughSortWrapper(t *testing.T) {
+	logger.SetLogger(testLogger)
+
+	const (
+		outerQuery = "sort_desc(count by (service) (requests))"
+		innerQuery = "count by (service) (requests)"
+	)
+	be := &prometheusSortBackend{Client: &prometheus.Client{}}
+	qr := &queryRecorder{}
+	targets := make(pool.Targets, 2)
+	for i, h := range []http.Handler{
+		aggregationMergeHandler(map[string]string{"api": "2", "worker": "10"}, qr),
+		aggregationMergeHandler(map[string]string{"api": "3", "worker": "1"}, qr),
+	} {
+		st := &healthcheck.Status{}
+		st.Set(healthcheck.StatusPassing)
+		targets[i] = pool.NewTarget(h, st, be)
+	}
+	p := pool.New(targets, -1)
+	defer p.Stop()
+	p.RefreshHealthy()
+
+	h := &handler{mergePaths: []string{"/"}}
+	h.SetPool(p)
+
+	req := newTestMergeRequest(t)
+	req.URL.RawQuery = "query=" + url.QueryEscape(outerQuery)
+	rsc := request.GetResources(req)
+	rsc.TimeRangeQuery = &timeseries.TimeRangeQuery{Statement: outerQuery}
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status got %d want %d body=%q", w.Code, http.StatusOK, w.Body.String())
+	}
+	if got, want := w.Body.String(), "worker=11,api=5"; got != want {
+		t.Fatalf("body got %q want %q", got, want)
 	}
 	queries := qr.Queries()
 	if len(queries) != 2 {

--- a/pkg/backends/prometheus/promql/rank_aggregation.go
+++ b/pkg/backends/prometheus/promql/rank_aggregation.go
@@ -40,19 +40,11 @@ var maxRankK = int(^uint(0) >> 1)
 
 func ParseRankAggregation(query string) (RankAggregation, bool) {
 	q := strings.TrimSpace(query)
-	if inner, ok := unwrapUnaryFunction(q, "sort_desc"); ok {
-		spec, found := ParseRankAggregation(inner)
+	if sortSpec, ok := ParseSortWrapper(q); ok {
+		spec, found := parseRankAggregation(sortSpec.InnerQuery)
 		if found {
 			spec.SortSet = true
-			spec.SortDescending = true
-		}
-		return spec, found
-	}
-	if inner, ok := unwrapUnaryFunction(q, "sort"); ok {
-		spec, found := ParseRankAggregation(inner)
-		if found {
-			spec.SortSet = true
-			spec.SortDescending = false
+			spec.SortDescending = sortSpec.Descending
 		}
 		return spec, found
 	}
@@ -187,11 +179,20 @@ func parseLabels(input string) []string {
 func unwrapUnaryFunction(query, name string) (string, bool) {
 	q := strings.TrimSpace(query)
 	ql := strings.ToLower(q)
-	prefix := name + "("
-	if !strings.HasPrefix(ql, prefix) {
+	if !strings.HasPrefix(ql, name) {
 		return "", false
 	}
 	openIdx := len(name)
+	for openIdx < len(q) {
+		c := q[openIdx]
+		if c != ' ' && c != '\t' && c != '\n' && c != '\r' {
+			break
+		}
+		openIdx++
+	}
+	if openIdx >= len(q) || q[openIdx] != '(' {
+		return "", false
+	}
 	closeIdx := findMatchingCloser(q, openIdx, '(', ')')
 	if closeIdx != len(q)-1 {
 		return "", false

--- a/pkg/backends/prometheus/promql/sort_wrapper.go
+++ b/pkg/backends/prometheus/promql/sort_wrapper.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package promql
+
+import "strings"
+
+// SortWrapper describes outer PromQL sort functions that TSM must apply after
+// merging the wrapped expression across backends.
+type SortWrapper struct {
+	InnerQuery string
+	Descending bool
+}
+
+// ParseSortWrapper unwraps an outer sort or sort_desc function. If multiple
+// sort wrappers are nested, InnerQuery excludes all of them and Descending
+// reflects the outermost wrapper that determines the final ordering.
+func ParseSortWrapper(query string) (SortWrapper, bool) {
+	q := strings.TrimSpace(query)
+	inner, descending, ok := unwrapSortFunction(q)
+	if !ok || strings.TrimSpace(inner) == "" {
+		return SortWrapper{}, false
+	}
+	for {
+		next, _, found := unwrapSortFunction(inner)
+		if !found || strings.TrimSpace(next) == "" {
+			break
+		}
+		inner = next
+	}
+	return SortWrapper{
+		InnerQuery: strings.TrimSpace(inner),
+		Descending: descending,
+	}, true
+}
+
+func unwrapSortFunction(query string) (inner string, descending bool, ok bool) {
+	if inner, ok := unwrapUnaryFunction(query, "sort_desc"); ok {
+		return inner, true, true
+	}
+	if inner, ok := unwrapUnaryFunction(query, "sort"); ok {
+		return inner, false, true
+	}
+	return "", false, false
+}

--- a/pkg/backends/prometheus/promql/sort_wrapper_test.go
+++ b/pkg/backends/prometheus/promql/sort_wrapper_test.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package promql
+
+import "testing"
+
+func TestParseSortWrapper(t *testing.T) {
+	tests := []struct {
+		name           string
+		query          string
+		wantInner      string
+		wantDescending bool
+		wantFound      bool
+	}{
+		{
+			name:      "ascending",
+			query:     "sort(sum(up))",
+			wantInner: "sum(up)",
+			wantFound: true,
+		},
+		{
+			name:           "descending",
+			query:          "sort_desc(count by (service) (up))",
+			wantInner:      "count by (service) (up)",
+			wantDescending: true,
+			wantFound:      true,
+		},
+		{
+			name:           "case and surrounding whitespace",
+			query:          "  SORT_DESC \n (label_replace(up, \"dst\", \"$1\", \"src\", \"(.*)\"))  ",
+			wantInner:      "label_replace(up, \"dst\", \"$1\", \"src\", \"(.*)\")",
+			wantDescending: true,
+			wantFound:      true,
+		},
+		{
+			name:           "nested wrappers use outer direction",
+			query:          "sort_desc(sort(sum(up)))",
+			wantInner:      "sum(up)",
+			wantDescending: true,
+			wantFound:      true,
+		},
+		{name: "plain expression", query: "sum(up)"},
+		{name: "empty wrapper", query: "sort()"},
+		{name: "trailing expression", query: "sort(sum(up)) + 1"},
+		{name: "different function", query: "sort_by_label(up, \"job\")"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, found := ParseSortWrapper(tt.query)
+			if found != tt.wantFound {
+				t.Fatalf("found got %v want %v", found, tt.wantFound)
+			}
+			if got.InnerQuery != tt.wantInner {
+				t.Errorf("inner query got %q want %q", got.InnerQuery, tt.wantInner)
+			}
+			if got.Descending != tt.wantDescending {
+				t.Errorf("descending got %v want %v", got.Descending, tt.wantDescending)
+			}
+		})
+	}
+}

--- a/pkg/backends/prometheus/tsm_provider.go
+++ b/pkg/backends/prometheus/tsm_provider.go
@@ -39,11 +39,20 @@ const promQueryParam = "query"
 // weighted average is required, and an optional warning for operators whose
 // results cannot be correctly merged across shards.
 func (c *Client) ClassifyMerge(query string) (strategy int, needsDualQuery bool, warning string) {
-	if spec, ok := promql.ParseRankAggregation(query); ok {
-		query = spec.InnerQuery
-	}
-
+	query, _ = tsmInnerQuery(query)
 	return classifyPromMerge(query)
+}
+
+func tsmInnerQuery(query string) (string, bool) {
+	if spec, ok := promql.ParseRankAggregation(query); ok {
+		return spec.InnerQuery, true
+	}
+	if spec, ok := promql.ParseSortWrapper(query); ok {
+		if _, found := promql.OuterAggregator(spec.InnerQuery); found {
+			return spec.InnerQuery, true
+		}
+	}
+	return query, false
 }
 
 func classifyPromMerge(query string) (strategy int, needsDualQuery bool, warning string) {
@@ -73,15 +82,15 @@ func classifyPromMerge(query string) (strategy int, needsDualQuery bool, warning
 	}
 }
 
-// RewriteForTSMMerge rewrites Prometheus rank aggregations before TSM fanout.
-// The shards receive the inner query; FinalizeTSMMerge later applies the
-// original topk/bottomk operation to the merged inner result.
+// RewriteForTSMMerge removes Prometheus operations that must run after TSM
+// fanout. The shards receive the inner query; FinalizeTSMMerge later applies
+// the original rank and/or sort operation to the merged result.
 func (c *Client) RewriteForTSMMerge(r *http.Request, query string) (*http.Request, string) {
-	spec, ok := promql.ParseRankAggregation(query)
+	innerQuery, ok := tsmInnerQuery(query)
 	if !ok {
 		return r, query
 	}
-	return rewritePromQueryParam(r, spec.InnerQuery, "rank aggregation"), spec.InnerQuery
+	return rewritePromQueryParam(r, innerQuery, "tsm finalizer"), innerQuery
 }
 
 // RewriteForWeightedAvg implements backends.TSMMergeProvider for the Prometheus
@@ -90,9 +99,7 @@ func (c *Client) RewriteForTSMMerge(r *http.Request, query string) (*http.Reques
 // into the Prometheus "query" parameter. Both GET (query string) and POST
 // (request body) encodings are handled transparently by params.SetRequestValues.
 func (c *Client) RewriteForWeightedAvg(r *http.Request, query string) (*http.Request, *http.Request) {
-	if spec, ok := promql.ParseRankAggregation(query); ok {
-		query = spec.InnerQuery
-	}
+	query, _ = tsmInnerQuery(query)
 
 	sumQuery := promql.ReplaceOuterAggregator(query, "avg", "sum")
 	countQuery := promql.ReplaceOuterAggregator(query, "avg", "count")

--- a/pkg/backends/prometheus/tsm_provider_test.go
+++ b/pkg/backends/prometheus/tsm_provider_test.go
@@ -58,11 +58,19 @@ func TestClassifyMerge(t *testing.T) {
 		{"sort_desc(topk(5, max(up)))", int(dataset.MergeStrategyMax), false, ""},
 		{"bottomk(5, up)", int(dataset.MergeStrategyDedup), false, ""},
 		{"sort_desc(topk(5, up))", int(dataset.MergeStrategyDedup), false, ""},
+		// sort wrappers preserve the inner aggregation strategy
+		{"sort(sum(up))", int(dataset.MergeStrategySum), false, ""},
+		{"sort_desc(count by (service) (up))", int(dataset.MergeStrategySum), false, ""},
+		{"sort(avg by (service) (up))", int(dataset.MergeStrategySum), true, ""},
+		{"sort(min(up))", int(dataset.MergeStrategyMin), false, ""},
+		{"sort_desc(max(up))", int(dataset.MergeStrategyMax), false, ""},
+		{"sort(up)", int(dataset.MergeStrategyDedup), false, ""},
 		// unsupported aggregators → dedup + warning containing the operator name
 		{"stddev(up)", int(dataset.MergeStrategyDedup), false, "stddev"},
 		{"stdvar(up)", int(dataset.MergeStrategyDedup), false, "stdvar"},
 		{"quantile(0.9, up)", int(dataset.MergeStrategyDedup), false, "quantile"},
 		{"topk(5, stddev(up))", int(dataset.MergeStrategyDedup), false, "stddev"},
+		{"sort_desc(stddev(up))", int(dataset.MergeStrategyDedup), false, "stddev"},
 		{"topk(k, up)", int(dataset.MergeStrategyDedup), false, "topk"},
 		{"limitk(5, up)", int(dataset.MergeStrategyDedup), false, "limitk"},
 		{"limit_ratio(0.5, up)", int(dataset.MergeStrategyDedup), false, "limit_ratio"},
@@ -271,6 +279,54 @@ func TestRewriteForTSMMergeRankAggregationPOST(t *testing.T) {
 	}
 }
 
+func TestRewriteForTSMMergeSortWrapperPOST(t *testing.T) {
+	const (
+		query    = "sort_desc(sum by (service) (requests))"
+		wantQ    = "sum by (service) (requests)"
+		origBody = "query=sort_desc%28sum+by+%28service%29+%28requests%29%29&start=1000&end=2000&step=15"
+	)
+	r, _ := http.NewRequest(http.MethodPost,
+		"http://example.com/api/v1/query_range",
+		io.NopCloser(bytes.NewBufferString(origBody)))
+	r.Header.Set(headers.NameContentType, headers.ValueXFormURLEncoded)
+	r = request.SetResources(r, &request.Resources{RequestBody: []byte(origBody)})
+
+	rewritten, rewrittenQuery := (&Client{}).RewriteForTSMMerge(r, query)
+	if rewrittenQuery != wantQ {
+		t.Fatalf("rewritten query got %q want %q", rewrittenQuery, wantQ)
+	}
+
+	gotValues, _, _ := params.GetRequestValues(rewritten)
+	if q := gotValues.Get("query"); q != wantQ {
+		t.Fatalf("rewritten request query got %q want %q", q, wantQ)
+	}
+	gotRsc := request.GetResources(rewritten)
+	if gotRsc == nil {
+		t.Fatal("expected non-nil resources")
+	}
+	gotBody, err := url.ParseQuery(string(gotRsc.RequestBody))
+	if err != nil {
+		t.Fatalf("parse rsc.RequestBody: %v", err)
+	}
+	if q := gotBody.Get("query"); q != wantQ {
+		t.Fatalf("rsc.RequestBody query got %q want %q", q, wantQ)
+	}
+}
+
+func TestRewriteForTSMMergePreservesNonAggregationSort(t *testing.T) {
+	const query = "sort(up)"
+	r, _ := http.NewRequest(http.MethodGet,
+		"http://example.com/api/v1/query?query="+url.QueryEscape(query), nil)
+
+	rewritten, rewrittenQuery := (&Client{}).RewriteForTSMMerge(r, query)
+	if rewritten != r {
+		t.Fatal("non-aggregation sort unexpectedly cloned the request")
+	}
+	if rewrittenQuery != query {
+		t.Fatalf("rewritten query got %q want %q", rewrittenQuery, query)
+	}
+}
+
 func TestRewriteForWeightedAvgRankAggregationGET(t *testing.T) {
 	const query = "topk(5, avg by (service) (requests))"
 	r, _ := http.NewRequest(http.MethodGet,
@@ -293,6 +349,29 @@ func TestRewriteForWeightedAvgRankAggregationGET(t *testing.T) {
 			}
 			if q := gotURL.Get("query"); q != tc.wantQ {
 				t.Errorf("URL query param: got %q, want %q", q, tc.wantQ)
+			}
+		})
+	}
+}
+
+func TestRewriteForWeightedAvgSortWrapperGET(t *testing.T) {
+	const query = "sort_desc(avg by (service) (requests))"
+	r, _ := http.NewRequest(http.MethodGet,
+		"http://example.com/api/v1/query?query="+url.QueryEscape(query), nil)
+
+	sumReq, countReq := (&Client{}).RewriteForWeightedAvg(r, query)
+	for _, tc := range []struct {
+		name  string
+		req   *http.Request
+		wantQ string
+	}{
+		{"sum", sumReq, "sum by (service) (requests)"},
+		{"count", countReq, "count by (service) (requests)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _, _ := params.GetRequestValues(tc.req)
+			if q := got.Get("query"); q != tc.wantQ {
+				t.Fatalf("query got %q want %q", q, tc.wantQ)
 			}
 		})
 	}

--- a/pkg/backends/prometheus/tsm_rank_finalize.go
+++ b/pkg/backends/prometheus/tsm_rank_finalize.go
@@ -19,6 +19,7 @@ package prometheus
 import (
 	"cmp"
 	"container/heap"
+	"encoding/json"
 	"math"
 	"slices"
 	"strconv"
@@ -114,19 +115,38 @@ func (h *rankCandidateHeap) tags(candidate rankCandidate) string {
 	return tags
 }
 
-// FinalizeTSMMerge applies Prometheus-only merge finalization after TSM fanout
-// has accumulated the rewritten inner-query responses. The rank step belongs
-// here so topk/bottomk operate on globally merged values, not per-backend ranks.
+// FinalizeTSMMerge applies Prometheus-only rank and sort finalization after TSM
+// fanout has accumulated the rewritten inner-query responses. These operations
+// belong here so they use globally merged values rather than per-backend data.
 func (c *Client) FinalizeTSMMerge(query string, ts timeseries.Timeseries) {
-	spec, ok := promql.ParseRankAggregation(query)
-	if !ok {
-		return
-	}
 	ds, ok := ts.(*dataset.DataSet)
 	if !ok || ds == nil {
 		return
 	}
-	finalizeRankAggregation(ds, spec)
+	if spec, found := promql.ParseRankAggregation(query); found {
+		finalizeRankAggregation(ds, spec)
+		return
+	}
+	if spec, found := promql.ParseSortWrapper(query); found {
+		if _, aggregationFound := promql.OuterAggregator(spec.InnerQuery); aggregationFound {
+			finalizeSortWrapper(ds, spec.Descending)
+		}
+	}
+}
+
+func finalizeSortWrapper(ds *dataset.DataSet, descending bool) {
+	if ds.Step() > 0 {
+		return
+	}
+
+	ds.UpdateLock.Lock()
+	defer ds.UpdateLock.Unlock()
+
+	for _, result := range ds.Results {
+		if result != nil {
+			sortSeriesIfInstant(result.SeriesList, descending)
+		}
+	}
 }
 
 func finalizeRankAggregation(ds *dataset.DataSet, spec promql.RankAggregation) {
@@ -175,7 +195,13 @@ func finalizeRankAggregation(ds *dataset.DataSet, spec promql.RankAggregation) {
 			}
 		}
 		result.SeriesList = keepSelectedRankPoints(result.SeriesList, selected)
-		sortRankSeriesIfInstant(result.SeriesList, spec)
+		descending := spec.Operator == rankOperatorTopK
+		if spec.SortSet {
+			descending = spec.SortDescending
+		}
+		if ds.Step() == 0 {
+			sortSeriesIfInstant(result.SeriesList, descending)
+		}
 	}
 }
 
@@ -192,6 +218,27 @@ func rankPointValue(point dataset.Point) (float64, bool) {
 		return 0, false
 	}
 	return f, true
+}
+
+func sortPointValue(point dataset.Point) (float64, bool) {
+	if value, ok := rankPointValue(point); ok {
+		return value, true
+	}
+	if len(point.Values) == 0 {
+		return 0, false
+	}
+	value, ok := point.Values[0].(string)
+	if !ok {
+		return 0, false
+	}
+	var histogram struct {
+		Sum string `json:"sum"`
+	}
+	if err := json.Unmarshal([]byte(value), &histogram); err != nil || histogram.Sum == "" {
+		return 0, false
+	}
+	result, err := strconv.ParseFloat(histogram.Sum, 64)
+	return result, err == nil
 }
 
 func compareRankCandidateValues(a, b rankCandidate, operator string) int {
@@ -274,7 +321,7 @@ func keepSelectedRankPoints(
 	return keptSeries
 }
 
-func sortRankSeriesIfInstant(seriesList dataset.SeriesList, spec promql.RankAggregation) {
+func sortSeriesIfInstant(seriesList dataset.SeriesList, descending bool) {
 	if len(seriesList) < 2 {
 		return
 	}
@@ -287,13 +334,9 @@ func sortRankSeriesIfInstant(seriesList dataset.SeriesList, spec promql.RankAggr
 			return
 		}
 	}
-	desc := spec.Operator == rankOperatorTopK
-	if spec.SortSet {
-		desc = spec.SortDescending
-	}
 	slices.SortStableFunc(seriesList, func(a, b *dataset.Series) int {
-		iv, iok := rankPointValue(a.Points[0])
-		jv, jok := rankPointValue(b.Points[0])
+		iv, iok := sortPointValue(a.Points[0])
+		jv, jok := sortPointValue(b.Points[0])
 		if !iok || !jok {
 			if iok {
 				return -1
@@ -304,7 +347,7 @@ func sortRankSeriesIfInstant(seriesList dataset.SeriesList, spec promql.RankAggr
 			return 0
 		}
 		op := rankOperatorBottomK
-		if desc {
+		if descending {
 			op = rankOperatorTopK
 		}
 		if rankValueLess(iv, jv, op) {

--- a/pkg/backends/prometheus/tsm_rank_finalize.go
+++ b/pkg/backends/prometheus/tsm_rank_finalize.go
@@ -30,9 +30,11 @@ import (
 )
 
 const (
-	histogramFieldName  = "histogram"
-	rankOperatorBottomK = "bottomk"
-	rankOperatorTopK    = "topk"
+	histogramFieldName      = "histogram"
+	rankOperatorBottomK     = "bottomk"
+	rankOperatorTopK        = "topk"
+	sortInRangeQueryWarning = "PromQL warning: sort is ineffective for range queries " +
+		"since results are always ordered by labels"
 )
 
 type rankBucketKey struct {
@@ -141,23 +143,41 @@ func (c *Client) FinalizeTSMMerge(query string, ts timeseries.Timeseries) {
 }
 
 func finalizeSortWrapper(ds *dataset.DataSet, descending bool) {
-	if ds.Step() > 0 {
-		return
-	}
+	isRangeQuery := ds.Step() > 0
 
 	ds.UpdateLock.Lock()
 	defer ds.UpdateLock.Unlock()
 
+	if isRangeQuery {
+		appendWarningOnce(ds, sortInRangeQueryWarning)
+	}
+
 	for _, result := range ds.Results {
-		if result != nil {
-			result.SeriesList = sortSeriesIfInstant(result.SeriesList, descending)
+		if result == nil {
+			continue
+		}
+		result.SeriesList = filterHistogramSeries(result.SeriesList)
+		if !isRangeQuery {
+			sortInstantSeries(result.SeriesList, descending)
 		}
 	}
 }
 
+func appendWarningOnce(ds *dataset.DataSet, warning string) {
+	if !slices.Contains(ds.Warnings, warning) {
+		ds.Warnings = append(ds.Warnings, warning)
+	}
+}
+
 func finalizeRankAggregation(ds *dataset.DataSet, spec promql.RankAggregation) {
+	isRangeQuery := ds.Step() > 0
+
 	ds.UpdateLock.Lock()
 	defer ds.UpdateLock.Unlock()
+
+	if isRangeQuery && spec.SortSet {
+		appendWarningOnce(ds, sortInRangeQueryWarning)
+	}
 
 	for _, result := range ds.Results {
 		if result == nil || len(result.SeriesList) == 0 {
@@ -205,8 +225,8 @@ func finalizeRankAggregation(ds *dataset.DataSet, spec promql.RankAggregation) {
 		if spec.SortSet {
 			descending = spec.SortDescending
 		}
-		if ds.Step() == 0 {
-			result.SeriesList = sortSeriesIfInstant(result.SeriesList, descending)
+		if !isRangeQuery {
+			sortInstantSeries(result.SeriesList, descending)
 		}
 	}
 }
@@ -312,10 +332,7 @@ func isHistogramSeries(series *dataset.Series) bool {
 		series.Header.ValueFieldsList[0].Name == histogramFieldName
 }
 
-func sortSeriesIfInstant(
-	seriesList dataset.SeriesList,
-	descending bool,
-) dataset.SeriesList {
+func filterHistogramSeries(seriesList dataset.SeriesList) dataset.SeriesList {
 	filtered := seriesList[:0]
 	for _, series := range seriesList {
 		if series == nil || isHistogramSeries(series) {
@@ -323,18 +340,20 @@ func sortSeriesIfInstant(
 		}
 		filtered = append(filtered, series)
 	}
-	seriesList = filtered
+	return filtered
+}
 
+func sortInstantSeries(seriesList dataset.SeriesList, descending bool) {
 	if len(seriesList) < 2 {
-		return seriesList
+		return
 	}
-	if len(seriesList[0].Points) != 1 {
-		return seriesList
+	if seriesList[0] == nil || len(seriesList[0].Points) != 1 {
+		return
 	}
 	epoch := seriesList[0].Points[0].Epoch
 	for _, series := range seriesList {
-		if len(series.Points) != 1 || series.Points[0].Epoch != epoch {
-			return seriesList
+		if series == nil || len(series.Points) != 1 || series.Points[0].Epoch != epoch {
+			return
 		}
 	}
 
@@ -368,5 +387,4 @@ func sortSeriesIfInstant(
 	for i := range items {
 		seriesList[i] = items[i].series
 	}
-	return seriesList
 }

--- a/pkg/backends/prometheus/tsm_rank_finalize.go
+++ b/pkg/backends/prometheus/tsm_rank_finalize.go
@@ -19,7 +19,6 @@ package prometheus
 import (
 	"cmp"
 	"container/heap"
-	"encoding/json"
 	"math"
 	"slices"
 	"strconv"
@@ -31,6 +30,7 @@ import (
 )
 
 const (
+	histogramFieldName  = "histogram"
 	rankOperatorBottomK = "bottomk"
 	rankOperatorTopK    = "topk"
 )
@@ -45,6 +45,12 @@ type rankCandidate struct {
 	pointIdx int
 	value    float64
 	order    int
+}
+
+type sortItem struct {
+	series *dataset.Series
+	value  float64
+	tags   string
 }
 
 type rankCandidateHeap struct {
@@ -144,7 +150,7 @@ func finalizeSortWrapper(ds *dataset.DataSet, descending bool) {
 
 	for _, result := range ds.Results {
 		if result != nil {
-			sortSeriesIfInstant(result.SeriesList, descending)
+			result.SeriesList = sortSeriesIfInstant(result.SeriesList, descending)
 		}
 	}
 }
@@ -200,7 +206,7 @@ func finalizeRankAggregation(ds *dataset.DataSet, spec promql.RankAggregation) {
 			descending = spec.SortDescending
 		}
 		if ds.Step() == 0 {
-			sortSeriesIfInstant(result.SeriesList, descending)
+			result.SeriesList = sortSeriesIfInstant(result.SeriesList, descending)
 		}
 	}
 }
@@ -218,27 +224,6 @@ func rankPointValue(point dataset.Point) (float64, bool) {
 		return 0, false
 	}
 	return f, true
-}
-
-func sortPointValue(point dataset.Point) (float64, bool) {
-	if value, ok := rankPointValue(point); ok {
-		return value, true
-	}
-	if len(point.Values) == 0 {
-		return 0, false
-	}
-	value, ok := point.Values[0].(string)
-	if !ok {
-		return 0, false
-	}
-	var histogram struct {
-		Sum string `json:"sum"`
-	}
-	if err := json.Unmarshal([]byte(value), &histogram); err != nil || histogram.Sum == "" {
-		return 0, false
-	}
-	result, err := strconv.ParseFloat(histogram.Sum, 64)
-	return result, err == nil
 }
 
 func compareRankCandidateValues(a, b rankCandidate, operator string) int {
@@ -321,41 +306,67 @@ func keepSelectedRankPoints(
 	return keptSeries
 }
 
-func sortSeriesIfInstant(seriesList dataset.SeriesList, descending bool) {
-	if len(seriesList) < 2 {
-		return
+func isHistogramSeries(series *dataset.Series) bool {
+	return series != nil &&
+		len(series.Header.ValueFieldsList) > 0 &&
+		series.Header.ValueFieldsList[0].Name == histogramFieldName
+}
+
+func sortSeriesIfInstant(
+	seriesList dataset.SeriesList,
+	descending bool,
+) dataset.SeriesList {
+	filtered := seriesList[:0]
+	for _, series := range seriesList {
+		if series == nil || isHistogramSeries(series) {
+			continue
+		}
+		filtered = append(filtered, series)
 	}
-	if seriesList[0] == nil || len(seriesList[0].Points) != 1 {
-		return
+	seriesList = filtered
+
+	if len(seriesList) < 2 {
+		return seriesList
+	}
+	if len(seriesList[0].Points) != 1 {
+		return seriesList
 	}
 	epoch := seriesList[0].Points[0].Epoch
 	for _, series := range seriesList {
-		if series == nil || len(series.Points) != 1 || series.Points[0].Epoch != epoch {
-			return
+		if len(series.Points) != 1 || series.Points[0].Epoch != epoch {
+			return seriesList
 		}
 	}
-	slices.SortStableFunc(seriesList, func(a, b *dataset.Series) int {
-		iv, iok := sortPointValue(a.Points[0])
-		jv, jok := sortPointValue(b.Points[0])
-		if !iok || !jok {
-			if iok {
-				return -1
-			}
-			if jok {
-				return 1
-			}
-			return 0
+
+	items := make([]sortItem, 0, len(seriesList))
+	for _, series := range seriesList {
+		value, ok := rankPointValue(series.Points[0])
+		if !ok {
+			value = math.NaN()
 		}
-		op := rankOperatorBottomK
-		if descending {
-			op = rankOperatorTopK
-		}
-		if rankValueLess(iv, jv, op) {
+		items = append(items, sortItem{
+			series: series,
+			value:  value,
+			tags:   series.Header.Tags.JSON(),
+		})
+	}
+
+	operator := rankOperatorBottomK
+	if descending {
+		operator = rankOperatorTopK
+	}
+	slices.SortStableFunc(items, func(a, b sortItem) int {
+		if rankValueLess(a.value, b.value, operator) {
 			return -1
 		}
-		if rankValueLess(jv, iv, op) {
+		if rankValueLess(b.value, a.value, operator) {
 			return 1
 		}
-		return strings.Compare(a.Header.Tags.JSON(), b.Header.Tags.JSON())
+		return strings.Compare(a.tags, b.tags)
 	})
+
+	for i := range items {
+		seriesList[i] = items[i].series
+	}
+	return seriesList
 }

--- a/pkg/backends/prometheus/tsm_rank_finalize_test.go
+++ b/pkg/backends/prometheus/tsm_rank_finalize_test.go
@@ -24,7 +24,9 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/epoch"
 )
@@ -114,6 +116,77 @@ func TestFinalizeTSMMergeRankAggregation(t *testing.T) {
 		got := seriesNames(ds)
 		want := []string{"b", "c"}
 		if !equalStrings(got, want) {
+			t.Fatalf("series got %v want %v", got, want)
+		}
+	})
+}
+
+func TestFinalizeTSMMergeSortWrapper(t *testing.T) {
+	t.Run("sort orders merged instant vector ascending", func(t *testing.T) {
+		ds := rankDataSet(
+			rankSeries("a", "3", 100),
+			rankSeries("b", "1", 100),
+			rankSeries("c", "2", 100),
+		)
+
+		(&Client{}).FinalizeTSMMerge("sort(sum(up))", ds)
+
+		if got, want := seriesNames(ds), []string{"b", "c", "a"}; !equalStrings(got, want) {
+			t.Fatalf("series got %v want %v", got, want)
+		}
+	})
+
+	t.Run("sort_desc orders merged instant vector descending", func(t *testing.T) {
+		ds := rankDataSet(
+			rankSeries("a", "1", 100),
+			rankSeries("b", "3", 100),
+			rankSeries("c", "2", 100),
+		)
+
+		(&Client{}).FinalizeTSMMerge("sort_desc(count(up))", ds)
+
+		if got, want := seriesNames(ds), []string{"b", "c", "a"}; !equalStrings(got, want) {
+			t.Fatalf("series got %v want %v", got, want)
+		}
+	})
+
+	t.Run("native histograms sort by observation sum", func(t *testing.T) {
+		ds := rankDataSet(
+			rankSeries("high", "4", 100),
+			rankSeries("histogram", `{"count":"2","sum":"2.5"}`, 100),
+			rankSeries("low", "1", 100),
+		)
+
+		(&Client{}).FinalizeTSMMerge("sort(sum(up))", ds)
+
+		if got, want := seriesNames(ds), []string{"low", "histogram", "high"}; !equalStrings(got, want) {
+			t.Fatalf("series got %v want %v", got, want)
+		}
+	})
+
+	t.Run("range vector order is unchanged", func(t *testing.T) {
+		ds := rankDataSet(
+			rankSeries("a", "3", 100),
+			rankSeries("b", "1", 100),
+		)
+		ds.TimeRangeQuery = &timeseries.TimeRangeQuery{Step: time.Minute}
+
+		(&Client{}).FinalizeTSMMerge("sort(sum(up))", ds)
+
+		if got, want := seriesNames(ds), []string{"a", "b"}; !equalStrings(got, want) {
+			t.Fatalf("series got %v want %v", got, want)
+		}
+	})
+
+	t.Run("non-aggregation sort is not finalized", func(t *testing.T) {
+		ds := rankDataSet(
+			rankSeries("a", "3", 100),
+			rankSeries("b", "1", 100),
+		)
+
+		(&Client{}).FinalizeTSMMerge("sort(up)", ds)
+
+		if got, want := seriesNames(ds), []string{"a", "b"}; !equalStrings(got, want) {
 			t.Fatalf("series got %v want %v", got, want)
 		}
 	})

--- a/pkg/backends/prometheus/tsm_rank_finalize_test.go
+++ b/pkg/backends/prometheus/tsm_rank_finalize_test.go
@@ -150,16 +150,18 @@ func TestFinalizeTSMMergeSortWrapper(t *testing.T) {
 		}
 	})
 
-	t.Run("native histograms sort by observation sum", func(t *testing.T) {
+	t.Run("native histograms are omitted", func(t *testing.T) {
+		histogram := rankSeries("histogram", `{"count":"2","sum":"2.5"}`, 100)
+		histogram.Header.ValueFieldsList = timeseries.FieldDefinitions{{Name: histogramFieldName}}
 		ds := rankDataSet(
+			histogram,
 			rankSeries("high", "4", 100),
-			rankSeries("histogram", `{"count":"2","sum":"2.5"}`, 100),
 			rankSeries("low", "1", 100),
 		)
 
 		(&Client{}).FinalizeTSMMerge("sort(sum(up))", ds)
 
-		if got, want := seriesNames(ds), []string{"low", "histogram", "high"}; !equalStrings(got, want) {
+		if got, want := seriesNames(ds), []string{"low", "high"}; !equalStrings(got, want) {
 			t.Fatalf("series got %v want %v", got, want)
 		}
 	})

--- a/pkg/backends/prometheus/tsm_rank_finalize_test.go
+++ b/pkg/backends/prometheus/tsm_rank_finalize_test.go
@@ -119,6 +119,38 @@ func TestFinalizeTSMMergeRankAggregation(t *testing.T) {
 			t.Fatalf("series got %v want %v", got, want)
 		}
 	})
+
+	t.Run("sort wrapper warns once for range query", func(t *testing.T) {
+		ds := rankDataSet(
+			rankSeries("a", "1", 100, "3", 200),
+			rankSeries("b", "2", 100, "4", 200),
+		)
+		ds.TimeRangeQuery = &timeseries.TimeRangeQuery{Step: time.Minute}
+		ds.Warnings = []string{"existing warning"}
+
+		client := &Client{}
+		client.FinalizeTSMMerge("sort(topk(1, up))", ds)
+		client.FinalizeTSMMerge("sort(topk(1, up))", ds)
+
+		want := []string{"existing warning", sortInRangeQueryWarning}
+		if !slices.Equal(ds.Warnings, want) {
+			t.Fatalf("warnings got %v want %v", ds.Warnings, want)
+		}
+	})
+
+	t.Run("unwrapped range query does not add sort warning", func(t *testing.T) {
+		ds := rankDataSet(
+			rankSeries("a", "1", 100, "3", 200),
+			rankSeries("b", "2", 100, "4", 200),
+		)
+		ds.TimeRangeQuery = &timeseries.TimeRangeQuery{Step: time.Minute}
+
+		(&Client{}).FinalizeTSMMerge("topk(1, up)", ds)
+
+		if slices.Contains(ds.Warnings, sortInRangeQueryWarning) {
+			t.Fatalf("unexpected sort warning: %v", ds.Warnings)
+		}
+	})
 }
 
 func TestFinalizeTSMMergeSortWrapper(t *testing.T) {
@@ -166,17 +198,31 @@ func TestFinalizeTSMMergeSortWrapper(t *testing.T) {
 		}
 	})
 
-	t.Run("range vector order is unchanged", func(t *testing.T) {
+	t.Run("range vector omits histograms, preserves order, and warns once", func(t *testing.T) {
+		histogram := rankSeries(
+			"histogram",
+			`{"count":"2","sum":"2.5"}`, 100,
+			`{"count":"3","sum":"4.5"}`, 200,
+		)
+		histogram.Header.ValueFieldsList = timeseries.FieldDefinitions{{Name: histogramFieldName}}
 		ds := rankDataSet(
-			rankSeries("a", "3", 100),
-			rankSeries("b", "1", 100),
+			histogram,
+			rankSeries("a", "3", 100, "4", 200),
+			rankSeries("b", "1", 100, "2", 200),
 		)
 		ds.TimeRangeQuery = &timeseries.TimeRangeQuery{Step: time.Minute}
+		ds.Warnings = []string{"existing warning"}
 
-		(&Client{}).FinalizeTSMMerge("sort(sum(up))", ds)
+		client := &Client{}
+		client.FinalizeTSMMerge("sort(sum(up))", ds)
+		client.FinalizeTSMMerge("sort(sum(up))", ds)
 
 		if got, want := seriesNames(ds), []string{"a", "b"}; !equalStrings(got, want) {
 			t.Fatalf("series got %v want %v", got, want)
+		}
+		wantWarnings := []string{"existing warning", sortInRangeQueryWarning}
+		if !slices.Equal(ds.Warnings, wantWarnings) {
+			t.Fatalf("warnings got %v want %v", ds.Warnings, wantWarnings)
 		}
 	})
 


### PR DESCRIPTION
## Description

Fixes #1063.

TSM previously classified PromQL from the outer expression, so queries such as `sort_desc(count by (...) (...))` fell back to deduplication. Keeping the wrapper on each fanout request also meant no final ordering was applied to the globally merged vector.

This change:

- recognizes outer `sort()` and `sort_desc()` wrappers, including nested wrappers and valid whitespace;
- classifies the wrapped aggregation so `sum`, `count`, `avg`, `min`, and `max` retain their existing merge behavior and unsupported aggregators retain their warning;
- sends the inner aggregation to fanout members, including the sum/count rewrite used for weighted averages;
- applies the requested ordering after the global merge for instant vectors, including native histograms ordered by observation sum;
- leaves range-query ordering and non-aggregation sort expressions unchanged.

The scatter/gather regression test uses two shards with colliding label sets and verifies that their counts are summed before the final descending sort.

Validation:

- `go test ./pkg/backends/prometheus/... ./pkg/backends/alb/... ./pkg/proxy/... -count=1`
- `go test -race ./pkg/backends/prometheus/promql ./pkg/backends/prometheus ./pkg/backends/alb/mech/tsm -run '^Test(ParseSortWrapper|ParseRankAggregation.*|ClassifyMerge|RewriteForTSMMerge.*|RewriteForWeightedAvg.*|FinalizeTSMMerge.*|ServeStandardMergesThroughSortWrapper)$' -count=10`
- `go vet ./pkg/backends/prometheus/... ./pkg/backends/alb/...`
- `go tool golangci-lint run --timeout 5m ./pkg/backends/prometheus/... ./pkg/backends/alb/mech/tsm`
- `go test -run '^$' ./...`
- Linux/amd64 integration test binary cross-compile

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Optimization
- [x] Test coverage
- [ ] Documentation
- [ ] Infrastructure

## AI Disclosure

- [ ] This contribution DOES NOT include AI-generated changes
- [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.