### PR TITLE
test: remove healthcheck wall-clock waits

### DIFF
--- a/integration/alb_chaos_test.go
+++ b/integration/alb_chaos_test.go
@@ -84,8 +84,9 @@ func runChaosCell(t *testing.T, mech, behavior string, chaosData http.HandlerFun
 	}
 	go startTrickster(t, ctx, expectedStartError{}, "-config", cfgPath)
 	waitForTrickster(t, fmt.Sprintf("127.0.0.1:%d", metricsPort))
-
-	time.Sleep(800 * time.Millisecond)
+	healthURL := fmt.Sprintf("http://127.0.0.1:%d/trickster/health", metricsPort)
+	requireHealthState(t, healthURL, "prom0", "available", 10*time.Second)
+	requireHealthState(t, healthURL, "prom1", "available", 10*time.Second)
 
 	cli := &http.Client{
 		Timeout: 5 * time.Second,

--- a/integration/alb_matrix_test.go
+++ b/integration/alb_matrix_test.go
@@ -223,6 +223,14 @@ func runMatrixCell(t *testing.T, c matrixCell) {
 	}
 	go startTrickster(t, ctx, expectedStartError{}, "-config", cfgPath)
 	waitForTrickster(t, fmt.Sprintf("127.0.0.1:%d", c.metricsPort))
+	healthURL := fmt.Sprintf("http://127.0.0.1:%d/trickster/health", c.metricsPort)
+	for i := range stubs {
+		bucket := "available"
+		if i < down {
+			bucket = "unavailable"
+		}
+		requireHealthState(t, healthURL, fmt.Sprintf("prom%d", i), bucket, 10*time.Second)
+	}
 
 	// In flapping mode, oscillate the "down" stubs every ~150ms. Stop on
 	// test cleanup so a long-running goroutine doesn't bleed into the
@@ -245,12 +253,6 @@ func runMatrixCell(t *testing.T, c matrixCell) {
 			}
 		}()
 	}
-
-	// Let healthchecks converge before we sample metrics. With interval=100ms
-	// and failure_threshold=1 the broken stubs should be marked Failing inside
-	// ~300ms; budget 800ms to absorb scheduler jitter and pool-refresh lag
-	// (pool.Targets() is informer-cached and may trail the status flip).
-	time.Sleep(800 * time.Millisecond)
 
 	before := metricsutil.Scrape(t, c.metricsPort)
 

--- a/integration/alb_unavail_test.go
+++ b/integration/alb_unavail_test.go
@@ -29,7 +29,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -85,16 +84,12 @@ func TestALBUnavailableMemberNotQueried(t *testing.T) {
 	metricsAddr := fmt.Sprintf("127.0.0.1:%d", metricsPort)
 	waitForTrickster(t, metricsAddr)
 
-	// Wait for the broken backend to record at least one healthcheck miss.
-	// failure_threshold: 1 + interval: 100ms means it should be marked
-	// unavailable within ~300ms.
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assert.Greater(collect, brokenHCHits.Load(), int64(0),
-			"waiting for first healthcheck probe to broken backend")
-	}, 5*time.Second, 50*time.Millisecond)
-
-	// Give the pool a beat to refresh after the status flip.
-	time.Sleep(300 * time.Millisecond)
+	healthURL := "http://" + metricsAddr + "/trickster/health"
+	requireHealthState(t, healthURL, "prom-broken", "unavailable", 10*time.Second)
+	requireALBMemberState(t, healthURL, "alb-fr-test", "prom-broken", "unavailable", 10*time.Second)
+	requireALBMemberState(t, healthURL, "alb-tsm-test", "prom-broken", "unavailable", 10*time.Second)
+	require.Greater(t, brokenHCHits.Load(), int64(0),
+		"expected at least one healthcheck probe to the broken backend")
 
 	// Snapshot the counter just before issuing user traffic; subsequent growth
 	// is what we attribute to fanout from the ALB.

