### PR TITLE
test: modernize benchmarks with b.Loop

### DIFF
--- a/pkg/cache/bbolt/bbolt_test.go
+++ b/pkg/cache/bbolt/bbolt_test.go
@@ -32,8 +32,9 @@ import (
 )
 
 const (
-	cacheProvider = "bbolt"
-	cacheKey      = "cacheKey"
+	cacheProvider     = "bbolt"
+	cacheKey          = "cacheKey"
+	benchmarkKeyCount = 10
 )
 
 func newCacheConfig(dbPath string) co.Options {
@@ -42,7 +43,8 @@ func newCacheConfig(dbPath string) co.Options {
 	}, Index: &io.Options{ReapInterval: time.Second}}
 }
 
-func storeBenchmark(b *testing.B) CacheClient {
+func setupBenchmark(b *testing.B) *CacheClient {
+	b.Helper()
 	logger.SetLogger(logging.ConsoleLogger(level.Error))
 	testDbPath := b.TempDir() + "/test.db"
 	cacheConfig := co.Options{
@@ -52,19 +54,15 @@ func storeBenchmark(b *testing.B) CacheClient {
 	}
 	bc := New(b.Name(), "", "", &cacheConfig)
 
-	err := bc.Connect()
-	if err != nil {
-		b.Error(err)
+	if err := bc.Connect(); err != nil {
+		b.Fatal(err)
 	}
-
-	// it should store a value
-	for n := 0; n < b.N; n++ {
-		err = bc.Store(cacheKey+strconv.Itoa(n), []byte("data"+strconv.Itoa(n)), time.Duration(60)*time.Second)
-		if err != nil {
+	b.Cleanup(func() {
+		if err := bc.Close(); err != nil {
 			b.Error(err)
 		}
-	}
-	return *bc
+	})
+	return bc
 }
 
 func TestBBoltCache_Connect(t *testing.T) {
@@ -133,8 +131,15 @@ func TestBBoltCache_Store(t *testing.T) {
 }
 
 func BenchmarkCache_Store(b *testing.B) {
-	bc := storeBenchmark(b)
-	defer bc.Close()
+	bc := setupBenchmark(b)
+	n := 0
+	for b.Loop() {
+		suffix := strconv.Itoa(n)
+		if err := bc.Store(cacheKey+suffix, []byte("data"+suffix), time.Minute); err != nil {
+			b.Fatal(err)
+		}
+		n++
+	}
 }
 
 func TestBBoltCache_Remove(t *testing.T) {
@@ -179,38 +184,15 @@ func TestBBoltCache_Remove(t *testing.T) {
 }
 
 func BenchmarkCache_Remove(b *testing.B) {
-	bc := storeBenchmark(b)
-	defer bc.Close()
-	for n := 0; n < b.N; n++ {
-		var data []byte
-		data, ls, err := bc.Retrieve(cacheKey + strconv.Itoa(n))
-		if err != nil {
-			b.Error(err)
+	bc := setupBenchmark(b)
+	for b.Loop() {
+		b.StopTimer()
+		if err := bc.Store(cacheKey, []byte("data"), time.Minute); err != nil {
+			b.Fatal(err)
 		}
-		if string(data) != "data"+strconv.Itoa(n) {
-			b.Errorf("wanted \"%s\". got \"%s\"", "data"+strconv.Itoa(n), data)
-		}
-		if ls != status.LookupStatusHit {
-			b.Errorf("expected %s got %s", status.LookupStatusHit, ls)
-		}
-
-		bc.Remove(cacheKey + strconv.Itoa(n))
-
-		// this should now return error
-		data, ls, err = bc.Retrieve(cacheKey + strconv.Itoa(n))
-		expectederr := `value for key [` + cacheKey + strconv.Itoa(n) + `] not in cache`
-		if err == nil {
-			b.Errorf("expected error for %s", expectederr)
-			bc.Close()
-		}
-		if err.Error() != expectederr {
-			b.Errorf("expected error '%s' got '%s'", expectederr, err.Error())
-		}
-		if ls != status.LookupStatusKeyMiss {
-			b.Errorf("expected %s got %s", status.LookupStatusKeyMiss, ls)
-		}
-		if string(data) != "" {
-			b.Errorf("wanted \"%s\". got \"%s\".", "data", data)
+		b.StartTimer()
+		if err := bc.Remove(cacheKey); err != nil {
+			b.Fatal(err)
 		}
 	}
 }
@@ -257,26 +239,28 @@ func TestBBoltCache_BulkRemove(t *testing.T) {
 }
 
 func BenchmarkCache_BulkRemove(b *testing.B) {
-	bc := storeBenchmark(b)
-	defer bc.Close()
-
-	var keyArray []string
-	for n := 0; n < b.N; n++ {
-		keyArray = append(keyArray, cacheKey+strconv.Itoa(n))
+	bc := setupBenchmark(b)
+	keys := make([]string, benchmarkKeyCount)
+	values := make([][]byte, benchmarkKeyCount)
+	for n := range benchmarkKeyCount {
+		suffix := strconv.Itoa(n)
+		keys[n] = cacheKey + suffix
+		values[n] = []byte("data" + suffix)
 	}
 
-	bc.Remove(keyArray...)
-
-	// it should be a cache miss
-	for n := 0; n < b.N; n++ {
-		_, ls, err := bc.Retrieve(cacheKey + strconv.Itoa(n))
-		if err == nil {
-			b.Errorf("expected key not found error for %s", cacheKey)
+	for b.Loop() {
+		b.StopTimer()
+		for n, key := range keys {
+			if err := bc.Store(key, values[n], time.Minute); err != nil {
+				b.Fatal(err)
+			}
 		}
-		if ls != status.LookupStatusKeyMiss {
-			b.Errorf("expected %s got %s", status.LookupStatusKeyMiss, ls)
+		b.StartTimer()
+		if err := bc.Remove(keys...); err != nil {
+			b.Fatal(err)
 		}
 	}
+	b.ReportMetric(benchmarkKeyCount, "keys/op")
 }
 
 func TestBBoltCache_Retrieve(t *testing.T) {
@@ -311,40 +295,21 @@ func TestBBoltCache_Retrieve(t *testing.T) {
 }
 
 func BenchmarkCache_Retrieve(b *testing.B) {
-	bc := storeBenchmark(b)
-	defer bc.Close()
+	bc := setupBenchmark(b)
+	if err := bc.Store(cacheKey, []byte("data"), time.Minute); err != nil {
+		b.Fatal(err)
+	}
 
-	for n := 0; n < b.N; n++ {
-		expected2 := `value for key [` + cacheKey + strconv.Itoa(n) + `] could not be deserialized from cache`
-
-		data, ls, err := bc.Retrieve(cacheKey + strconv.Itoa(n))
+	for b.Loop() {
+		data, ls, err := bc.Retrieve(cacheKey)
 		if err != nil {
-			b.Error(err)
+			b.Fatal(err)
 		}
-		if string(data) != "data"+strconv.Itoa(n) {
-			b.Errorf("wanted \"%s\". got \"%s\".", "data"+strconv.Itoa(n), data)
+		if string(data) != "data" {
+			b.Fatalf("wanted %q, got %q", "data", data)
 		}
 		if ls != status.LookupStatusHit {
-			b.Errorf("expected %s got %s", status.LookupStatusHit, ls)
-		}
-
-		// create a corrupted cache entry and expect an error
-		writeToBBolt(bc.dbh, bc.Config.BBolt.Bucket, cacheKey+strconv.Itoa(n), []byte("asdasdfasf"+strconv.Itoa(n)))
-
-		// it should fail to retrieve a value
-		data, ls, err = bc.Retrieve(cacheKey + strconv.Itoa(n))
-		if err == nil {
-			b.Errorf("expected error for %s", expected2)
-			bc.Close()
-		}
-		if err.Error() != expected2 {
-			b.Errorf("expected error '%s' got '%s'", expected2, err.Error())
-		}
-		if string(data) != "" {
-			b.Errorf("wanted \"%s\". got \"%s\".", "data"+strconv.Itoa(n), data)
-		}
-		if ls != status.LookupStatusKeyMiss {
-			b.Errorf("expected %s got %s", status.LookupStatusKeyMiss, ls)
+			b.Fatalf("expected %s, got %s", status.LookupStatusHit, ls)
 		}
 	}
 }

--- a/pkg/cache/filesystem/filesystem_test.go
+++ b/pkg/cache/filesystem/filesystem_test.go
@@ -17,7 +17,6 @@
 package filesystem
 
 import (
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -34,11 +33,13 @@ import (
 )
 
 const (
-	cacheProvider = "filesystem"
-	cacheKey      = "cacheKey"
+	cacheProvider     = "filesystem"
+	cacheKey          = "cacheKey"
+	benchmarkKeyCount = 10
 )
 
-func storeBenchmark(b *testing.B) CacheClient {
+func setupBenchmark(b *testing.B) *CacheClient {
+	b.Helper()
 	logger.SetLogger(logging.ConsoleLogger(level.Error))
 	dir := b.TempDir() + "/cache/" + cacheProvider
 	cacheConfig := co.Options{
@@ -47,20 +48,15 @@ func storeBenchmark(b *testing.B) CacheClient {
 	}
 	fc := NewCache(b.Name(), &cacheConfig)
 
-	err := fc.Connect()
-	if err != nil {
-		b.Error(err)
+	if err := fc.Connect(); err != nil {
+		b.Fatal(err)
 	}
-
-	// it should store a value
-	for n := 0; n < b.N; n++ {
-		err = fc.Store(cacheKey+strconv.Itoa(n), []byte("data"+strconv.Itoa(n)),
-			time.Duration(60)*time.Second)
-		if err != nil {
+	b.Cleanup(func() {
+		if err := fc.Close(); err != nil {
 			b.Error(err)
 		}
-	}
-	return *fc
+	})
+	return fc
 }
 
 func newCacheConfig(t *testing.T) co.Options {
@@ -142,8 +138,15 @@ func TestFilesystemCache_Store(t *testing.T) {
 }
 
 func BenchmarkCache_Store(b *testing.B) {
-	fc := storeBenchmark(b)
-	defer fc.Close()
+	fc := setupBenchmark(b)
+	n := 0
+	for b.Loop() {
+		suffix := strconv.Itoa(n)
+		if err := fc.Store(cacheKey+suffix, []byte("data"+suffix), time.Minute); err != nil {
+			b.Fatal(err)
+		}
+		n++
+	}
 }
 
 func TestFilesystemCache_Retrieve(t *testing.T) {
@@ -179,58 +182,21 @@ func TestFilesystemCache_Retrieve(t *testing.T) {
 }
 
 func BenchmarkCache_Retrieve(b *testing.B) {
-	fc := storeBenchmark(b)
-	defer fc.Close()
+	fc := setupBenchmark(b)
+	if err := fc.Store(cacheKey, []byte("data"), time.Minute); err != nil {
+		b.Fatal(err)
+	}
 
-	for n := 0; n < b.N; n++ {
-		expected1 := `value for key [` + cacheKey + strconv.Itoa(n) + `] not in cache`
-		expected2 := `value for key [` + cacheKey + strconv.Itoa(n) + `] could not be deserialized from cache`
-
-		data, ls, err := fc.Retrieve(cacheKey + strconv.Itoa(n))
+	for b.Loop() {
+		data, ls, err := fc.Retrieve(cacheKey)
 		if err != nil {
-			b.Error(err)
+			b.Fatal(err)
 		}
-		if string(data) != "data"+strconv.Itoa(n) {
-			b.Errorf("wanted \"%s\". got \"%s\".", "data"+strconv.Itoa(n), data)
+		if string(data) != "data" {
+			b.Fatalf("wanted %q, got %q", "data", data)
 		}
 		if ls != status.LookupStatusHit {
-			b.Errorf("expected %s got %s", status.LookupStatusHit, ls)
-		}
-
-		// this should now return error
-		data, ls, err = fc.Retrieve(cacheKey + strconv.Itoa(n))
-		if err == nil {
-			b.Errorf("expected error for %s", expected1)
-			fc.Close()
-		}
-		if err.Error() != expected1 {
-			b.Errorf("expected error '%s' got '%s'", expected1, err.Error())
-		}
-		if string(data) != "" {
-			b.Errorf("wanted \"%s\". got \"%s\".", "data"+strconv.Itoa(n), data)
-		}
-		if ls != status.LookupStatusKeyMiss {
-			b.Errorf("expected %s got %s", status.LookupStatusKeyMiss, ls)
-		}
-
-		filename := fc.getFileName(cacheKey + strconv.Itoa(n))
-		// create a corrupted cache entry and expect an error
-		os.WriteFile(filename, []byte("junk"), os.FileMode(0o777))
-
-		// it should fail to retrieve a value
-		data, ls, err = fc.Retrieve(cacheKey + strconv.Itoa(n))
-		if err == nil {
-			b.Errorf("expected error for %s", expected2)
-			fc.Close()
-		}
-		if err.Error() != expected2 {
-			b.Errorf("expected error '%s' got '%s'", expected2, err.Error())
-		}
-		if string(data) != "" {
-			b.Errorf("wanted \"%s\". got \"%s\".", "data"+strconv.Itoa(n), data)
-		}
-		if ls != status.LookupStatusKeyMiss {
-			b.Errorf("expected %s got %s", status.LookupStatusKeyMiss, ls)
+			b.Fatalf("expected %s, got %s", status.LookupStatusHit, ls)
 		}
 	}
 }
@@ -278,40 +244,15 @@ func TestFilesystemCache_Remove(t *testing.T) {
 }
 
 func BenchmarkCache_Remove(b *testing.B) {
-	fc := storeBenchmark(b)
-	defer fc.Close()
-
-	for n := 0; n < b.N; n++ {
-		var data []byte
-		data, ls, err := fc.Retrieve(cacheKey + strconv.Itoa(n))
-		if err != nil {
-			b.Error(err)
+	fc := setupBenchmark(b)
+	for b.Loop() {
+		b.StopTimer()
+		if err := fc.Store(cacheKey, []byte("data"), time.Minute); err != nil {
+			b.Fatal(err)
 		}
-		if string(data) != "data"+strconv.Itoa(n) {
-			b.Errorf("wanted \"%s\". got \"%s\"", "data"+strconv.Itoa(n), data)
-		}
-		if ls != status.LookupStatusHit {
-			b.Errorf("expected %s got %s", status.LookupStatusHit, ls)
-		}
-
-		fc.Remove(cacheKey + strconv.Itoa(n))
-
-		// this should now return error
-		data, ls, err = fc.Retrieve(cacheKey + strconv.Itoa(n))
-		expectederr := `value for key [` + cacheKey + strconv.Itoa(n) + `] not in cache`
-		if err == nil {
-			b.Errorf("expected error for %s", expectederr)
-			fc.Close()
-		}
-		if err.Error() != expectederr {
-			b.Errorf("expected error '%s' got '%s'", expectederr, err.Error())
-		}
-
-		if string(data) != "" {
-			b.Errorf("wanted \"%s\". got \"%s\".", "data", data)
-		}
-		if ls != status.LookupStatusKeyMiss {
-			b.Errorf("expected %s got %s", status.LookupStatusKeyMiss, ls)
+		b.StartTimer()
+		if err := fc.Remove(cacheKey); err != nil {
+			b.Fatal(err)
 		}
 	}
 }
@@ -359,24 +300,26 @@ func TestFilesystemCache_BulkRemove(t *testing.T) {
 }
 
 func BenchmarkCache_BulkRemove(b *testing.B) {
-	fc := storeBenchmark(b)
-	defer fc.Close()
-
-	var keyArray []string
-	for n := 0; n < b.N; n++ {
-		keyArray = append(keyArray, cacheKey+strconv.Itoa(n))
+	fc := setupBenchmark(b)
+	keys := make([]string, benchmarkKeyCount)
+	values := make([][]byte, benchmarkKeyCount)
+	for n := range benchmarkKeyCount {
+		suffix := strconv.Itoa(n)
+		keys[n] = cacheKey + suffix
+		values[n] = []byte("data" + suffix)
 	}
 
-	fc.Remove(keyArray...)
-
-	// it should be a cache miss
-	for n := 0; n < b.N; n++ {
-		_, ls, err := fc.Retrieve(cacheKey + strconv.Itoa(n))
-		if err == nil {
-			b.Errorf("expected key not found error for %s", cacheKey)
+	for b.Loop() {
+		b.StopTimer()
+		for n, key := range keys {
+			if err := fc.Store(key, values[n], time.Minute); err != nil {
+				b.Fatal(err)
+			}
 		}
-		if ls != status.LookupStatusKeyMiss {
-			b.Errorf("expected %s got %s", status.LookupStatusKeyMiss, ls)
+		b.StartTimer()
+		if err := fc.Remove(keys...); err != nil {
+			b.Fatal(err)
 		}
 	}
+	b.ReportMetric(benchmarkKeyCount, "keys/op")
 }

--- a/pkg/cache/memory/memory_test.go
+++ b/pkg/cache/memory/memory_test.go
@@ -30,8 +30,9 @@ import (
 )
 
 const (
-	provider = "memory"
-	cacheKey = "cacheKey"
+	provider          = "memory"
+	cacheKey          = "cacheKey"
+	benchmarkKeyCount = 10
 )
 
 type testReferenceObject struct{}
@@ -40,22 +41,20 @@ func (r *testReferenceObject) Size() int {
 	return 1
 }
 
-func storeBenchmark(b *testing.B) *Cache {
+func setupBenchmark(b *testing.B) *Cache {
+	b.Helper()
 	logger.SetLogger(logging.ConsoleLogger(level.Error))
 	cacheConfig := co.Options{Provider: provider, Index: &io.Options{ReapInterval: 0}}
 	mc := New(b.Name(), &cacheConfig)
 
-	err := mc.Connect()
-	if err != nil {
-		b.Error(err)
+	if err := mc.Connect(); err != nil {
+		b.Fatal(err)
 	}
-	// Note: don't close the cache here, callers use the cache after this for testing purposes
-	for n := 0; n < b.N; n++ {
-		err = mc.Store(cacheKey+strconv.Itoa(n), []byte("data"+strconv.Itoa(n)), time.Duration(60)*time.Second)
-		if err != nil {
+	b.Cleanup(func() {
+		if err := mc.Close(); err != nil {
 			b.Error(err)
 		}
-	}
+	})
 	return mc
 }
 
@@ -135,7 +134,15 @@ func TestCache_Store(t *testing.T) {
 }
 
 func BenchmarkCache_Store(b *testing.B) {
-	storeBenchmark(b)
+	mc := setupBenchmark(b)
+	n := 0
+	for b.Loop() {
+		suffix := strconv.Itoa(n)
+		if err := mc.Store(cacheKey+suffix, []byte("data"+suffix), time.Minute); err != nil {
+			b.Fatal(err)
+		}
+		n++
+	}
 }
 
 func TestCache_Retrieve(t *testing.T) {
@@ -172,19 +179,21 @@ func TestCache_Retrieve(t *testing.T) {
 }
 
 func BenchmarkCache_Retrieve(b *testing.B) {
-	mc := storeBenchmark(b)
+	mc := setupBenchmark(b)
+	if err := mc.Store(cacheKey, []byte("data"), time.Minute); err != nil {
+		b.Fatal(err)
+	}
 
-	for n := 0; n < b.N; n++ {
-		var data []byte
-		data, ls, err := mc.Retrieve(cacheKey + strconv.Itoa(n))
+	for b.Loop() {
+		data, ls, err := mc.Retrieve(cacheKey)
 		if err != nil {
-			b.Error(err)
+			b.Fatal(err)
 		}
-		if string(data) != "data"+strconv.Itoa(n) {
-			b.Errorf("wanted \"%s\". got \"%s\"", "data"+strconv.Itoa(n), data)
+		if string(data) != "data" {
+			b.Fatalf("wanted %q, got %q", "data", data)
 		}
 		if ls != status.LookupStatusHit {
-			b.Errorf("expected %s got %s", status.LookupStatusHit, ls)
+			b.Fatalf("expected %s, got %s", status.LookupStatusHit, ls)
 		}
 	}
 }
@@ -238,39 +247,15 @@ func TestCache_Remove(t *testing.T) {
 }
 
 func BenchmarkCache_Remove(b *testing.B) {
-	mc := storeBenchmark(b)
-
-	for n := 0; n < b.N; n++ {
-		var data []byte
-		data, ls, err := mc.Retrieve(cacheKey + strconv.Itoa(n))
-		if err != nil {
-			b.Error(err)
+	mc := setupBenchmark(b)
+	for b.Loop() {
+		b.StopTimer()
+		if err := mc.Store(cacheKey, []byte("data"), time.Minute); err != nil {
+			b.Fatal(err)
 		}
-		if string(data) != "data"+strconv.Itoa(n) {
-			b.Errorf("wanted \"%s\". got \"%s\"", "data"+strconv.Itoa(n), data)
-		}
-		if ls != status.LookupStatusHit {
-			b.Errorf("expected %s got %s", status.LookupStatusHit, ls)
-		}
-
-		mc.Remove(cacheKey + strconv.Itoa(n))
-
-		// this should now return error
-		data, ls, err = mc.Retrieve(cacheKey + strconv.Itoa(n))
-		expectederr := `key not found in cache` // cache.ErrKNF
-		if err == nil {
-			b.Errorf("expected error for %s", expectederr)
-			mc.Close()
-		}
-		if err.Error() != expectederr {
-			b.Errorf("expected error '%s' got '%s'", expectederr, err.Error())
-		}
-		if ls != status.LookupStatusKeyMiss {
-			b.Errorf("expected %s got %s", status.LookupStatusKeyMiss, ls)
-		}
-
-		if string(data) != "" {
-			b.Errorf("wanted \"%s\". got \"%s\".", "data", data)
+		b.StartTimer()
+		if err := mc.Remove(cacheKey); err != nil {
+			b.Fatal(err)
 		}
 	}
 }
@@ -317,23 +302,26 @@ func TestCache_BulkRemove(t *testing.T) {
 }
 
 func BenchmarkCache_BulkRemove(b *testing.B) {
-	var keyArray []string
-	for n := 0; n < b.N; n++ {
-		keyArray = append(keyArray, cacheKey+strconv.Itoa(n))
+	mc := setupBenchmark(b)
+	keys := make([]string, benchmarkKeyCount)
+	values := make([][]byte, benchmarkKeyCount)
+	for n := range benchmarkKeyCount {
+		suffix := strconv.Itoa(n)
+		keys[n] = cacheKey + suffix
+		values[n] = []byte("data" + suffix)
 	}
 
-	mc := storeBenchmark(b)
-
-	mc.Remove(keyArray...)
-
-	// it should be a cache miss
-	for n := 0; n < b.N; n++ {
-		_, ls, err := mc.Retrieve(cacheKey + strconv.Itoa(n))
-		if err == nil {
-			b.Errorf("expected key not found error for %s", cacheKey)
+	for b.Loop() {
+		b.StopTimer()
+		for n, key := range keys {
+			if err := mc.Store(key, values[n], time.Minute); err != nil {
+				b.Fatal(err)
+			}
 		}
-		if ls != status.LookupStatusKeyMiss {
-			b.Errorf("expected %s got %s", status.LookupStatusKeyMiss, ls)
+		b.StartTimer()
+		if err := mc.Remove(keys...); err != nil {
+			b.Fatal(err)
 		}
 	}
+	b.ReportMetric(benchmarkKeyCount, "keys/op")
 }

--- a/pkg/cache/redis/redis_test.go
+++ b/pkg/cache/redis/redis_test.go
@@ -33,21 +33,25 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 )
 
-const cacheKey = `cacheKey`
+const (
+	cacheKey          = `cacheKey`
+	benchmarkKeyCount = 10
+)
 
-func storeBenchmark(b *testing.B) (*CacheClient, func()) {
-	rc, close := setupRedisCache(clientTypeStandard)
-	err := rc.Connect()
-	if err != nil {
-		b.Error(err)
+func setupBenchmark(b *testing.B) *CacheClient {
+	b.Helper()
+	rc, closeServer := setupRedisCache(clientTypeStandard)
+	if err := rc.Connect(); err != nil {
+		closeServer()
+		b.Fatal(err)
 	}
-	for n := 0; n < b.N; n++ {
-		err := rc.Store(cacheKey+strconv.Itoa(n), []byte("data"+strconv.Itoa(n)), time.Duration(60)*time.Second)
-		if err != nil {
+	b.Cleanup(func() {
+		if err := rc.Close(); err != nil {
 			b.Error(err)
 		}
-	}
-	return rc, close
+		closeServer()
+	})
+	return rc
 }
 
 func setupRedisCache(ct clientType) (*CacheClient, func()) {
@@ -235,11 +239,15 @@ func TestRedisCache_Store(t *testing.T) {
 }
 
 func BenchmarkCache_Store(b *testing.B) {
-	rc, close := storeBenchmark(b)
-	if rc == nil {
-		b.Error("Could not create the redis cache")
+	rc := setupBenchmark(b)
+	n := 0
+	for b.Loop() {
+		suffix := strconv.Itoa(n)
+		if err := rc.Store(cacheKey+suffix, []byte("data"+suffix), time.Minute); err != nil {
+			b.Fatal(err)
+		}
+		n++
 	}
-	defer close()
 }
 
 func TestRedisCache_Retrieve(t *testing.T) {
@@ -269,19 +277,21 @@ func TestRedisCache_Retrieve(t *testing.T) {
 }
 
 func BenchmarkCache_Retrieve(b *testing.B) {
-	rc, close := storeBenchmark(b)
-	defer close()
+	rc := setupBenchmark(b)
+	if err := rc.Store(cacheKey, []byte("data"), time.Minute); err != nil {
+		b.Fatal(err)
+	}
 
-	for n := 0; n < b.N; n++ {
-		data, ls, err := rc.Retrieve(cacheKey + strconv.Itoa(n))
+	for b.Loop() {
+		data, ls, err := rc.Retrieve(cacheKey)
 		if err != nil {
-			b.Error(err)
+			b.Fatal(err)
 		}
 		if ls != status.LookupStatusHit {
-			b.Errorf("expected %s got %s", status.LookupStatusHit, ls)
+			b.Fatalf("expected %s, got %s", status.LookupStatusHit, ls)
 		}
-		if string(data) != "data"+strconv.Itoa(n) {
-			b.Errorf("wanted \"%s\". got \"%s\".", "data"+strconv.Itoa(n), data)
+		if string(data) != "data" {
+			b.Fatalf("wanted %q, got %q", "data", data)
 		}
 	}
 }
@@ -343,30 +353,15 @@ func TestCache_Remove(t *testing.T) {
 }
 
 func BenchmarkCache_Remove(b *testing.B) {
-	rc, close := storeBenchmark(b)
-	defer close()
-
-	for n := 0; n < b.N; n++ {
-		var data []byte
-		data, ls, err := rc.Retrieve(cacheKey + strconv.Itoa(n))
-		if err != nil {
-			b.Error(err)
+	rc := setupBenchmark(b)
+	for b.Loop() {
+		b.StopTimer()
+		if err := rc.Store(cacheKey, []byte("data"), time.Minute); err != nil {
+			b.Fatal(err)
 		}
-		if string(data) != "data"+strconv.Itoa(n) {
-			b.Errorf("wanted \"%s\". got \"%s\"", "data"+strconv.Itoa(n), data)
-		}
-		if ls != status.LookupStatusHit {
-			b.Errorf("expected %s got %s", status.LookupStatusHit, ls)
-		}
-
-		rc.Remove(cacheKey + strconv.Itoa(n))
-
-		_, ls, err = rc.Retrieve(cacheKey + strconv.Itoa(n))
-		if err == nil {
-			b.Errorf("expected key not found error for %s", cacheKey+strconv.Itoa(n))
-		}
-		if ls != status.LookupStatusKeyMiss {
-			b.Errorf("expected %s got %s", status.LookupStatusKeyMiss, ls)
+		b.StartTimer()
+		if err := rc.Remove(cacheKey); err != nil {
+			b.Fatal(err)
 		}
 	}
 }
@@ -412,24 +407,26 @@ func TestCache_BulkRemove(t *testing.T) {
 }
 
 func BenchmarkCache_BulkRemove(b *testing.B) {
-	rc, close := storeBenchmark(b)
-	defer close()
-
-	var keyArray []string
-	for n := 0; n < b.N; n++ {
-		keyArray = append(keyArray, cacheKey+strconv.Itoa(n))
+	rc := setupBenchmark(b)
+	keys := make([]string, benchmarkKeyCount)
+	values := make([][]byte, benchmarkKeyCount)
+	for n := range benchmarkKeyCount {
+		suffix := strconv.Itoa(n)
+		keys[n] = cacheKey + suffix
+		values[n] = []byte("data" + suffix)
 	}
 
-	rc.Remove(keyArray...)
-
-	// it should be a cache miss
-	for n := 0; n < b.N; n++ {
-		_, ls, err := rc.Retrieve(cacheKey + strconv.Itoa(n))
-		if err == nil {
-			b.Errorf("expected key not found error for %s", cacheKey)
+	for b.Loop() {
+		b.StopTimer()
+		for n, key := range keys {
+			if err := rc.Store(key, values[n], time.Minute); err != nil {
+				b.Fatal(err)
+			}
 		}
-		if ls != status.LookupStatusKeyMiss {
-			b.Errorf("expected %s got %s", status.LookupStatusKeyMiss, ls)
+		b.StartTimer()
+		if err := rc.Remove(keys...); err != nil {
+			b.Fatal(err)
 		}
 	}
+	b.ReportMetric(benchmarkKeyCount, "keys/op")
 }

--- a/pkg/proxy/engines/deltaproxycache_bench_test.go
+++ b/pkg/proxy/engines/deltaproxycache_bench_test.go
@@ -49,7 +49,7 @@ func BenchmarkDeltaProxyCache(b *testing.B) {
 		int(step.Seconds()), extr.Start.Unix(), extr.End.Unix(), queryReturnsOKNoLatency)
 
 	w := httptest.NewRecorder()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		client.QueryRangeHandler(w, r)
 	}
 }
@@ -79,7 +79,7 @@ func BenchmarkDeltaProxyCacheChunks(b *testing.B) {
 		int(step.Seconds()), extr.Start.Unix(), extr.End.Unix(), queryReturnsOKNoLatency)
 
 	w := httptest.NewRecorder()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		client.QueryRangeHandler(w, r)
 	}
 }

--- a/pkg/proxy/engines/objectproxycache_bench_test.go
+++ b/pkg/proxy/engines/objectproxycache_bench_test.go
@@ -49,7 +49,7 @@ func BenchmarkObjectProxyCache(b *testing.B) {
 	o.MaxTTL = time.Duration(15000) * time.Millisecond
 
 	w := httptest.NewRecorder()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		ObjectProxyCacheRequest(w, r)
 	}
 }
@@ -77,7 +77,7 @@ func BenchmarkObjectProxyCacheChunks(b *testing.B) {
 	o.MaxTTL = time.Duration(15000) * time.Millisecond
 
 	w := httptest.NewRecorder()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		ObjectProxyCacheRequest(w, r)
 	}
 }

--- a/pkg/proxy/engines/progressive_collapse_forwarder_test.go
+++ b/pkg/proxy/engines/progressive_collapse_forwarder_test.go
@@ -393,8 +393,10 @@ func BenchmarkPCFWrite(b *testing.B) {
 	b.SetBytes(int64(bufSize) * 1024)
 
 	for b.Loop() {
+		b.StopTimer()
 		pcf.dataIndex = 0
 		pcf.rIndex.Store(0)
+		b.StartTimer()
 		if _, err := pcf.Write(testBytes); err != nil {
 			b.Fatal(err)
 		}
@@ -434,8 +436,10 @@ func BenchmarkPCFWriteRead(b *testing.B) {
 	b.SetBytes(int64(bufSize) * 1024)
 
 	for b.Loop() {
+		b.StopTimer()
 		pcf.dataIndex = 0
 		pcf.rIndex.Store(0)
+		b.StartTimer()
 		if _, err := pcf.Write(testBytes); err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/proxy/engines/progressive_collapse_forwarder_test.go
+++ b/pkg/proxy/engines/progressive_collapse_forwarder_test.go
@@ -387,15 +387,17 @@ func BenchmarkPCFWrite(b *testing.B) {
 	bufSize := 32
 
 	testBytes := make([]byte, bufSize*1024)
-	l := b.N * bufSize * 1024
 	resp := &http.Response{}
+	pcf := NewPCF(resp, int64(len(testBytes))).(*progressiveCollapseForwarder)
 
-	pcf := NewPCF(resp, int64(l))
 	b.SetBytes(int64(bufSize) * 1024)
 
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		pcf.Write(testBytes)
+	for b.Loop() {
+		pcf.dataIndex = 0
+		pcf.rIndex.Store(0)
+		if _, err := pcf.Write(testBytes); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 
@@ -405,25 +407,17 @@ func BenchmarkPCFRead(b *testing.B) {
 	testBytes := make([]byte, bufSize*1024)
 	readBuf := make([]byte, bufSize*1024)
 
-	l := b.N * bufSize * 1024
 	resp := &http.Response{}
 
-	var readIndex uint64
-	var err error
-
-	pcf := NewPCF(resp, int64(l))
+	pcf := NewPCF(resp, int64(len(testBytes)))
 	b.SetBytes(int64(bufSize) * 1024)
-	for i := 0; i < b.N; i++ {
-		pcf.Write(testBytes)
+	if _, err := pcf.Write(testBytes); err != nil {
+		b.Fatal(err)
 	}
 
-	b.ResetTimer()
-
-	for n := 0; n < b.N; n++ {
-		_, err = pcf.IndexRead(readIndex, readBuf)
-		readIndex++
-		if err != nil {
-			break
+	for b.Loop() {
+		if _, err := pcf.IndexRead(0, readBuf); err != nil {
+			b.Fatal(err)
 		}
 	}
 }
@@ -434,23 +428,19 @@ func BenchmarkPCFWriteRead(b *testing.B) {
 	testBytes := make([]byte, bufSize*1024)
 	readBuf := make([]byte, bufSize*1024)
 
-	l := b.N * bufSize * 1024
 	resp := &http.Response{}
+	pcf := NewPCF(resp, int64(len(testBytes))).(*progressiveCollapseForwarder)
 
-	var readIndex uint64
-	var err error
-
-	pcf := NewPCF(resp, int64(l))
 	b.SetBytes(int64(bufSize) * 1024)
 
-	b.ResetTimer()
-
-	for n := 0; n < b.N; n++ {
-		pcf.Write(testBytes)
-		_, err = pcf.IndexRead(readIndex, readBuf)
-		readIndex++
-		if err != nil {
-			break
+	for b.Loop() {
+		pcf.dataIndex = 0
+		pcf.rIndex.Store(0)
+		if _, err := pcf.Write(testBytes); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := pcf.IndexRead(0, readBuf); err != nil {
+			b.Fatal(err)
 		}
 	}
 }

--- a/pkg/timeseries/dataset/dataset_test.go
+++ b/pkg/timeseries/dataset/dataset_test.go
@@ -1017,7 +1017,9 @@ func BenchmarkCropToRange(b *testing.B) {
 	}
 
 	for b.Loop() {
+		b.StopTimer()
 		ds.Results[0].SeriesList = seriesList
+		b.StartTimer()
 		ds.CropToRange(bmExt)
 	}
 }

--- a/pkg/timeseries/dataset/dataset_test.go
+++ b/pkg/timeseries/dataset/dataset_test.go
@@ -850,14 +850,11 @@ func TestStepNilTimeRangeQuery(t *testing.T) {
 }
 
 func BenchmarkMerge(b *testing.B) {
-	dss := make([]*DataSet, b.N*2)
-	for i := 0; i < b.N; i++ {
-		dss[i] = genBenchmarkDataset(10)
-		dss[i+1] = genBenchmarkDataset(10)
-	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i += 2 {
-		dss[i].Merge(true, dss[i+1])
+	left := genBenchmarkDataset(10)
+	right := genBenchmarkDataset(10)
+
+	for b.Loop() {
+		left.Merge(true, right)
 	}
 }
 
@@ -1012,16 +1009,15 @@ func TestDefaultSizeCropper(t *testing.T) {
 }
 
 func BenchmarkCropToRange(b *testing.B) {
-	dss := make([]*DataSet, b.N)
-	for i := 0; i < b.N; i++ {
-		dss[i] = genBenchmarkDataset(10)
-	}
+	ds := genBenchmarkDataset(10)
+	seriesList := ds.Results[0].SeriesList
 	bmExt := timeseries.Extent{
 		Start: time.Now().Add(time.Second * -750),
 		End:   time.Now().Add(time.Second * -250),
 	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		dss[i].CropToRange(bmExt)
+
+	for b.Loop() {
+		ds.Results[0].SeriesList = seriesList
+		ds.CropToRange(bmExt)
 	}
 }

--- a/pkg/timeseries/dataset/point_test.go
+++ b/pkg/timeseries/dataset/point_test.go
@@ -108,7 +108,7 @@ func TestPointEqual(t *testing.T) {
 func BenchmarkPointsAreEqual(b *testing.B) {
 	p1 := testPoints()[0]
 	p2 := testPoints()[1]
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		PointsAreEqual(p1, p2)
 	}
 }
@@ -131,7 +131,7 @@ func BenchmarkPointClone(b *testing.B) {
 		Size:   27,
 		Values: []any{1},
 	}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		p.Clone()
 	}
 }
@@ -195,10 +195,8 @@ func TestPointsSize(t *testing.T) {
 }
 
 func BenchmarkPointsSize(b *testing.B) {
-	for i := range b.N {
-		b.StopTimer()
-		pts := genTestPoints(i, 1000)
-		b.StartTimer()
+	pts := genTestPoints(0, 1000)
+	for b.Loop() {
 		pts.Size()
 	}
 }
@@ -300,7 +298,7 @@ func BenchmarkFindRange(b *testing.B) {
 	pts := genTestPoints(0, 10000) // Create a large dataset for meaningful benchmarks
 	startEpoch := epoch.Epoch(2500 * time.Second)
 	endEpoch := epoch.Epoch(7500 * time.Second)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = pts.findRange(startEpoch, endEpoch, 0, len(pts)-1)
 	}
 }

--- a/pkg/timeseries/extent_list_test.go
+++ b/pkg/timeseries/extent_list_test.go
@@ -1241,55 +1241,39 @@ var res any
 
 func BenchmarkCalculateDeltas(b *testing.B) {
 	bmTimeStep := time.Duration(10)
-	haves := make([]ExtentList, b.N)
-	wants := make([]Extent, b.N)
-	for i := 0; i < b.N; i++ {
-		el, s, e := genBenchmarkExtentList(10, bmTimeStep)
-		haves[i] = el
-		wants[i] = Extent{
-			Start: s.Add(2 * bmTimeStep),
-			End:   e.Add(-2 * bmTimeStep),
-		}
+	have, s, e := genBenchmarkExtentList(10, bmTimeStep)
+	want := Extent{
+		Start: s.Add(2 * bmTimeStep),
+		End:   e.Add(-2 * bmTimeStep),
 	}
-	b.ResetTimer()
+	needs := ExtentList{want}
 	var r ExtentList
-	for i := 0; i < b.N; i++ {
-		r = haves[i].CalculateDeltas(ExtentList{wants[i]}, bmTimeStep)
+	for b.Loop() {
+		r = have.CalculateDeltas(needs, bmTimeStep)
 	}
 	res = r
 }
 
 func BenchmarkCrop(b *testing.B) {
 	bmTimeStep := time.Duration(10)
-	haves := make([]ExtentList, b.N)
-	wants := make([]Extent, b.N)
-	for i := 0; i < b.N; i++ {
-		el, s, e := genBenchmarkExtentList(10, bmTimeStep)
-		haves[i] = el
-		wants[i] = Extent{
-			Start: s.Add(2 * bmTimeStep),
-			End:   e.Add(-2 * bmTimeStep),
-		}
+	have, s, e := genBenchmarkExtentList(10, bmTimeStep)
+	want := Extent{
+		Start: s.Add(2 * bmTimeStep),
+		End:   e.Add(-2 * bmTimeStep),
 	}
-	b.ResetTimer()
 	var r ExtentList
-	for i := 0; i < b.N; i++ {
-		r = haves[i].Crop(wants[i])
+	for b.Loop() {
+		r = have.Crop(want)
 	}
 	res = r
 }
 
 func BenchmarkCompress(b *testing.B) {
 	bmTimeStep := time.Duration(10)
-	haves := make([]ExtentList, b.N)
-	for i := 0; i < b.N; i++ {
-		el, _, _ := genBenchmarkExtentList(10, bmTimeStep)
-		haves[i] = el
-	}
-	b.ResetTimer()
+	have, _, _ := genBenchmarkExtentList(10, bmTimeStep)
 	var r ExtentList
-	for i := 0; i < b.N; i++ {
-		r = haves[i].Compress(bmTimeStep)
+	for b.Loop() {
+		r = have.Compress(bmTimeStep)
 	}
 	res = r
 }

--- a/pkg/util/strings/strings_test.go
+++ b/pkg/util/strings/strings_test.go
@@ -62,7 +62,7 @@ func TestUnique(t *testing.T) {
 
 func BenchmarkUnique(b *testing.B) {
 	initial := []string{"test", "test", "test1", "test2", "test2", "test", "test3"}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		Unique(initial)
 	}
 }


### PR DESCRIPTION
## Description

Modernizes the handwritten serial benchmarks to use Go's `b.Loop()` API.

Cache benchmarks now separate setup from measured operations, close their clients, and use fixed 10-key batches for bulk removal. Benchmarks with mutable state reset or reuse inputs without allocating from `b.N`; this also fixes the old merge benchmark's half-iteration loop and includes the remaining `range b.N` points-size benchmark.

Fixes #1061

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Optimization
- [x] Test coverage
- [ ] Documentation
- [ ] Infrastructure

## AI Disclosure

- [ ] This contribution DOES NOT include AI-generated changes
- [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.