### PR TITLE
feat: configure backend CORS policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Trickster is a fully-featured HTTP Reverse Proxy Cache for HTTP applications lik
 * [Supports TLS](./docs/tls.md) and HTTP/2 for frontend termination and backend origination
 * Offers several options for a [caching layer](./docs/caches.md), including in-memory, filesystem, Redis and bbolt
 * [Highly customizable](./docs/configuring.md), using simple yaml configuration settings, [down to the HTTP Path](./docs/paths.md)
+* Per-backend and per-path [CORS response policies](./docs/cors.md)
 * Built-in Prometheus [metrics](./docs/metrics.md) and customizable [Health Check](./docs/health.md) Endpoints for end-to-end monitoring
 * [Negative Caching](./docs/negative-caching.md) to prevent domino effect outages
 * High-performance [Collapsed Forwarding](./docs/collapsed-forwarding.md)

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -24,7 +24,7 @@ Refer to [examples/conf/example.full.yaml](../examples/conf/example.full.yaml) f
 
 Trickster supports Environment variable substitution in its configuration file where sensitive information is expected.
 - Supported via the following fields:
-  - `caches[*].redis.password`, `backends[*].healthcheck.headers`, `backends[*].paths[*].request_headers`, `backends[*].paths[*].request_params`, `backends[*].paths[*].response_headers`
+  - `caches[*].redis.password`, `backends[*].healthcheck.headers`, `backends[*].cors.headers`, `backends[*].paths[*].cors.headers`, `backends[*].paths[*].request_headers`, `backends[*].paths[*].request_params`, `backends[*].paths[*].response_headers`
 
 Usage `${ENV_VAR_NAME}`, example:
 ```yaml

--- a/docs/cors.md
+++ b/docs/cors.md
@@ -1,0 +1,78 @@
+# Cross-Origin Resource Sharing
+
+Trickster can control Cross-Origin Resource Sharing (CORS) response headers for each backend. A path can override its backend's policy by providing its own `cors` block.
+
+For compatibility, a backend or path without a `cors` block uses Trickster's legacy behavior: `Access-Control-Allow-Origin` is set to `*`, while other CORS headers from the origin are left unchanged.
+
+## Modes
+
+| Mode | Behavior |
+| --- | --- |
+| `preserve` | Return the origin's `Access-Control-*` response headers unchanged. |
+| `merge` | Preserve origin CORS headers, then apply the configured headers as overrides. |
+| `replace` | Remove all origin `Access-Control-*` response headers, then apply the configured headers. |
+| `disable` | Remove all origin `Access-Control-*` response headers. This mode cannot include a `headers` block. |
+
+When `preserve` or `merge` is configured, Trickster includes the request's `Origin` header in the cache key. This prevents an origin-specific CORS response from being served to a request from another origin.
+
+## Backend Configuration
+
+The following example replaces the origin's CORS headers with a fixed policy:
+
+```yaml
+backends:
+  default:
+    provider: reverseproxycache
+    origin_url: http://api.example.com
+    cors:
+      mode: replace
+      headers:
+        Access-Control-Allow-Origin: https://dashboard.example.com
+        Access-Control-Allow-Credentials: "true"
+        Access-Control-Expose-Headers: X-Trickster-Result
+```
+
+To preserve the origin's CORS headers while replacing selected values, use `merge`:
+
+```yaml
+cors:
+  mode: merge
+  headers:
+    Access-Control-Allow-Origin: https://trickster.example.com
+```
+
+To return all origin CORS headers unchanged, use `preserve` without a `headers` map:
+
+```yaml
+cors:
+  mode: preserve
+```
+
+To disable CORS headers, use `disable` without a `headers` block:
+
+```yaml
+cors:
+  mode: disable
+```
+
+Only `Access-Control-*` response headers can be configured in a `cors.headers` map. As with path `response_headers`, prefix a header name with `-` to remove that header in `merge` mode or `+` to append another value.
+
+## Path Overrides
+
+A path-level policy replaces the backend policy for requests matching that path:
+
+```yaml
+backends:
+  default:
+    provider: reverseproxycache
+    origin_url: http://api.example.com
+    cors:
+      mode: preserve
+    paths:
+      - path: /private/
+        match_type: prefix
+        cors:
+          mode: disable
+```
+
+For an ALB, user router, or rule backend that dispatches to another backend internally, the policy on the client-facing backend and path takes precedence. Internal routing therefore cannot change the CORS policy associated with the public Trickster route.

--- a/docs/paths.md
+++ b/docs/paths.md
@@ -152,6 +152,9 @@ backends:
         # before replying to the client
         response_headers:
           Expires: '-1'
+        # a path-level CORS policy overrides the backend policy; see docs/cors.md
+        cors:
+          mode: preserve
       - path: /images/
         methods:
           - GET

--- a/examples/conf/example.full.yaml
+++ b/examples/conf/example.full.yaml
@@ -272,6 +272,14 @@ backends:
 #     # Options are standard, x, both, or none; default is standard
 #     forwarded_headers: standard
 
+#     # cors controls Access-Control-* response headers for this backend. When omitted, Trickster retains
+#     # its legacy Access-Control-Allow-Origin: '*' behavior. Modes are preserve, merge, replace, and disable.
+#     # See /docs/cors.md for mode behavior, path overrides, and cache-key handling.
+#     cors:
+#       mode: replace
+#       headers:
+#         Access-Control-Allow-Origin: https://dashboard.example.com
+
 #     # cache_key_prefix defines the prefix this backend appends to cache keys. When using a shared cache like Redis,
 #     # this can help partition multiple trickster instances that may have the same same hostname or ip address (the default prefix)
 #     cache_key_prefix: example
@@ -468,6 +476,8 @@ backends:
 #         response_headers:
 #           Cache-Control: no-cache                  # attach these headers to the response down to the client
 #           Content-Type: text/plain
+#         cors:                                      # overrides the backend CORS policy for this path
+#           mode: disable                            # remove all Access-Control-* response headers
 #       - path: /example/
 #         methods: [ GET, POST ]
 #         collapsed_forwarding: progressive    # see /docs/collapsed_forwarding.md

--- a/pkg/backends/options/options.go
+++ b/pkg/backends/options/options.go
@@ -38,6 +38,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/config/types"
 	tro "github.com/trickstercache/trickster/v2/pkg/observability/tracing/options"
 	autho "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/options"
+	corso "github.com/trickstercache/trickster/v2/pkg/proxy/cors/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request/rewriter"
@@ -166,6 +167,8 @@ type Options struct {
 
 	// ForwardedHeaders indicates the class of 'Forwarded' header to attach to upstream requests
 	ForwardedHeaders string `yaml:"forwarded_headers,omitempty"`
+	// CORS configures downstream CORS response headers for this backend
+	CORS *corso.Options `yaml:"cors,omitempty"`
 
 	// IsDefault indicates if this is the d.Default backend for any request not matching a configured route
 	IsDefault bool `yaml:"is_default,omitempty"`
@@ -300,6 +303,9 @@ func (o *Options) Clone() *Options {
 	if o.TLS != nil {
 		out.TLS = o.TLS.Clone()
 	}
+	if o.CORS != nil {
+		out.CORS = o.CORS.Clone()
+	}
 
 	if o.FastForwardPath != nil {
 		out.FastForwardPath = o.FastForwardPath.Clone()
@@ -350,6 +356,11 @@ func (o *Options) Validate() (bool, error) {
 
 	if len(o.Paths) > 0 {
 		if err := o.Paths.Validate(); err != nil {
+			return false, err
+		}
+	}
+	if o.CORS != nil {
+		if _, err := o.CORS.Validate(); err != nil {
 			return false, err
 		}
 	}
@@ -622,6 +633,11 @@ func (o *Options) Initialize(name string) error {
 	}
 	if o.TLS != nil {
 		if err := o.TLS.Initialize(""); err != nil {
+			return err
+		}
+	}
+	if o.CORS != nil {
+		if err := o.CORS.Initialize(""); err != nil {
 			return err
 		}
 	}

--- a/pkg/backends/options/options_test.go
+++ b/pkg/backends/options/options_test.go
@@ -31,6 +31,7 @@ import (
 	co "github.com/trickstercache/trickster/v2/pkg/cache/options"
 	tro "github.com/trickstercache/trickster/v2/pkg/observability/tracing/options"
 	autho "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/options"
+	corso "github.com/trickstercache/trickster/v2/pkg/proxy/cors/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
 	rwopts "github.com/trickstercache/trickster/v2/pkg/proxy/request/rewriter/options"
@@ -69,6 +70,50 @@ func TestNew(t *testing.T) {
 	if o.FetchConcurrencyLimit != DefaultFetchConcurrencyLimit {
 		t.Errorf("expected FetchConcurrencyLimit=%d, got %d",
 			DefaultFetchConcurrencyLimit, o.FetchConcurrencyLimit)
+	}
+}
+
+func TestCORSOptionsYAML(t *testing.T) {
+	o, err := fromYAML(`
+backends:
+  test:
+    provider: reverseproxycache
+    origin_url: http://example.com
+    cors:
+      mode: merge
+      headers:
+        Access-Control-Allow-Origin: https://trickster.example.com
+    paths:
+      - path: /private
+        cors:
+          mode: disable
+`, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := o.Initialize("test"); err != nil {
+		t.Fatal(err)
+	}
+	if o.CORS == nil || o.CORS.Mode != corso.ModeMerge {
+		t.Fatalf("backend CORS mode = %v, want %q", o.CORS, corso.ModeMerge)
+	}
+	if got := o.CORS.Headers[headers.NameAllowOrigin]; got != "https://trickster.example.com" {
+		t.Fatalf("backend allow origin = %q", got)
+	}
+	if len(o.Paths) != 1 || o.Paths[0].CORS == nil || o.Paths[0].CORS.Mode != corso.ModeDisable {
+		t.Fatalf("path CORS = %v, want disable policy", o.Paths)
+	}
+	if o.Paths[0].CORS.Headers != nil {
+		t.Fatalf("disabled path CORS headers = %v, want nil", o.Paths[0].CORS.Headers)
+	}
+	if ok, err := o.Validate(); !ok || err != nil {
+		t.Fatalf("Validate() = %v, %v", ok, err)
+	}
+
+	clone := o.Clone()
+	clone.CORS.Headers[headers.NameAllowOrigin] = "https://other.example.com"
+	if o.CORS.Headers[headers.NameAllowOrigin] != "https://trickster.example.com" {
+		t.Fatal("clone mutated backend CORS headers")
 	}
 }
 

--- a/pkg/proxy/cors/cors.go
+++ b/pkg/proxy/cors/cors.go
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package cors applies backend and path CORS policies to downstream responses.
+package cors
+
+import (
+	"net/http"
+	"strings"
+
+	corso "github.com/trickstercache/trickster/v2/pkg/proxy/cors/options"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+)
+
+const corsHeaderPrefix = "access-control-"
+
+// Apply applies a CORS policy to a response header collection.
+func Apply(h http.Header, o *corso.Options) {
+	if h == nil {
+		return
+	}
+	if o == nil {
+		o = corso.Legacy()
+	}
+	if o.IsLegacy() {
+		deleteHeader(h, headers.NameAllowOrigin)
+		headers.AddResponseHeaders(h)
+		return
+	}
+	mode := corso.Mode(strings.ToLower(string(o.Mode)))
+	if mode == "" {
+		mode = corso.ModeReplace
+	}
+	if mode == corso.ModePreserve {
+		return
+	}
+	if mode == corso.ModeReplace || mode == corso.ModeDisable {
+		for name := range h {
+			if strings.HasPrefix(strings.ToLower(name), corsHeaderPrefix) {
+				delete(h, name)
+			}
+		}
+	}
+	if mode == corso.ModeDisable {
+		return
+	}
+	updateHeaders(h, o.Headers)
+}
+
+func updateHeaders(h http.Header, updates map[string]string) {
+	for configuredName, value := range updates {
+		if configuredName == "" {
+			continue
+		}
+		operation := byte(0)
+		name := configuredName
+		if name[0] == '+' || name[0] == '-' {
+			operation = name[0]
+			name = name[1:]
+		}
+		if name == "" {
+			continue
+		}
+		switch operation {
+		case '-':
+			deleteHeader(h, name)
+		case '+':
+			values := takeHeader(h, name)
+			for _, existing := range values {
+				h.Add(name, existing)
+			}
+			h.Add(name, value)
+		default:
+			deleteHeader(h, name)
+			h.Set(name, value)
+		}
+	}
+}
+
+func takeHeader(h http.Header, name string) []string {
+	var values []string
+	for existing, existingValues := range h {
+		if strings.EqualFold(existing, name) {
+			values = append(values, existingValues...)
+			delete(h, existing)
+		}
+	}
+	return values
+}
+
+func deleteHeader(h http.Header, name string) {
+	for existing := range h {
+		if strings.EqualFold(existing, name) {
+			delete(h, existing)
+		}
+	}
+}
+
+// ResponseWriter applies a CORS policy before the final response headers are written.
+type ResponseWriter interface {
+	http.ResponseWriter
+	Finalize()
+}
+
+// Wrap returns a response writer that applies the policy before response headers are written.
+func Wrap(w http.ResponseWriter, o *corso.Options) ResponseWriter {
+	return &responseWriter{ResponseWriter: w, options: o}
+}
+
+type responseWriter struct {
+	http.ResponseWriter
+	options     *corso.Options
+	wroteHeader bool
+	applied     bool
+}
+
+func (w *responseWriter) WriteHeader(code int) {
+	if w.wroteHeader {
+		return
+	}
+	if code >= 100 && code < 200 {
+		w.ResponseWriter.WriteHeader(code)
+		return
+	}
+	w.wroteHeader = true
+	w.apply()
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *responseWriter) Write(p []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	// The selected handler owns content type and contextual escaping; this wrapper
+	// must forward reverse-proxied response bodies byte-for-byte.
+	return w.ResponseWriter.Write(p)
+}
+
+// Finalize applies the policy when a handler returns without explicitly writing a response.
+func (w *responseWriter) Finalize() {
+	if !w.wroteHeader {
+		w.apply()
+	}
+}
+
+func (w *responseWriter) apply() {
+	if w.applied {
+		return
+	}
+	w.applied = true
+	Apply(w.Header(), w.options)
+}
+
+func (w *responseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}

--- a/pkg/proxy/cors/cors_test.go
+++ b/pkg/proxy/cors/cors_test.go
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cors
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/config/types"
+	corso "github.com/trickstercache/trickster/v2/pkg/proxy/cors/options"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+)
+
+func TestApply(t *testing.T) {
+	tests := []struct {
+		name       string
+		options    *corso.Options
+		wantOrigin string
+		wantCreds  string
+		wantExpose string
+	}{
+		{
+			name:       "legacy wildcard preserves other headers",
+			wantOrigin: "*",
+			wantCreds:  "true",
+		},
+		{
+			name:       "preserve",
+			options:    &corso.Options{Mode: corso.ModePreserve},
+			wantOrigin: "https://origin.example.com",
+			wantCreds:  "true",
+		},
+		{
+			name: "merge",
+			options: &corso.Options{Mode: corso.ModeMerge, Headers: types.EnvStringMap{
+				headers.NameAllowOrigin:             "https://trickster.example.com",
+				"-Access-Control-Allow-Credentials": "",
+				"Access-Control-Expose-Headers":     "X-Trickster-Result",
+			}},
+			wantOrigin: "https://trickster.example.com",
+			wantExpose: "X-Trickster-Result",
+		},
+		{
+			name: "replace",
+			options: &corso.Options{Mode: corso.ModeReplace, Headers: types.EnvStringMap{
+				headers.NameAllowOrigin: "https://trickster.example.com",
+			}},
+			wantOrigin: "https://trickster.example.com",
+		},
+		{
+			name:    "replace empty disables cors",
+			options: &corso.Options{Mode: corso.ModeReplace},
+		},
+		{
+			name:    "disable",
+			options: &corso.Options{Mode: corso.ModeDisable},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := http.Header{
+				headers.NameAllowOrigin:            {"https://origin.example.com"},
+				"access-control-allow-credentials": {"true"},
+				"X-Unrelated":                      {"keep"},
+			}
+			Apply(h, tc.options)
+			if got := h.Get(headers.NameAllowOrigin); got != tc.wantOrigin {
+				t.Errorf("Access-Control-Allow-Origin = %q, want %q", got, tc.wantOrigin)
+			}
+			if got := headerValue(h, "Access-Control-Allow-Credentials"); got != tc.wantCreds {
+				t.Errorf("Access-Control-Allow-Credentials = %q, want %q", got, tc.wantCreds)
+			}
+			if got := h.Get("Access-Control-Expose-Headers"); got != tc.wantExpose {
+				t.Errorf("Access-Control-Expose-Headers = %q, want %q", got, tc.wantExpose)
+			}
+			if got := h.Get("X-Unrelated"); got != "keep" {
+				t.Errorf("X-Unrelated = %q, want keep", got)
+			}
+		})
+	}
+}
+
+func headerValue(h http.Header, name string) string {
+	for k, values := range h {
+		if http.CanonicalHeaderKey(k) == http.CanonicalHeaderKey(name) && len(values) > 0 {
+			return values[0]
+		}
+	}
+	return ""
+}
+
+func TestResponseWriterAppliesPolicyOnImplicitStatus(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	w := Wrap(recorder, &corso.Options{Mode: corso.ModeReplace})
+	w.Header().Set(headers.NameAllowOrigin, "https://origin.example.com")
+	if _, err := w.Write([]byte("body")); err != nil {
+		t.Fatal(err)
+	}
+	if got := recorder.Result().Header.Get(headers.NameAllowOrigin); got != "" {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want empty", got)
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+}
+
+func TestResponseWriterFinalizesWithoutWrite(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	w := Wrap(recorder, &corso.Options{Mode: corso.ModeReplace})
+	w.Header().Set(headers.NameAllowOrigin, "https://origin.example.com")
+	w.Finalize()
+	if got := recorder.Result().Header.Get(headers.NameAllowOrigin); got != "" {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want empty", got)
+	}
+}
+
+func TestResponseWriterAllowsInformationalBeforeFinalStatus(t *testing.T) {
+	w := &statusResponseWriter{header: make(http.Header)}
+	cw := Wrap(w, &corso.Options{Mode: corso.ModeReplace, Headers: types.EnvStringMap{
+		headers.NameAllowOrigin: "https://trickster.example.com",
+	}})
+	cw.WriteHeader(http.StatusEarlyHints)
+	cw.WriteHeader(http.StatusNoContent)
+
+	if len(w.codes) != 2 || w.codes[0] != http.StatusEarlyHints || w.codes[1] != http.StatusNoContent {
+		t.Fatalf("status codes = %v, want [%d %d]", w.codes,
+			http.StatusEarlyHints, http.StatusNoContent)
+	}
+	if got := w.header.Get(headers.NameAllowOrigin); got != "https://trickster.example.com" {
+		t.Fatalf("Access-Control-Allow-Origin = %q", got)
+	}
+}
+
+type statusResponseWriter struct {
+	header http.Header
+	codes  []int
+}
+
+func (w *statusResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *statusResponseWriter) WriteHeader(code int) {
+	w.codes = append(w.codes, code)
+}
+
+func (w *statusResponseWriter) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func TestResponseWriterUnwrap(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	w := Wrap(recorder, nil)
+	unwrapper, ok := w.(interface{ Unwrap() http.ResponseWriter })
+	if !ok || unwrapper.Unwrap() != recorder {
+		t.Fatal("wrapped response writer must expose its underlying writer")
+	}
+}

--- a/pkg/proxy/cors/options/options.go
+++ b/pkg/proxy/cors/options/options.go
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package options defines configurable CORS response-header policies.
+package options
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"strings"
+
+	"github.com/trickstercache/trickster/v2/pkg/config/types"
+	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
+	"golang.org/x/net/http/httpguts"
+)
+
+// Mode identifies how Trickster combines origin and configured CORS headers.
+type Mode string
+
+const (
+	// ModePreserve leaves origin-provided CORS headers unchanged.
+	ModePreserve Mode = "preserve"
+	// ModeMerge preserves origin-provided CORS headers and applies configured overrides.
+	ModeMerge Mode = "merge"
+	// ModeReplace removes origin-provided CORS headers before applying configured headers.
+	ModeReplace Mode = "replace"
+	// ModeDisable removes all origin-provided CORS headers.
+	ModeDisable Mode = "disable"
+)
+
+const corsHeaderPrefix = "access-control-"
+
+// Options defines a CORS response-header policy.
+type Options struct {
+	Mode    Mode               `yaml:"mode,omitempty"`
+	Headers types.EnvStringMap `yaml:"headers,omitempty"`
+	legacy  bool
+}
+
+var _ types.ConfigOptions[Options] = &Options{}
+
+// New returns the default replace policy.
+func New() *Options {
+	return &Options{Mode: ModeReplace}
+}
+
+// Legacy returns the backwards-compatible wildcard CORS policy.
+func Legacy() *Options {
+	return &Options{legacy: true}
+}
+
+// Clone returns an exact copy of the options.
+func (o *Options) Clone() *Options {
+	if o == nil {
+		return nil
+	}
+	out := pointers.Clone(o)
+	out.Headers = maps.Clone(o.Headers)
+	return out
+}
+
+// Initialize normalizes configured values.
+func (o *Options) Initialize(_ string) error {
+	if o == nil {
+		return nil
+	}
+	o.Mode = Mode(strings.ToLower(string(o.Mode)))
+	if o.Mode == "" {
+		o.Mode = ModeReplace
+	}
+	if o.Headers == nil && o.Mode != ModeDisable {
+		o.Headers = make(types.EnvStringMap)
+	}
+	return nil
+}
+
+// Validate validates the CORS mode and configured response headers.
+func (o *Options) Validate() (bool, error) {
+	if o == nil {
+		return true, nil
+	}
+	mode := Mode(strings.ToLower(string(o.Mode)))
+	if mode == "" {
+		mode = ModeReplace
+	}
+	switch mode {
+	case ModePreserve, ModeMerge, ModeReplace, ModeDisable:
+	default:
+		return false, fmt.Errorf("invalid CORS mode: %s", o.Mode)
+	}
+	if mode == ModePreserve && len(o.Headers) > 0 {
+		return false, errors.New("CORS headers cannot be configured in preserve mode")
+	}
+	if mode == ModeDisable && o.Headers != nil {
+		return false, errors.New("CORS headers cannot be configured in disable mode")
+	}
+	seen := make(map[string]string, len(o.Headers))
+	for configuredName, value := range o.Headers {
+		operation, name, ok := configuredHeaderName(configuredName)
+		if !ok || !httpguts.ValidHeaderFieldName(name) ||
+			!strings.HasPrefix(strings.ToLower(name), corsHeaderPrefix) {
+			return false, fmt.Errorf("invalid CORS response header: %s", configuredName)
+		}
+		if operation != '-' && !httpguts.ValidHeaderFieldValue(value) {
+			return false, fmt.Errorf("invalid value for CORS response header: %s", configuredName)
+		}
+		normalized := strings.ToLower(name)
+		if previous, ok := seen[normalized]; ok {
+			return false, fmt.Errorf("duplicate CORS response header: %s and %s",
+				previous, configuredName)
+		}
+		seen[normalized] = configuredName
+	}
+	return true, nil
+}
+
+func configuredHeaderName(configuredName string) (byte, string, bool) {
+	if configuredName == "" {
+		return 0, "", false
+	}
+	var operation byte
+	name := configuredName
+	if name[0] == '+' || name[0] == '-' {
+		operation = name[0]
+		name = name[1:]
+	}
+	if name == "" || name[0] == '+' || name[0] == '-' {
+		return 0, "", false
+	}
+	return operation, name, true
+}
+
+// PreservesOrigin reports whether origin-provided CORS headers remain in the response.
+func (o *Options) PreservesOrigin() bool {
+	if o == nil || o.legacy {
+		return false
+	}
+	mode := Mode(strings.ToLower(string(o.Mode)))
+	return mode == ModePreserve || mode == ModeMerge
+}
+
+// IsLegacy reports whether this is the backwards-compatible implicit policy.
+func (o *Options) IsLegacy() bool {
+	return o != nil && o.legacy
+}
+
+// UnmarshalYAML applies defaults before decoding a CORS configuration block.
+func (o *Options) UnmarshalYAML(unmarshal func(any) error) error {
+	type loadOptions Options
+	lo := loadOptions(*(New()))
+	if err := unmarshal(&lo); err != nil {
+		return err
+	}
+	*o = Options(lo)
+	return nil
+}

--- a/pkg/proxy/cors/options/options_test.go
+++ b/pkg/proxy/cors/options/options_test.go
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package options
+
+import (
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/config/types"
+	"gopkg.in/yaml.v2"
+)
+
+func TestOptionsInitialize(t *testing.T) {
+	o := &Options{Mode: "MERGE"}
+	if err := o.Initialize(""); err != nil {
+		t.Fatal(err)
+	}
+	if o.Mode != ModeMerge {
+		t.Fatalf("Mode = %q, want %q", o.Mode, ModeMerge)
+	}
+	if o.Headers == nil {
+		t.Fatal("Headers must be initialized")
+	}
+}
+
+func TestOptionsValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		options *Options
+		wantErr bool
+	}{
+		{name: "preserve", options: &Options{Mode: ModePreserve}},
+		{name: "merge override", options: &Options{Mode: ModeMerge,
+			Headers: types.EnvStringMap{"Access-Control-Allow-Origin": "https://example.com"}}},
+		{name: "merge delete", options: &Options{Mode: ModeMerge,
+			Headers: types.EnvStringMap{"-Access-Control-Allow-Credentials": ""}}},
+		{name: "replace empty", options: &Options{Mode: ModeReplace}},
+		{name: "disable", options: &Options{Mode: ModeDisable}},
+		{name: "disable with empty headers", options: &Options{Mode: ModeDisable,
+			Headers: types.EnvStringMap{}}, wantErr: true},
+		{name: "disable with headers", options: &Options{Mode: ModeDisable,
+			Headers: types.EnvStringMap{"Access-Control-Allow-Origin": "*"}}, wantErr: true},
+		{name: "default mode", options: &Options{}},
+		{name: "invalid mode", options: &Options{Mode: "append"}, wantErr: true},
+		{name: "preserve ignores headers", options: &Options{Mode: ModePreserve,
+			Headers: types.EnvStringMap{"Access-Control-Allow-Origin": "*"}}, wantErr: true},
+		{name: "non cors header", options: &Options{Mode: ModeReplace,
+			Headers: types.EnvStringMap{"X-Other": "value"}}, wantErr: true},
+		{name: "double operation", options: &Options{Mode: ModeMerge,
+			Headers: types.EnvStringMap{"+-Access-Control-Allow-Origin": "*"}}, wantErr: true},
+		{name: "invalid field name", options: &Options{Mode: ModeMerge,
+			Headers: types.EnvStringMap{"Access-Control-Allow Origin": "*"}}, wantErr: true},
+		{name: "invalid field value", options: &Options{Mode: ModeMerge,
+			Headers: types.EnvStringMap{"Access-Control-Allow-Origin": "*\r\nX-Injected: true"}},
+			wantErr: true},
+		{name: "case insensitive duplicate", options: &Options{Mode: ModeMerge,
+			Headers: types.EnvStringMap{
+				"Access-Control-Allow-Origin":  "https://first.example.com",
+				"+access-control-allow-origin": "https://second.example.com",
+			}}, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.options.Validate()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestOptionsUnmarshalYAMLDisableTracksHeadersBlock(t *testing.T) {
+	tests := []struct {
+		name        string
+		yaml        string
+		wantHeaders bool
+		wantErr     bool
+	}{
+		{name: "without headers", yaml: "mode: disable\n"},
+		{name: "with empty headers", yaml: "mode: disable\nheaders: {}\n",
+			wantHeaders: true, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var o Options
+			if err := yaml.Unmarshal([]byte(tc.yaml), &o); err != nil {
+				t.Fatal(err)
+			}
+			if err := o.Initialize(""); err != nil {
+				t.Fatal(err)
+			}
+			if got := o.Headers != nil; got != tc.wantHeaders {
+				t.Fatalf("Headers configured = %t, want %t", got, tc.wantHeaders)
+			}
+			_, err := o.Validate()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestOptionsClone(t *testing.T) {
+	o := &Options{Mode: ModeMerge,
+		Headers: types.EnvStringMap{"Access-Control-Allow-Origin": "https://example.com"}}
+	clone := o.Clone()
+	clone.Headers["Access-Control-Allow-Origin"] = "https://other.example.com"
+	if got := o.Headers["Access-Control-Allow-Origin"]; got != "https://example.com" {
+		t.Fatalf("clone mutated source Headers: %q", got)
+	}
+}
+
+func TestOptionsUnmarshalYAMLDefaultsToReplace(t *testing.T) {
+	var o Options
+	if err := yaml.Unmarshal([]byte("headers: {}\n"), &o); err != nil {
+		t.Fatal(err)
+	}
+	if o.Mode != ModeReplace {
+		t.Fatalf("Mode = %q, want %q", o.Mode, ModeReplace)
+	}
+	if o.Headers == nil {
+		t.Fatal("Headers must be initialized")
+	}
+}
+
+func TestLegacyPolicy(t *testing.T) {
+	o := Legacy()
+	if !o.IsLegacy() {
+		t.Fatal("Legacy() must return a legacy policy")
+	}
+	if o.PreservesOrigin() {
+		t.Fatal("legacy policy must not change existing cache-key behavior")
+	}
+	o.Mode = ModeReplace
+	if Legacy().Mode != "" {
+		t.Fatal("Legacy() returned shared mutable state")
+	}
+}

--- a/pkg/proxy/engines/httpproxy.go
+++ b/pkg/proxy/engines/httpproxy.go
@@ -167,7 +167,6 @@ func PrepareResponseWriter(w io.Writer, code int, header http.Header) io.Writer 
 		h := rw.Header()
 		headers.Merge(h, header)
 		headers.StripClientHeaders(h)
-		headers.AddResponseHeaders(h)
 		if code > 0 {
 			rw.WriteHeader(code)
 		}

--- a/pkg/proxy/engines/key.go
+++ b/pkg/proxy/engines/key.go
@@ -48,7 +48,7 @@ func (pr *proxyRequest) DeriveCacheKey(extra string) string {
 	pc := pr.rsc.PathConfig
 
 	if pc == nil {
-		return md5.Checksum(pr.URL.Path + extra)
+		return md5.Checksum(pr.URL.Path + pr.corsCacheKeyPart(pr.Request) + extra)
 	}
 
 	var qp url.Values
@@ -79,7 +79,11 @@ func (pr *proxyRequest) DeriveCacheKey(extra string) string {
 	}
 
 	if pc.KeyHasher != nil {
-		return pc.KeyHasher(r.URL.Path, qp, r.Header, b, trq, extra)
+		key := pc.KeyHasher(r.URL.Path, qp, r.Header, b, trq, extra)
+		if corsPart := pr.corsCacheKeyPart(r); corsPart != "" {
+			return md5.Checksum(key + corsPart)
+		}
+		return key
 	}
 
 	var k int
@@ -184,7 +188,16 @@ func (pr *proxyRequest) DeriveCacheKey(extra string) string {
 	}
 	vals = vals[:k]
 	slices.Sort(vals)
-	return md5.Checksum(pr.URL.Path + "." + strings.Join(vals, "") + extra)
+	return md5.Checksum(pr.URL.Path + "." + strings.Join(vals, "") +
+		pr.corsCacheKeyPart(r) + extra)
+}
+
+func (pr *proxyRequest) corsCacheKeyPart(r *http.Request) string {
+	if pr == nil || pr.rsc == nil || pr.rsc.FrontendCORS == nil ||
+		!pr.rsc.FrontendCORS.PreservesOrigin() || r == nil {
+		return ""
+	}
+	return ".origin." + r.Header.Get(headers.NameOrigin)
 }
 
 func deepSearch(document map[string]any, key string) (string, error) {

--- a/pkg/proxy/engines/key_test.go
+++ b/pkg/proxy/engines/key_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/level"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	ct "github.com/trickstercache/trickster/v2/pkg/proxy/context"
+	corso "github.com/trickstercache/trickster/v2/pkg/proxy/cors/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
@@ -208,6 +209,48 @@ func exampleKeyHasher(path string, params url.Values, headers http.Header,
 	body []byte, trq *timeseries.TimeRangeQuery, extra string,
 ) string {
 	return "test-key"
+}
+
+func TestDeriveCacheKeyVariesByCORSOrigin(t *testing.T) {
+	makeKey := func(policy *corso.Options, origin string, customHasher bool) string {
+		t.Helper()
+		pc := po.New()
+		if customHasher {
+			pc.KeyHasher = exampleKeyHasher
+		}
+		rsc := request.NewResources(&bo.Options{}, pc, nil, nil, nil, nil)
+		rsc.FrontendCORS = policy
+		r := httptest.NewRequest(http.MethodGet, "http://trickster.example.com/data", nil)
+		r.Header.Set(headers.NameOrigin, origin)
+		r = request.SetResources(r, rsc)
+		return newProxyRequest(r, nil).DeriveCacheKey("")
+	}
+
+	tests := []struct {
+		name          string
+		policy        *corso.Options
+		customHasher  bool
+		wantDifferent bool
+	}{
+		{name: "preserve", policy: &corso.Options{Mode: corso.ModePreserve}, wantDifferent: true},
+		{name: "merge", policy: &corso.Options{Mode: corso.ModeMerge}, wantDifferent: true},
+		{name: "replace", policy: &corso.Options{Mode: corso.ModeReplace}},
+		{name: "disable", policy: &corso.Options{Mode: corso.ModeDisable}},
+		{name: "legacy", policy: corso.Legacy()},
+		{name: "custom hasher preserve", policy: &corso.Options{Mode: corso.ModePreserve},
+			customHasher: true, wantDifferent: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			first := makeKey(tc.policy, "https://first.example.com", tc.customHasher)
+			second := makeKey(tc.policy, "https://second.example.com", tc.customHasher)
+			if got := first != second; got != tc.wantDifferent {
+				t.Fatalf("cache keys differ = %v, want %v (%q, %q)",
+					got, tc.wantDifferent, first, second)
+			}
+		})
+	}
 }
 
 // TestDeriveCacheKey_MultiValueParams is a comprehensive test for multi-value

--- a/pkg/proxy/engines/objectproxycache_test.go
+++ b/pkg/proxy/engines/objectproxycache_test.go
@@ -34,12 +34,14 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/cache"
 	"github.com/trickstercache/trickster/v2/pkg/cache/status"
 	tc "github.com/trickstercache/trickster/v2/pkg/proxy/context"
+	corso "github.com/trickstercache/trickster/v2/pkg/proxy/cors/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/errors"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/forwarding"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 	tu "github.com/trickstercache/trickster/v2/pkg/testutil"
+	"github.com/trickstercache/trickster/v2/pkg/util/middleware"
 )
 
 func setupTestHarnessOPC(file, body string, code int,
@@ -147,6 +149,88 @@ func TestObjectProxyCacheRequest(t *testing.T) {
 	_, e = testFetchOPC(r, http.StatusPartialContent, "test", map[string]string{"status": "hit"})
 	for _, err = range e {
 		t.Error(err)
+	}
+}
+
+func TestObjectProxyCacheCORSOnMissAndHit(t *testing.T) {
+	hdrs := map[string]string{
+		headers.NameCacheControl:           "max-age=60",
+		headers.NameAllowOrigin:            "https://origin.example.com",
+		"Access-Control-Allow-Credentials": "true",
+	}
+	ts, _, r, rsc, err := setupTestHarnessOPC("", "test", http.StatusOK, hdrs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeTestHarness(ts, r)
+
+	rsc.BackendOptions.CORS = &corso.Options{
+		Mode: corso.ModeReplace,
+		Headers: map[string]string{
+			headers.NameAllowOrigin: "https://trickster.example.com",
+		},
+	}
+	h := middleware.WithResourcesContext(rsc.BackendClient, rsc.BackendOptions,
+		rsc.CacheClient, rsc.PathConfig, rsc.Tracer, http.HandlerFunc(ObjectProxyCacheRequest))
+	base := request.ClearResources(r)
+
+	for i, wantStatus := range []string{"kmiss", "hit"} {
+		recorder := httptest.NewRecorder()
+		req := base.Clone(base.Context())
+		h.ServeHTTP(recorder, req)
+		resp := recorder.Result()
+		if got := resp.Header.Get(headers.NameAllowOrigin); got != "https://trickster.example.com" {
+			t.Errorf("request %d allow origin = %q", i+1, got)
+		}
+		if got := resp.Header.Get("Access-Control-Allow-Credentials"); got != "" {
+			t.Errorf("request %d retained origin credentials header: %q", i+1, got)
+		}
+		if err := testResultHeaderPartMatch(resp.Header, map[string]string{"status": wantStatus}); err != nil {
+			t.Errorf("request %d: %v", i+1, err)
+		}
+		resp.Body.Close()
+	}
+}
+
+func TestObjectProxyCachePreservedCORSVariesByOrigin(t *testing.T) {
+	hdrs := map[string]string{
+		headers.NameCacheControl: "max-age=60",
+		headers.NameAllowOrigin:  "https://origin.example.com",
+	}
+	ts, _, r, rsc, err := setupTestHarnessOPC("", "test", http.StatusOK, hdrs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeTestHarness(ts, r)
+
+	rsc.BackendOptions.CORS = &corso.Options{Mode: corso.ModePreserve}
+	h := middleware.WithResourcesContext(rsc.BackendClient, rsc.BackendOptions,
+		rsc.CacheClient, rsc.PathConfig, rsc.Tracer, http.HandlerFunc(ObjectProxyCacheRequest))
+	base := request.ClearResources(r)
+
+	requests := []struct {
+		origin string
+		status string
+	}{
+		{origin: "https://first.example.com", status: "kmiss"},
+		{origin: "https://second.example.com", status: "kmiss"},
+		{origin: "https://first.example.com", status: "hit"},
+	}
+
+	for i, tc := range requests {
+		recorder := httptest.NewRecorder()
+		req := base.Clone(base.Context())
+		req.Header = base.Header.Clone()
+		req.Header.Set(headers.NameOrigin, tc.origin)
+		h.ServeHTTP(recorder, req)
+		resp := recorder.Result()
+		if got := resp.Header.Get(headers.NameAllowOrigin); got != "https://origin.example.com" {
+			t.Errorf("request %d allow origin = %q", i+1, got)
+		}
+		if err := testResultHeaderPartMatch(resp.Header, map[string]string{"status": tc.status}); err != nil {
+			t.Errorf("request %d: %v", i+1, err)
+		}
+		resp.Body.Close()
 	}
 }
 

--- a/pkg/proxy/handlers/trickster/purge/purge.go
+++ b/pkg/proxy/handlers/trickster/purge/purge.go
@@ -18,6 +18,7 @@ package purge
 
 import (
 	"fmt"
+	"html"
 	"net/http"
 	"strings"
 
@@ -38,11 +39,19 @@ func writeValidationError(w http.ResponseWriter, errorMsg string) {
 	w.Write([]byte(errorMsg))
 }
 
+func writePurgeResult(w http.ResponseWriter, backendName, target string) {
+	w.Header().Set(headers.NameContentType, headers.ValueTextPlain)
+	w.Header().Set(headers.NameCacheControl, headers.ValueNoCache)
+	w.WriteHeader(http.StatusOK)
+	w.Write(fmt.Appendf(nil, "purged: %s | %s\n",
+		html.EscapeString(backendName), html.EscapeString(target)))
+}
+
 // validateBackend checks if the backend exists and writes an error response if not
 // Returns true if valid, false if invalid (and error response was written)
 func validateBackend(w http.ResponseWriter, backend backends.Backend, backendName string) bool {
 	if backend == nil {
-		writeValidationError(w, "Backend "+backendName+" doesn't exist.")
+		writeValidationError(w, "Backend "+html.EscapeString(backendName)+" doesn't exist.")
 		return false
 	}
 	return true
@@ -52,7 +61,7 @@ func validateBackend(w http.ResponseWriter, backend backends.Backend, backendNam
 // Returns true if valid, false if invalid (and error response was written)
 func validateCache(w http.ResponseWriter, cache cache.Cache, backendName string) bool {
 	if cache == nil {
-		writeValidationError(w, "Backend "+backendName+" doesn't have a cache.")
+		writeValidationError(w, "Backend "+html.EscapeString(backendName)+" doesn't have a cache.")
 		return false
 	}
 	return true
@@ -80,10 +89,7 @@ func KeyHandler(pathPrefix string,
 			return
 		}
 		cache.Remove(purgeKey)
-		w.Header().Set(headers.NameContentType, headers.ValueTextPlain)
-		w.Header().Set(headers.NameCacheControl, headers.ValueNoCache)
-		w.WriteHeader(http.StatusOK)
-		w.Write(fmt.Appendf(nil, "purged: %s | %s\n", backendName, purgeKey))
+		writePurgeResult(w, backendName, purgeKey)
 	}
 }
 
@@ -137,9 +143,6 @@ func PathHandler(pathPrefix string,
 			}
 		}
 
-		w.Header().Set(headers.NameContentType, headers.ValueTextPlain)
-		w.Header().Set(headers.NameCacheControl, headers.ValueNoCache)
-		w.WriteHeader(http.StatusOK)
-		w.Write(fmt.Appendf(nil, "purged: %s | %s\n", backendName, purgePath))
+		writePurgeResult(w, backendName, purgePath)
 	}
 }

--- a/pkg/proxy/handlers/trickster/purge/purge_test.go
+++ b/pkg/proxy/handlers/trickster/purge/purge_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/cache/options"
 	"github.com/trickstercache/trickster/v2/pkg/cache/status"
 	"github.com/trickstercache/trickster/v2/pkg/checksum/md5"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 )
 
 // memCache is a minimal in-memory cache.Cache used to assert key-format parity
@@ -82,6 +83,62 @@ type fakeBackend struct {
 
 func (f *fakeBackend) Configuration() *bo.Options { return f.cfg }
 func (f *fakeBackend) Cache() cache.Cache         { return f.cache }
+
+func TestWritePurgeResultEscapesReflectedValues(t *testing.T) {
+	w := httptest.NewRecorder()
+	writePurgeResult(w, "<backend>", "/<script>&")
+
+	if got, want := w.Body.String(), "purged: &lt;backend&gt; | /&lt;script&gt;&amp;\n"; got != want {
+		t.Fatalf("body = %q, want %q", got, want)
+	}
+	if got := w.Header().Get(headers.NameContentType); got != headers.ValueTextPlain {
+		t.Fatalf("Content-Type = %q, want %q", got, headers.ValueTextPlain)
+	}
+	if got := w.Header().Get(headers.NameCacheControl); got != headers.ValueNoCache {
+		t.Fatalf("Cache-Control = %q, want %q", got, headers.ValueNoCache)
+	}
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestValidationErrorsEscapeBackendName(t *testing.T) {
+	tests := []struct {
+		name     string
+		validate func(http.ResponseWriter) bool
+		wantBody string
+	}{
+		{
+			name: "missing backend",
+			validate: func(w http.ResponseWriter) bool {
+				return validateBackend(w, nil, "<backend>")
+			},
+			wantBody: "Backend &lt;backend&gt; doesn't exist.",
+		},
+		{
+			name: "missing cache",
+			validate: func(w http.ResponseWriter) bool {
+				return validateCache(w, nil, "<backend>")
+			},
+			wantBody: "Backend &lt;backend&gt; doesn't have a cache.",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			if tc.validate(w) {
+				t.Fatal("validation unexpectedly succeeded")
+			}
+			if got := w.Body.String(); got != tc.wantBody {
+				t.Fatalf("body = %q, want %q", got, tc.wantBody)
+			}
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+			}
+		})
+	}
+}
 
 // TestPathHandler_KeyFormatMatchesEngines stores entries under the engine key
 // format for two backends sharing CacheKeyPrefix, then issues purges and

--- a/pkg/proxy/headers/forwarding.go
+++ b/pkg/proxy/headers/forwarding.go
@@ -330,9 +330,8 @@ func parseXForwardHeaders(h http.Header) Hops {
 	return nil
 }
 
-// AddResponseHeaders injects standard Trickster headers into downstream HTTP responses
+// AddResponseHeaders applies Trickster's legacy wildcard CORS response header.
 func AddResponseHeaders(h http.Header) {
-	// We're read only and a harmless API, so allow all CORS
 	h.Set(NameAllowOrigin, "*")
 }
 

--- a/pkg/proxy/headers/headers.go
+++ b/pkg/proxy/headers/headers.go
@@ -80,6 +80,8 @@ const (
 	NameCacheControl = "Cache-Control"
 	// NameAllowOrigin represents the HTTP Header Name of "Access-Control-Allow-Origin"
 	NameAllowOrigin = "Access-Control-Allow-Origin"
+	// NameOrigin represents the HTTP Header Name of "Origin"
+	NameOrigin = "Origin"
 	// NameConnection represents the HTTP Header Name of "Connection"
 	NameConnection = "Connection"
 	// NameContentType represents the HTTP Header Name of "Content-Type"

--- a/pkg/proxy/paths/options/options.go
+++ b/pkg/proxy/paths/options/options.go
@@ -27,6 +27,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/cache/key"
 	"github.com/trickstercache/trickster/v2/pkg/config/types"
 	autho "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/options"
+	corso "github.com/trickstercache/trickster/v2/pkg/proxy/cors/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/forwarding"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/methods"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
@@ -59,6 +60,8 @@ type Options struct {
 	RequestParams types.EnvStringMap `yaml:"request_params,omitempty"`
 	// ResponseHeaders is a map of http headers that will be added to responses to the downstream client
 	ResponseHeaders types.EnvStringMap `yaml:"response_headers,omitempty"`
+	// CORS overrides the backend CORS response-header policy for this path
+	CORS *corso.Options `yaml:"cors,omitempty"`
 	// ResponseCode sets a custom response code to be sent to downstream clients for this path.
 	ResponseCode int `yaml:"response_code,omitempty"`
 	// ResponseBody sets a custom response body to be sent to the donstream client for this path.
@@ -124,6 +127,9 @@ func (o *Options) Clone() *Options {
 	out.RequestHeaders = maps.Clone(o.RequestHeaders)
 	out.RequestParams = maps.Clone(o.RequestParams)
 	out.ResponseHeaders = maps.Clone(o.ResponseHeaders)
+	if o.CORS != nil {
+		out.CORS = o.CORS.Clone()
+	}
 	out.Methods = slices.Clone(o.Methods)
 	out.CacheKeyParams = slices.Clone(o.CacheKeyParams)
 	out.CacheKeyHeaders = slices.Clone(o.CacheKeyHeaders)
@@ -174,6 +180,11 @@ func (o *Options) Initialize(_ string) error {
 	if o.ResponseBody != nil && *o.ResponseBody != "" {
 		o.ResponseBodyBytes = []byte(*o.ResponseBody)
 	}
+	if o.CORS != nil {
+		if err := o.CORS.Initialize(""); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }
@@ -205,6 +216,11 @@ func (o *Options) Validate() (bool, error) {
 	}
 	if o.ResponseCode != 0 && (o.ResponseCode < 100 || o.ResponseCode >= 600) {
 		return false, fmt.Errorf("invalid response_code: %d (must be between 100 and 599)", o.ResponseCode)
+	}
+	if o.CORS != nil {
+		if _, err := o.CORS.Validate(); err != nil {
+			return false, err
+		}
 	}
 	return true, nil
 }

--- a/pkg/proxy/request/resources.go
+++ b/pkg/proxy/request/resources.go
@@ -29,6 +29,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing"
 	auth "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/types"
 	tctx "github.com/trickstercache/trickster/v2/pkg/proxy/context"
+	corso "github.com/trickstercache/trickster/v2/pkg/proxy/cors/options"
 	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
@@ -40,6 +41,7 @@ type Resources struct {
 	sync.Mutex
 	BackendOptions    *bo.Options
 	PathConfig        *po.Options
+	FrontendCORS      *corso.Options
 	CacheConfig       *co.Options
 	CacheClient       cache.Cache
 	BackendClient     backends.Backend
@@ -73,6 +75,7 @@ func (r *Resources) Clone() *Resources {
 	return &Resources{
 		BackendOptions:        r.BackendOptions,
 		PathConfig:            r.PathConfig,
+		FrontendCORS:          r.FrontendCORS,
 		CacheConfig:           r.CacheConfig,
 		CacheClient:           r.CacheClient,
 		BackendClient:         r.BackendClient,
@@ -147,6 +150,9 @@ func (r *Resources) Merge(r2 *Resources) {
 	}
 	r.BackendOptions = r2.BackendOptions
 	r.PathConfig = r2.PathConfig
+	if r.FrontendCORS == nil {
+		r.FrontendCORS = r2.FrontendCORS
+	}
 	r.CacheConfig = r2.CacheConfig
 	r.CacheClient = r2.CacheClient
 	r.BackendClient = r2.BackendClient

--- a/pkg/util/middleware/config_context.go
+++ b/pkg/util/middleware/config_context.go
@@ -24,6 +24,8 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/cache"
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/context"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/cors"
+	corso "github.com/trickstercache/trickster/v2/pkg/proxy/cors/options"
 	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 )
@@ -33,6 +35,14 @@ func WithResourcesContext(client backends.Backend, o *bo.Options,
 	c cache.Cache, p *po.Options, t *tracing.Tracer,
 	next http.Handler,
 ) http.Handler {
+	corsOptions := corso.Legacy()
+	if o != nil && o.CORS != nil {
+		corsOptions = o.CORS
+	}
+	if p != nil && p.CORS != nil {
+		corsOptions = p.CORS
+	}
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if o != nil && (o.LatencyMin > 0 || o.LatencyMax > 0) {
 			processSimulatedLatency(w, o.LatencyMin, o.LatencyMax)
@@ -44,14 +54,22 @@ func WithResourcesContext(client backends.Backend, o *bo.Options,
 		} else {
 			resources = request.NewResources(o, p, c.Configuration(), c, client, t)
 		}
+		resources.FrontendCORS = corsOptions
 		ctx := r.Context()
 		rsc, ok := context.Resources(ctx).(*request.Resources)
 		if !ok {
-			next.ServeHTTP(w, r.WithContext(context.WithResources(r.Context(), resources)))
+			cw := cors.Wrap(w, corsOptions)
+			defer cw.Finalize()
+			next.ServeHTTP(cw, r.WithContext(context.WithResources(r.Context(), resources)))
 			return
 		}
+		wrapResponse := rsc.FrontendCORS == nil
 		rsc.Merge(resources)
-
+		if wrapResponse {
+			cw := cors.Wrap(w, rsc.FrontendCORS)
+			defer cw.Finalize()
+			w = cw
+		}
 		next.ServeHTTP(w, r.WithContext(context.WithResources(r.Context(), rsc)))
 	})
 }

--- a/pkg/util/middleware/config_context_test.go
+++ b/pkg/util/middleware/config_context_test.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
+	"github.com/trickstercache/trickster/v2/pkg/config/types"
+	corso "github.com/trickstercache/trickster/v2/pkg/proxy/cors/options"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+)
+
+func TestWithResourcesContextAppliesLegacyCORS(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(headers.NameAllowOrigin, "https://origin.example.com")
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	h := WithResourcesContext(nil, bo.New(), nil, po.New(), nil, next)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	result := recorder.Result()
+	if got := result.Header.Get(headers.NameAllowOrigin); got != "*" {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want *", got)
+	}
+	if got := result.Header.Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Fatalf("Access-Control-Allow-Credentials = %q, want true", got)
+	}
+}
+
+func TestWithResourcesContextPathCORSOverridesBackend(t *testing.T) {
+	backend := bo.New()
+	backend.CORS = &corso.Options{Mode: corso.ModePreserve}
+	path := po.New()
+	path.CORS = &corso.Options{Mode: corso.ModeReplace}
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(headers.NameAllowOrigin, "https://origin.example.com")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	h := WithResourcesContext(nil, backend, nil, path, nil, next)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if got := recorder.Result().Header.Get(headers.NameAllowOrigin); got != "" {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want empty", got)
+	}
+}
+
+func TestWithResourcesContextFinalizesCORSWithoutWrite(t *testing.T) {
+	backend := bo.New()
+	backend.CORS = &corso.Options{Mode: corso.ModeReplace}
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(headers.NameAllowOrigin, "https://origin.example.com")
+	})
+	h := WithResourcesContext(nil, backend, nil, po.New(), nil, next)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if got := recorder.Result().Header.Get(headers.NameAllowOrigin); got != "" {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want empty", got)
+	}
+}
+
+func TestWithResourcesContextKeepsClientFacingCORSAcrossNestedRoute(t *testing.T) {
+	outer := bo.New()
+	outer.CORS = &corso.Options{Mode: corso.ModeReplace, Headers: types.EnvStringMap{
+		headers.NameAllowOrigin: "https://public.example.com",
+	}}
+	inner := bo.New()
+	inner.CORS = &corso.Options{Mode: corso.ModeReplace, Headers: types.EnvStringMap{
+		headers.NameAllowOrigin: "https://member.example.com",
+	}}
+
+	final := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rsc := request.GetResources(r)
+		if rsc == nil {
+			t.Fatal("missing request resources")
+		}
+		if rsc.BackendOptions != inner {
+			t.Error("nested route must still update active backend resources")
+		}
+		if rsc.FrontendCORS != outer.CORS {
+			t.Error("nested route replaced the client-facing CORS policy")
+		}
+		w.Header().Set(headers.NameAllowOrigin, "https://origin.example.com")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	innerHandler := WithResourcesContext(nil, inner, nil, po.New(), nil, final)
+	outerHandler := WithResourcesContext(nil, outer, nil, po.New(), nil, innerHandler)
+	recorder := httptest.NewRecorder()
+	outerHandler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if got := recorder.Result().Header.Get(headers.NameAllowOrigin); got != "https://public.example.com" {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want client-facing policy", got)
+	}
+}


### PR DESCRIPTION
## Description

Related to #1008.

Adds per-backend and per-path CORS response policies with `preserve`, `merge`, and `replace` modes. The client-facing route keeps ownership of the policy across ALB, user-router, and rule dispatch, and policies that preserve origin headers partition cache keys by the request `Origin`.

To avoid changing existing 2.x behavior, an omitted `cors` block still applies the legacy `Access-Control-Allow-Origin: *` behavior. CORS can be deliberately disabled with `mode: disable`, which rejects any `headers` block.

CodeQL validation also identified request-derived values reflected by the purge handlers. Those status and error responses now escape backend names and purge targets before passing through response-writer middleware.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Optimization
- [x] Test coverage
- [x] Documentation
- [ ] Infrastructure

## AI Disclosure

- [ ] This contribution DOES NOT include AI-generated changes
- [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.