--- a/pkg/backends/alb/pool/health_test.go
+++ b/pkg/backends/alb/pool/health_test.go
@@ -19,90 +19,64 @@ package pool
 import (
 	"net/http"
 	"testing"
-	"time"
+	"testing/synctest"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
 )
 
 func TestCheckHealth(t *testing.T) {
-	tgt := &Target{
-		hcStatus: &healthcheck.Status{},
-	}
+	synctest.Test(t, func(t *testing.T) {
+		tgt := &Target{
+			hcStatus: &healthcheck.Status{},
+		}
 
-	tgt.hcStatus.Set(healthcheck.StatusPassing)
+		tgt.hcStatus.Set(healthcheck.StatusPassing)
 
-	p := &pool{ch: make(chan bool, 1), done: make(chan struct{}), targets: []*Target{tgt}, healthyFloor: -1}
-	p.workers.Add(1)
-	go func() {
-		p.checkHealth()
-	}()
-	p.scheduleRefresh()
-	waitFor(t, func() bool {
+		p := &pool{ch: make(chan bool, 1), done: make(chan struct{}), targets: []*Target{tgt}, healthyFloor: -1}
+		p.workers.Add(1)
+		go p.checkHealth()
+		defer p.Stop()
+		p.scheduleRefresh()
+		synctest.Wait()
+
 		h := p.healthyHandlers.Load()
-		return h != nil && len(*h) == 1
-	}, 2*time.Second)
-	p.Stop()
-
-	h := p.healthyHandlers.Load()
-	if h == nil {
-		t.Error("expected non-nil healthy list")
-		return
-	}
-	l := len(*h)
-	if l != 1 {
-		t.Errorf("expected %d got %d", 1, l)
-	}
+		if h == nil {
+			t.Fatal("expected non-nil healthy list")
+		}
+		if got := len(*h); got != 1 {
+			t.Errorf("expected %d got %d", 1, got)
+		}
+	})
 }
 
 func TestBurstUpdatesEvictFailingTarget(t *testing.T) {
-	st1 := &healthcheck.Status{}
-	st2 := &healthcheck.Status{}
-	t1 := NewTarget(http.NotFoundHandler(), st1, nil)
-	t2 := NewTarget(http.NotFoundHandler(), st2, nil)
-	p := New(Targets{t1, t2}, 1)
-	defer p.Stop()
+	synctest.Test(t, func(t *testing.T) {
+		st1 := &healthcheck.Status{}
+		st2 := &healthcheck.Status{}
+		t1 := NewTarget(http.NotFoundHandler(), st1, nil)
+		t2 := NewTarget(http.NotFoundHandler(), st2, nil)
+		p := New(Targets{t1, t2}, 1)
+		defer p.Stop()
 
-	st1.Set(healthcheck.StatusPassing)
-	st2.Set(healthcheck.StatusPassing)
-
-	waitForHealthyTargetsLen(t, p, 2, 2*time.Second)
-
-	// Emit a burst of updates that may overrun subscriber channel buffers and
-	// drop intermediate notifications. Final state is failing.
-	for range 256 {
 		st1.Set(healthcheck.StatusPassing)
+		st2.Set(healthcheck.StatusPassing)
+		synctest.Wait()
+		if got := len(p.Targets()); got != 2 {
+			t.Fatalf("setup: expected 2 healthy targets, got %d", got)
+		}
+
+		// Emit a burst of updates that may overrun subscriber channel buffers and
+		// drop intermediate notifications. Final state is failing.
+		for range 256 {
+			st1.Set(healthcheck.StatusPassing)
+			st1.Set(healthcheck.StatusFailing)
+		}
 		st1.Set(healthcheck.StatusFailing)
-	}
-	st1.Set(healthcheck.StatusFailing)
+		synctest.Wait()
 
-	waitForHealthyTargetsLen(t, p, 1, 2*time.Second)
-
-	got := p.Targets()
-	if len(got) != 1 || got[0] != t2 {
-		t.Fatalf("expected only target 2 to remain healthy, got: %#v", got)
-	}
-}
-
-func waitForHealthyTargetsLen(t *testing.T, p Pool, expected int, timeout time.Duration) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if len(p.Targets()) == expected {
-			return
+		got := p.Targets()
+		if len(got) != 1 || got[0] != t2 {
+			t.Fatalf("expected only target 2 to remain healthy, got: %#v", got)
 		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatalf("timed out waiting for %d healthy targets; got %d", expected, len(p.Targets()))
-}
-
-func waitFor(t *testing.T, cond func() bool, timeout time.Duration) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if cond() {
-			return
-		}
-		time.Sleep(2 * time.Millisecond)
-	}
-	t.Fatalf("timed out waiting for condition")
+	})
 }

--- a/pkg/backends/alb/pool/pool_livetargets_bench_test.go
+++ b/pkg/backends/alb/pool/pool_livetargets_bench_test.go
@@ -19,7 +19,6 @@ package pool
 import (
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
 )
@@ -32,16 +31,8 @@ func BenchmarkLiveTargets(b *testing.B) {
 		st.Set(healthcheck.StatusPassing)
 		targets[i] = NewTarget(http.NotFoundHandler(), st, nil)
 	}
-	p := New(targets, 1)
-	defer p.Stop()
-
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if len(p.Targets()) == n {
-			break
-		}
-		time.Sleep(2 * time.Millisecond)
-	}
+	p := &pool{targets: targets, healthyFloor: 1}
+	p.RefreshHealthy()
 	if got := len(p.Targets()); got != n {
 		b.Fatalf("setup: expected %d healthy targets, got %d", n, got)
 	}

--- a/pkg/backends/alb/pool/pool_livetargets_freshness_test.go
+++ b/pkg/backends/alb/pool/pool_livetargets_freshness_test.go
@@ -19,42 +19,31 @@ package pool
 import (
 	"net/http"
 	"testing"
-	"time"
+	"testing/synctest"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
 )
 
 func TestLiveTargets_ReflectsImmediateFlap(t *testing.T) {
-	const n = 8
-	targets := make(Targets, n)
-	for i := range n {
-		st := &healthcheck.Status{}
-		st.Set(healthcheck.StatusPassing)
-		targets[i] = NewTarget(http.NotFoundHandler(), st, nil)
-	}
-	p := New(targets, 1)
-	defer p.Stop()
-
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if len(p.Targets()) == n {
-			break
+	synctest.Test(t, func(t *testing.T) {
+		const n = 8
+		targets := make(Targets, n)
+		for i := range n {
+			st := &healthcheck.Status{}
+			st.Set(healthcheck.StatusPassing)
+			targets[i] = NewTarget(http.NotFoundHandler(), st, nil)
 		}
-		time.Sleep(2 * time.Millisecond)
-	}
-	if got := len(p.Targets()); got != n {
-		t.Fatalf("setup: expected %d live targets, got %d", n, got)
-	}
+		p := New(targets, 1)
+		defer p.Stop()
+		synctest.Wait()
 
-	targets[0].hcStatus.Set(healthcheck.StatusFailing)
-
-	deadline = time.Now().Add(1 * time.Second)
-	for time.Now().Before(deadline) {
-		if len(p.Targets()) == n-1 {
-			return
+		if got := len(p.Targets()); got != n {
+			t.Fatalf("setup: expected %d live targets, got %d", n, got)
 		}
-		time.Sleep(time.Millisecond)
-	}
-	t.Fatalf("LiveTargets did not reflect flap within 1s; got %d expected %d",
-		len(p.Targets()), n-1)
+
+		targets[0].hcStatus.Set(healthcheck.StatusFailing)
+		if got := len(p.Targets()); got != n-1 {
+			t.Fatalf("expected immediate flap to leave %d live targets, got %d", n-1, got)
+		}
+	})
 }

--- a/pkg/backends/alb/pool/pool_unavail_test.go
+++ b/pkg/backends/alb/pool/pool_unavail_test.go
@@ -19,7 +19,7 @@ package pool
 import (
 	"net/http"
 	"testing"
-	"time"
+	"testing/synctest"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
 )
@@ -29,27 +29,33 @@ import (
 // view intact; Targets re-checks against the current atomic status to close
 // the race window.
 func TestLiveTargetsDropsStaleFailingTarget(t *testing.T) {
-	st1 := &healthcheck.Status{}
-	st2 := &healthcheck.Status{}
-	t1 := NewTarget(http.NotFoundHandler(), st1, nil)
-	t2 := NewTarget(http.NotFoundHandler(), st2, nil)
+	synctest.Test(t, func(t *testing.T) {
+		st1 := &healthcheck.Status{}
+		st2 := &healthcheck.Status{}
+		t1 := NewTarget(http.NotFoundHandler(), st1, nil)
+		t2 := NewTarget(http.NotFoundHandler(), st2, nil)
 
-	p := New(Targets{t1, t2}, 1)
-	st1.Set(healthcheck.StatusPassing)
-	st2.Set(healthcheck.StatusPassing)
-	waitForHealthyTargetsLen(t, p, 2, 2*time.Second)
+		p := New(Targets{t1, t2}, 1)
+		defer p.Stop()
+		st1.Set(healthcheck.StatusPassing)
+		st2.Set(healthcheck.StatusPassing)
+		synctest.Wait()
+		if got := len(p.Targets()); got != 2 {
+			t.Fatalf("setup: expected 2 healthy targets, got %d", got)
+		}
 
-	// Pin the snapshot stale by stopping the pool's refresh goroutines, then
-	// flip t2 to Failing.
-	p.Stop()
-	st2.Set(healthcheck.StatusFailing)
+		// Pin the snapshot stale by stopping the pool's refresh goroutines, then
+		// flip t2 to Failing.
+		p.Stop()
+		st2.Set(healthcheck.StatusFailing)
 
-	if got := len(p.(*pool).snapshot()); got != 2 {
-		t.Fatalf("snapshot: expected 2 (stale), got %d", got)
-	}
+		if got := len(p.(*pool).snapshot()); got != 2 {
+			t.Fatalf("snapshot: expected 2 (stale), got %d", got)
+		}
 
-	live := p.Targets()
-	if len(live) != 1 || live[0] != t1 {
-		t.Fatalf("Targets: expected only t1, got %#v", live)
-	}
+		live := p.Targets()
+		if len(live) != 1 || live[0] != t1 {
+			t.Fatalf("Targets: expected only t1, got %#v", live)
+		}
+	})
 }

--- a/pkg/backends/healthcheck/target_concurrent_test.go
+++ b/pkg/backends/healthcheck/target_concurrent_test.go
@@ -18,9 +18,11 @@ package healthcheck
 
 import (
 	"context"
+	"net/http"
 	"net/url"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -70,25 +72,28 @@ func TestTargetConcurrentStartStopRace(t *testing.T) {
 // has returned".
 func TestTargetRestartAfterStop(t *testing.T) {
 	logger.SetLogger(testLogger)
-	ts := newTestServer(200, "OK", map[string]string{})
-	defer ts.Close()
-	u, err := url.Parse(ts.URL)
-	require.NoError(t, err)
+	synctest.Test(t, func(t *testing.T) {
+		client := &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return okProbeResponse(req), nil
+			}),
+		}
+		tgt, err := newTarget(context.Background(), "restart", "restart", &ho.Options{
+			Verb:          "GET",
+			Scheme:        "http",
+			Host:          "restart.invalid",
+			Path:          "/",
+			Interval:      200 * time.Millisecond,
+			ExpectedCodes: []int{200},
+		}, client)
+		require.NoError(t, err)
 
-	tgt, err := newTarget(context.Background(), "restart", "restart", &ho.Options{
-		Verb:          "GET",
-		Scheme:        u.Scheme,
-		Host:          u.Host,
-		Path:          "/",
-		Interval:      200 * time.Millisecond,
-		ExpectedCodes: []int{200},
-	}, ts.Client())
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	for range 10 {
-		tgt.Start(ctx)
-		time.Sleep(time.Millisecond)
-		tgt.Stop()
-	}
+		ctx := context.Background()
+		for range 10 {
+			tgt.Start(ctx)
+			time.Sleep(time.Second)
+			synctest.Wait()
+			tgt.Stop()
+		}
+	})
 }


### PR DESCRIPTION
## Description

Fixes #1007.

This completes the wall-clock cleanup started in #1031:

- replace the remaining ALB pool polling loops with `testing/synctest` synchronization or deterministic benchmark setup
- make the ALB matrix and chaos tests wait for the expected `/trickster/health` state instead of sleeping for a fixed 800ms
- remove the extra 300ms pool-refresh delay from the unavailable-member regression
- run the target restart regression with a fake transport and virtual time

The proposed production `Clock` interface is not needed here: Go 1.26 `testing/synctest` controls the standard-library timers used by the in-process tests. The daemon-level integration tests use real HTTP listeners, so they now observe Trickster's health state directly.

This is intended as test-stability hardening for the 2.1 release.

## Type of Change

- - [ ] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.

## Tests

- ALB and healthcheck package tests, including repeated and race runs
- full 72-cell `TestALBMatrix`
- `TestALBChaosBehaviors` and `TestALBUnavailableMemberNotQueried` repeated three times
- affected-package lint and repository compile-only test
- Linux integration test binary cross-compile