### PR TITLE
refactor: introduce TSM merge plans

### DIFF
--- a/pkg/backends/alb/mech/fanout/concurrency_limiter_test.go
+++ b/pkg/backends/alb/mech/fanout/concurrency_limiter_test.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fanout
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestConcurrencyLimiter(t *testing.T) {
+	if limiter := NewConcurrencyLimiter(0); limiter != nil {
+		t.Fatal("zero limit unexpectedly created a limiter")
+	}
+	if limiter := NewConcurrencyLimiter(-1); limiter != nil {
+		t.Fatal("negative limit unexpectedly created a limiter")
+	}
+
+	limiter := NewConcurrencyLimiter(1)
+	if err := limiter.acquire(context.Background()); err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := limiter.acquire(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled acquire: got %v want context.Canceled", err)
+	}
+	limiter.release()
+	if err := limiter.acquire(context.Background()); err != nil {
+		t.Fatalf("acquire after release: %v", err)
+	}
+	limiter.release()
+}

--- a/pkg/backends/alb/mech/fanout/fanout.go
+++ b/pkg/backends/alb/mech/fanout/fanout.go
@@ -120,6 +120,10 @@ type Config struct {
 	Variant string
 	// ConcurrencyLimit caps in-flight member calls. 0 means unlimited.
 	ConcurrencyLimit int
+	// ConcurrencyLimiter, when non-nil, shares one concurrency bound across
+	// multiple fanout calls. ConcurrencyLimit creates a call-local limiter when
+	// this field is nil.
+	ConcurrencyLimiter *ConcurrencyLimiter
 	// MaxCaptureBytes caps each member's response body capture. 0 uses
 	// capture.DefaultMaxBytes.
 	MaxCaptureBytes int
@@ -149,6 +153,39 @@ type Config struct {
 	// OnResult must be safe for concurrent invocation. The supplied Result
 	// is the same one that will appear in the All return slice.
 	OnResult func(idx int, r *Result)
+}
+
+// ConcurrencyLimiter bounds in-flight member calls across one or more fanouts.
+// A nil limiter means unlimited concurrency.
+type ConcurrencyLimiter struct {
+	slots chan struct{}
+}
+
+// NewConcurrencyLimiter returns a limiter for positive limits and nil when
+// concurrency is unlimited.
+func NewConcurrencyLimiter(limit int) *ConcurrencyLimiter {
+	if limit <= 0 {
+		return nil
+	}
+	return &ConcurrencyLimiter{slots: make(chan struct{}, limit)}
+}
+
+func (l *ConcurrencyLimiter) acquire(ctx context.Context) error {
+	if l == nil {
+		return nil
+	}
+	select {
+	case l.slots <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (l *ConcurrencyLimiter) release() {
+	if l != nil {
+		<-l.slots
+	}
 }
 
 // All scatters parent to every target and gathers slot-ordered Results.
@@ -291,9 +328,9 @@ func scatterInto(ctx context.Context, parent *http.Request, targets pool.Targets
 	}
 
 	var eg errgroup.Group
-	var slots chan struct{}
-	if cfg.ConcurrencyLimit > 0 {
-		slots = make(chan struct{}, cfg.ConcurrencyLimit)
+	limiter := cfg.ConcurrencyLimiter
+	if limiter == nil {
+		limiter = NewConcurrencyLimiter(cfg.ConcurrencyLimit)
 	}
 
 	// Aggregate capture-buffer budget across all slots. Each dispatched slot
@@ -331,28 +368,24 @@ func scatterInto(ctx context.Context, parent *http.Request, targets pool.Targets
 			metrics.ALBFanoutFailures.WithLabelValues(cfg.Mechanism, cfg.Variant, "aggregate_cap").Inc()
 			continue
 		}
-		if slots != nil {
-			select {
-			case slots <- struct{}{}:
-			case <-ctx.Done():
-				dispatchErr = ctx.Err()
-				markUndispatched(i, dispatchErr)
-			}
-			if dispatchErr != nil {
+		if limiter != nil {
+			if err := limiter.acquire(ctx); err != nil {
+				dispatchErr = err
+				markUndispatched(i, err)
 				break
 			}
 			// A slot and cancellation can become ready together. Do not start a
 			// handler after cancellation merely because select chose the slot.
 			if err := ctx.Err(); err != nil {
-				<-slots
+				limiter.release()
 				dispatchErr = err
 				markUndispatched(i, err)
 				break
 			}
 		}
 		eg.Go(func() error {
-			if slots != nil {
-				defer func() { <-slots }()
+			if limiter != nil {
+				defer limiter.release()
 			}
 			results[i].Index = i
 			defer mech.RecoverFanoutPanic(cfg.Mechanism, cfg.Variant, i, func() {

--- a/pkg/backends/alb/mech/tsm/merge_plan.go
+++ b/pkg/backends/alb/mech/tsm/merge_plan.go
@@ -319,7 +319,8 @@ func (h *handler) collectPlanResult(
 		}
 	}
 	result.contrib = contribution
-	result.failed = contribution == nil
+	result.failed = contribution == nil || result.statusCode < http.StatusOK ||
+		result.statusCode >= http.StatusMultipleChoices
 	execution.contributions[member] = contribution
 	execution.results[member] = result
 }

--- a/pkg/backends/alb/mech/tsm/merge_plan.go
+++ b/pkg/backends/alb/mech/tsm/merge_plan.go
@@ -1,0 +1,465 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tsm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/trickstercache/trickster/v2/pkg/backends"
+	"github.com/trickstercache/trickster/v2/pkg/backends/alb/mech/fanout"
+	"github.com/trickstercache/trickster/v2/pkg/backends/alb/names"
+	"github.com/trickstercache/trickster/v2/pkg/backends/alb/pool"
+	"github.com/trickstercache/trickster/v2/pkg/encoding"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
+	"github.com/trickstercache/trickster/v2/pkg/observability/metrics"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/failures"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
+	"golang.org/x/sync/errgroup"
+)
+
+func defaultTSMMergePlan(r *http.Request, query string) *backends.TSMMergePlan {
+	return &backends.TSMMergePlan{
+		OriginalQuery: query,
+		Variants: []backends.TSMQueryVariant{{
+			Name:              "primary",
+			Request:           r,
+			MergeStrategy:     int(dataset.MergeStrategyDedup),
+			ResponseAuthority: true,
+		}},
+		Reduction: backends.TSMReductionSpec{
+			Kind:          backends.TSMReductionStandard,
+			InputVariants: []string{"primary"},
+		},
+		Completeness:            backends.TSMCompletenessResponseAuthority,
+		AllowSingleMemberBypass: true,
+	}
+}
+
+func planNeedsLabelStripping(plan *backends.TSMMergePlan) bool {
+	if plan == nil || len(plan.Variants) > 1 {
+		return plan != nil
+	}
+	for _, variant := range plan.Variants {
+		if dataset.MergeStrategy(variant.MergeStrategy) != dataset.MergeStrategyDedup {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *handler) servePlan(
+	w http.ResponseWriter,
+	r *http.Request,
+	hl pool.Targets,
+	rsc *request.Resources,
+	plan *backends.TSMMergePlan,
+	stripKeys []string,
+	finalizer mergeFinalizer,
+	warnMsg string,
+) {
+	if plan.Reduction.Kind == backends.TSMReductionStandard {
+		variant := plan.Variants[0]
+		if !plan.Finalizer.Enabled {
+			finalizer = nil
+		}
+		h.serveStandard(w, variant.Request, hl, rsc,
+			dataset.MergeStrategy(variant.MergeStrategy), stripKeys,
+			plan.Finalizer.Query, finalizer, warnMsg)
+		return
+	}
+	h.serveMultiVariantPlan(w, r, hl, rsc, plan, stripKeys, finalizer, warnMsg)
+}
+
+type planVariantExecution struct {
+	results       []gatherResult
+	contributions []*gatherContribution
+	fanoutResults []fanout.Result
+}
+
+// serveMultiVariantPlan applies one shared concurrency bound across variants.
+// MaxFanoutCaptureBytes remains independent per variant, matching the previous
+// weighted-average behavior; MaxCaptureBytes still applies to every response.
+func (h *handler) serveMultiVariantPlan(
+	w http.ResponseWriter,
+	r *http.Request,
+	hl pool.Targets,
+	rsc *request.Resources,
+	plan *backends.TSMMergePlan,
+	stripKeys []string,
+	finalizer mergeFinalizer,
+	warnMsg string,
+) {
+	parentCtx := r.Context()
+	memberCount := len(hl)
+	executions := make([]planVariantExecution, len(plan.Variants))
+	limiter := fanout.NewConcurrencyLimiter(
+		h.tsmOptions.ConcurrencyOptions.GetQueryConcurrencyLimit(),
+	)
+	dedupToleranceNanos := h.dedupToleranceNanos()
+
+	var eg errgroup.Group
+	for variantIndex := range plan.Variants {
+		variant := plan.Variants[variantIndex]
+		executions[variantIndex] = planVariantExecution{
+			results:       make([]gatherResult, memberCount),
+			contributions: make([]*gatherContribution, memberCount),
+		}
+
+		primed, err := fanout.PrimeBody(variant.Request)
+		if err != nil {
+			logger.Warn("tsm plan variant body preparation failure", logging.Pairs{
+				"variant": variant.Name, "error": err,
+			})
+			failures.HandleBadGateway(w, r)
+			return
+		}
+		plan.Variants[variantIndex].Request = primed
+
+		eg.Go(func() error {
+			execution := &executions[variantIndex]
+			fanoutResults, err := fanout.All(parentCtx, primed, hl, fanout.Config{
+				Mechanism:             names.MechanismTSM,
+				Variant:               variant.Name,
+				ConcurrencyLimiter:    limiter,
+				MaxCaptureBytes:       h.maxCaptureBytes,
+				MaxFanoutCaptureBytes: h.maxFanoutCaptureBytes,
+				Resources: func(int) *request.Resources {
+					return &request.Resources{
+						IsMergeMember:         true,
+						TSReqestOptions:       rsc.TSReqestOptions,
+						TSMergeStrategy:       variant.MergeStrategy,
+						TSDedupToleranceNanos: dedupToleranceNanos,
+					}
+				},
+				OnResult: func(member int, fr *fanout.Result) {
+					h.collectPlanResult(parentCtx, execution, member, fr, stripKeys, variant.Name)
+				},
+			})
+			execution.fanoutResults = fanoutResults
+			return err
+		})
+	}
+	if err := eg.Wait(); err != nil && parentCtx.Err() == nil {
+		logger.Warn("tsm plan gather failure", logging.Pairs{"error": err})
+	}
+	if parentCtx.Err() != nil {
+		return
+	}
+
+	authorityIndex, _ := plan.ResponseAuthority()
+	if allFanoutFailed(executions[authorityIndex].fanoutResults) {
+		failures.HandleBadGateway(w, r)
+		return
+	}
+
+	var responseSeed *dataset.DataSet
+	if !hasCompletePlanMember(plan, executions, memberCount) {
+		responseSeed = emptyResponseSeed(executions[authorityIndex].contributions)
+		if responseSeed == nil {
+			for variantIndex := range executions {
+				if variantIndex == authorityIndex {
+					continue
+				}
+				if responseSeed = emptyResponseSeed(executions[variantIndex].contributions); responseSeed != nil {
+					break
+				}
+			}
+		}
+	}
+	warnings, hasPlanFailure := applyPlanCompleteness(plan, executions, memberCount)
+	accumulators := make([]*merge.Accumulator, len(plan.Variants))
+	for variantIndex := range plan.Variants {
+		accumulators[variantIndex] = merge.NewAccumulator()
+		failedMembers := mergeGatherContributions(parentCtx, accumulators[variantIndex],
+			executions[variantIndex].contributions)
+		if len(failedMembers) > 0 {
+			for _, member := range failedMembers {
+				metrics.ALBFanoutFailures.WithLabelValues(
+					names.MechanismTSM, plan.Variants[variantIndex].Name, "merge",
+				).Inc()
+				logger.Warn("tsm plan contribution merge failure", logging.Pairs{
+					"variant": plan.Variants[variantIndex].Name,
+					"member":  member,
+				})
+			}
+			// Re-running a partially mutated generic accumulator is unsafe. Fail
+			// closed instead of reducing variants built from different members.
+			failures.HandleBadGateway(w, r)
+			return
+		}
+		if parentCtx.Err() != nil {
+			return
+		}
+	}
+
+	responseAccumulator, err := reducePlan(parentCtx, plan, accumulators)
+	if err != nil {
+		logger.Warn("tsm plan reduction failure", logging.Pairs{"error": err})
+		failures.HandleBadGateway(w, r)
+		return
+	}
+	if responseAccumulator.GetTSData() == nil {
+		if responseSeed == nil {
+			responseSeed = &dataset.DataSet{}
+		}
+		responseAccumulator.SetTSData(responseSeed)
+	}
+	if warnMsg != "" {
+		warnings = append(warnings, warnMsg)
+	}
+	appendPlanWarnings(responseAccumulator, warnings)
+	if parentCtx.Err() != nil {
+		return
+	}
+	if plan.Finalizer.Enabled {
+		finalizer.FinalizeTSMMerge(plan.Finalizer.Query, responseAccumulator.GetTSData())
+	}
+	if parentCtx.Err() != nil {
+		return
+	}
+
+	authorityResults := executions[authorityIndex].results
+	mrf, winnerHeaders := pickWinner(authorityResults)
+	statusCode, statusHeader, has2xx, hasNon2xx := aggregateStatus(authorityResults)
+	if (has2xx && hasNon2xx) || (hasPlanFailure && has2xx) {
+		statusHeader = headers.MergeResultHeaderVals(statusHeader, "engine=ALB; status=phit")
+	}
+	if mrf == nil {
+		failures.HandleBadGateway(w, r)
+		return
+	}
+	mergeMultiValuedHeaders(w.Header(), authorityResults, winnerHeaders)
+	if winnerHeaders != nil {
+		headers.Merge(w.Header(), winnerHeaders)
+	}
+	if statusHeader != "" {
+		w.Header().Set(headers.NameTricksterResult, statusHeader)
+	}
+	if statusCode == 0 {
+		statusCode = http.StatusOK
+	}
+	mrf(w, r, responseAccumulator, statusCode)
+}
+
+func (h *handler) collectPlanResult(
+	ctx context.Context,
+	execution *planVariantExecution,
+	member int,
+	fr *fanout.Result,
+	stripKeys []string,
+	variantName string,
+) {
+	if ctx.Err() != nil || fr == nil || fr.Failed || fr.Request == nil || fr.Capture == nil {
+		execution.results[member].failed = true
+		return
+	}
+	rsc := request.GetResources(fr.Request)
+	if rsc == nil {
+		execution.results[member].failed = true
+		return
+	}
+
+	result := gatherResult{
+		statusCode: fr.Capture.StatusCode(),
+		header:     fr.Capture.Header(),
+		mergeFunc:  rsc.MergeRespondFunc,
+	}
+	if rsc.Response != nil && rsc.Response.StatusCode > 0 {
+		result.statusCode = rsc.Response.StatusCode
+	}
+	if rsc.MergeFunc == nil || rsc.MergeRespondFunc == nil {
+		logger.Warn("tsm plan gather failed due to nil func", logging.Pairs{
+			"variant": variantName, "member": member,
+		})
+		result.failed = true
+		execution.results[member] = result
+		return
+	}
+
+	var contribution *gatherContribution
+	if rsc.TS != nil {
+		contribution = prepareGatherContribution(ctx, rsc, nil, member, stripKeys)
+	} else {
+		body, err := encoding.DecompressResponseBody(
+			fr.Capture.Header().Get(headers.NameContentEncoding),
+			fr.Capture.Body(),
+		)
+		if err != nil {
+			logger.Warn("tsm plan gather decode failure", logging.Pairs{
+				"variant": variantName, "member": member, "error": err,
+			})
+			result.failed = true
+			execution.results[member] = result
+			return
+		}
+		if len(body) > 0 {
+			contribution = prepareGatherContribution(ctx, rsc, body, member, stripKeys)
+		}
+	}
+	result.contrib = contribution
+	result.failed = contribution == nil
+	execution.contributions[member] = contribution
+	execution.results[member] = result
+}
+
+func applyPlanCompleteness(
+	plan *backends.TSMMergePlan,
+	executions []planVariantExecution,
+	memberCount int,
+) ([]string, bool) {
+	var warnings []string
+	var hasFailure bool
+	for member := range memberCount {
+		missing := make([]int, 0, len(plan.Variants))
+		for variantIndex := range plan.Variants {
+			result := executions[variantIndex].results[member]
+			if result.failed || executions[variantIndex].contributions[member] == nil {
+				missing = append(missing, variantIndex)
+				metrics.ALBFanoutFailures.WithLabelValues(
+					names.MechanismTSM, plan.Variants[variantIndex].Name, "no_contribution",
+				).Inc()
+			}
+		}
+		if len(missing) == 0 {
+			continue
+		}
+		hasFailure = true
+		for _, variantIndex := range missing {
+			warnings = append(warnings,
+				"trickster: tsm excluded pool member "+strconv.Itoa(member)+
+					": variant \""+plan.Variants[variantIndex].Name+"\" returned no usable response")
+		}
+		if plan.Completeness == backends.TSMCompletenessAllVariants {
+			for variantIndex := range executions {
+				executions[variantIndex].contributions[member] = nil
+			}
+		}
+	}
+	return warnings, hasFailure
+}
+
+func hasCompletePlanMember(
+	plan *backends.TSMMergePlan,
+	executions []planVariantExecution,
+	memberCount int,
+) bool {
+	authority, _ := plan.ResponseAuthority()
+	for member := range memberCount {
+		if plan.Completeness == backends.TSMCompletenessResponseAuthority {
+			if !executions[authority].results[member].failed &&
+				executions[authority].contributions[member] != nil {
+				return true
+			}
+			continue
+		}
+		complete := true
+		for variantIndex := range executions {
+			if executions[variantIndex].results[member].failed ||
+				executions[variantIndex].contributions[member] == nil {
+				complete = false
+				break
+			}
+		}
+		if complete {
+			return true
+		}
+	}
+	return false
+}
+
+func emptyResponseSeed(contributions []*gatherContribution) *dataset.DataSet {
+	for _, contribution := range contributions {
+		if contribution == nil {
+			continue
+		}
+		ds, ok := contribution.data.(*dataset.DataSet)
+		if !ok || ds == nil {
+			continue
+		}
+		clone, ok := ds.Clone().(*dataset.DataSet)
+		if !ok {
+			return nil
+		}
+		clone.ExtentList = nil
+		clone.VolatileExtentList = nil
+		for _, result := range clone.Results {
+			if result != nil {
+				result.SeriesList = result.SeriesList[:0]
+			}
+		}
+		return clone
+	}
+	return nil
+}
+
+func reducePlan(
+	ctx context.Context,
+	plan *backends.TSMMergePlan,
+	accumulators []*merge.Accumulator,
+) (*merge.Accumulator, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	indexes := make(map[string]int, len(plan.Variants))
+	for i, variant := range plan.Variants {
+		indexes[variant.Name] = i
+	}
+
+	switch plan.Reduction.Kind {
+	case backends.TSMReductionStandard:
+		return accumulators[indexes[plan.Reduction.InputVariants[0]]], nil
+	case backends.TSMReductionWeightedAverage:
+		sumAccumulator := accumulators[indexes[plan.Reduction.InputVariants[0]]]
+		countAccumulator := accumulators[indexes[plan.Reduction.InputVariants[1]]]
+		sumTS, countTS := sumAccumulator.GetTSData(), countAccumulator.GetTSData()
+		if sumTS == nil && countTS == nil {
+			return sumAccumulator, nil
+		}
+		sumDS, sumOK := sumTS.(*dataset.DataSet)
+		countDS, countOK := countTS.(*dataset.DataSet)
+		if !sumOK || !countOK || sumDS == nil || countDS == nil {
+			return nil, errors.New("weighted-average reduction requires paired datasets")
+		}
+		pruneUnpairedWeightedAvgSeries(sumDS, countDS, plan.OriginalQuery)
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		sumDS.FinalizeWeightedAvg(countDS, plan.OriginalQuery)
+		return sumAccumulator, nil
+	default:
+		return nil, fmt.Errorf("unsupported tsm reduction kind %d", plan.Reduction.Kind)
+	}
+}
+
+func appendPlanWarnings(accumulator *merge.Accumulator, warnings []string) {
+	if accumulator == nil || len(warnings) == 0 {
+		return
+	}
+	if ds, ok := accumulator.GetTSData().(*dataset.DataSet); ok && ds != nil {
+		ds.UpdateLock.Lock()
+		ds.Warnings = append(ds.Warnings, warnings...)
+		ds.UpdateLock.Unlock()
+	}
+}

--- a/pkg/backends/alb/mech/tsm/time_series_merge.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge.go
@@ -46,7 +46,6 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
-	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -77,10 +76,6 @@ type handler struct {
 
 type mergeFinalizer interface {
 	FinalizeTSMMerge(query string, ts timeseries.Timeseries)
-}
-
-type mergeRequestRewriter interface {
-	RewriteForTSMMerge(r *http.Request, query string) (*http.Request, string)
 }
 
 // stripKeysSnapshot binds a computed stripKeys slice to the poolVersion it
@@ -286,7 +281,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// rejects requests without start/end/step, so classify directly off
 	// the `query` form parameter. Without this, the merge-strategy
 	// classifier sees an empty string on every instant query and always
-	// falls back to Dedup — which defeats the per-query strip-injected-
+	// falls back to Dedup, which defeats the per-query strip-injected-
 	// labels path for any PromQL aggregation issued as an instant query.
 	//
 	// Body safety for POST form requests: params.GetRequestValues reads
@@ -302,28 +297,35 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			query = qp.Get("query")
 		}
 	}
-	var mergeStrategy dataset.MergeStrategy
-	var needsDualQuery bool
-	var warnMsg string
-	var mp backends.TSMMergeProvider
+	plan := defaultTSMMergePlan(r, query)
 	var finalizer mergeFinalizer
-	var rewriter mergeRequestRewriter
 	if hl[0] != nil {
 		if b := hl[0].Backend(); b != nil {
-			if p, ok := b.(backends.TSMMergeProvider); ok {
-				mp = p
-				strategyInt, dq, w := mp.ClassifyMerge(query)
-				mergeStrategy, needsDualQuery, warnMsg = dataset.MergeStrategy(strategyInt), dq, w
+			if planner, ok := b.(backends.TSMMergeProvider); ok {
+				var err error
+				plan, err = planner.PlanTSMMerge(r, query)
+				if err != nil {
+					logger.Warn("tsm merge plan construction failure", logging.Pairs{"error": err})
+					failures.HandleBadGateway(w, r)
+					return
+				}
 			}
 			if f, ok := b.(mergeFinalizer); ok {
 				finalizer = f
 			}
-			if rw, ok := b.(mergeRequestRewriter); ok {
-				rewriter = rw
-			}
-			// backends that don't implement TSMMergeProvider default to dedup.
 		}
 	}
+	if err := plan.Validate(); err != nil {
+		logger.Warn("invalid tsm merge plan", logging.Pairs{"error": err})
+		failures.HandleBadGateway(w, r)
+		return
+	}
+	if plan.Finalizer.Enabled && finalizer == nil {
+		logger.Warn("tsm merge plan requires an unavailable finalizer", nil)
+		failures.HandleBadGateway(w, r)
+		return
+	}
+	warnMsg := plan.UnsupportedWarning
 
 	// Collect injected label keys from pool backends so they can be stripped
 	// before merging. This ensures series from different backends hash
@@ -331,7 +333,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Stripping is only needed when a non-dedup strategy is in play. The set
 	// is cached and reused across requests until the pool is replaced.
 	var stripKeys []string
-	if mergeStrategy != dataset.MergeStrategyDedup || needsDualQuery {
+	if planNeedsLabelStripping(plan) {
 		stripKeys = h.computeStripKeys(hl)
 	}
 
@@ -360,32 +362,14 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.degradeActive.Store(false)
 	}
 
-	// Single-live-member fast path: with one shard there is nothing to merge
-	// or dedup against, so the lone backend's response IS the answer. Skip
-	// only when label stripping or dual-query rewriting would still need to
-	// happen (D1 covers the strip case; weighted-avg covers the dual-query
-	// case), or when the pool is degraded (configured > 1, one live) so the
-	// merge path can attach the degrade warning. Otherwise the merge path's
-	// OnResult stripping handles solo pools correctly, and genuinely
-	// single-member pools return the lone response directly instead of 502'ing
-	// on a one-shard merge that has no peer to dedup or cross-merge against.
-	if l == 1 && len(stripKeys) == 0 && !needsDualQuery && !degraded {
+	// A plan may explicitly allow direct proxying when no planned rewrite,
+	// reduction, finalization, warning, or injected-label cleanup is needed.
+	if l == 1 && len(stripKeys) == 0 && plan.AllowSingleMemberBypass && !degraded {
 		defaultHandler.ServeHTTP(w, r)
 		return
 	}
 
-	if needsDualQuery {
-		h.serveWeightedAvg(w, r, hl, rsc, mp, query, stripKeys, finalizer)
-		return
-	}
-
-	fanoutReq := r
-	if rewriter != nil {
-		fanoutReq, _ = rewriter.RewriteForTSMMerge(r, query)
-	}
-
-	// Standard scatter/gather for all non-avg strategies.
-	h.serveStandard(w, fanoutReq, hl, rsc, mergeStrategy, stripKeys, query, finalizer, warnMsg)
+	h.servePlan(w, r, hl, rsc, plan, stripKeys, finalizer, warnMsg)
 }
 
 // gatherResult captures the per-member fanout outcome used to assemble the
@@ -883,253 +867,4 @@ func pruneUnpairedWeightedAvgSeries(sumDS, countDS *dataset.DataSet, pairingQuer
 				" series with no matching count side: "+strings.Join(dropped, ","))
 	}
 	sumDS.UpdateLock.Unlock()
-}
-
-// serveWeightedAvg implements the dual-query scatter/gather for outer avg
-// aggregators. For each shard it fires two concurrent requests:
-//   - a "sum" variant (avg → sum) to accumulate the total sum per series
-//   - a "count" variant (avg → count) to accumulate the total count per series
-//
-// After all shards respond, FinalizeWeightedAvg divides sum by count to
-// produce a true weighted arithmetic mean, avoiding the skew that
-// avg-of-averages produces when shards have different cardinalities.
-// The original query string is passed for pairing so sum/count rewrites
-// align with the same logical statement (see dataset.FinalizeWeightedAvg).
-func (h *handler) serveWeightedAvg(
-	w http.ResponseWriter, r *http.Request,
-	hl pool.Targets, rsc *request.Resources,
-	mp backends.TSMMergeProvider, query string, stripKeys []string,
-	finalizer mergeFinalizer,
-) {
-	l := len(hl)
-
-	// Rewrite the request once; the provider encapsulates both the query
-	// expression substitution and the wire-protocol injection (URL param,
-	// POST body, etc.).
-	sumBase, countBase := mp.RewriteForWeightedAvg(r, query)
-
-	sumBase, err := fanout.PrimeBody(sumBase)
-	if err != nil {
-		failures.HandleBadGateway(w, r)
-		return
-	}
-	countBase, err = fanout.PrimeBody(countBase)
-	if err != nil {
-		failures.HandleBadGateway(w, r)
-		return
-	}
-
-	sumAccum := merge.NewAccumulator()
-	countAccum := merge.NewAccumulator()
-
-	limit := h.tsmOptions.ConcurrencyOptions.GetQueryConcurrencyLimit()
-
-	// results captures sum-query outcomes only -- the response envelope
-	// (status, headers, RespondFunc) comes from the sum side; count results
-	// affect the arithmetic, not the envelope.
-	results := make([]gatherResult, l)
-	sumContributions := make([]*gatherContribution, l)
-	countContributions := make([]*gatherContribution, l)
-
-	dedupToleranceNanos := h.dedupToleranceNanos()
-	resourcesFn := func(int) *request.Resources {
-		return &request.Resources{
-			IsMergeMember:         true,
-			TSReqestOptions:       rsc.TSReqestOptions,
-			TSMergeStrategy:       int(dataset.MergeStrategySum),
-			TSDedupToleranceNanos: dedupToleranceNanos,
-		}
-	}
-
-	parentCtx := r.Context()
-	var eg errgroup.Group
-	eg.Go(func() error {
-		_, err := fanout.All(parentCtx, sumBase, hl, fanout.Config{
-			Mechanism:             names.MechanismTSM,
-			Variant:               "avg-sum",
-			ConcurrencyLimit:      limit,
-			MaxCaptureBytes:       h.maxCaptureBytes,
-			MaxFanoutCaptureBytes: h.maxFanoutCaptureBytes,
-			Resources:             resourcesFn,
-			OnResult: func(i int, fr *fanout.Result) {
-				if parentCtx.Err() != nil {
-					results[i].failed = true
-					return
-				}
-				if fr.Failed || fr.Request == nil || fr.Capture == nil {
-					results[i].failed = true
-					return
-				}
-				rsc2 := request.GetResources(fr.Request)
-				if rsc2 == nil {
-					results[i].failed = true
-					return
-				}
-				var contribution *gatherContribution
-				if rsc2.TS != nil {
-					contribution = prepareGatherContribution(parentCtx, rsc2, nil, i, stripKeys)
-				} else if fr.Capture != nil {
-					body, derr := encoding.DecompressResponseBody(
-						fr.Capture.Header().Get(headers.NameContentEncoding),
-						fr.Capture.Body(),
-					)
-					if derr != nil {
-						logger.Warn("tsm avg sum gather decode failure", logging.Pairs{
-							"member": i, "error": derr,
-						})
-						results[i].failed = true
-						return
-					}
-					contribution = prepareGatherContribution(parentCtx, rsc2, body, i, stripKeys)
-				}
-				sumContributions[i] = contribution
-				sc := fr.Capture.StatusCode()
-				if rsc2.Response != nil && rsc2.Response.StatusCode > 0 {
-					sc = rsc2.Response.StatusCode
-				}
-				results[i] = gatherResult{
-					statusCode: sc,
-					header:     fr.Capture.Header(),
-					mergeFunc:  rsc2.MergeRespondFunc,
-					contrib:    contribution,
-					failed:     contribution == nil,
-				}
-			},
-		})
-		return err
-	})
-	eg.Go(func() error {
-		_, err := fanout.All(parentCtx, countBase, hl, fanout.Config{
-			Mechanism:             names.MechanismTSM,
-			Variant:               "avg-count",
-			ConcurrencyLimit:      limit,
-			MaxCaptureBytes:       h.maxCaptureBytes,
-			MaxFanoutCaptureBytes: h.maxFanoutCaptureBytes,
-			Resources:             resourcesFn,
-			OnResult: func(i int, fr *fanout.Result) {
-				// Count-side intentionally does not touch results[i]: the
-				// sum-side owns the response envelope. Panics in this slot
-				// are already recovered + countered by fanout.All.
-				if parentCtx.Err() != nil || fr.Failed || fr.Request == nil {
-					return
-				}
-				rsc2 := request.GetResources(fr.Request)
-				if rsc2 == nil {
-					return
-				}
-				if rsc2.TS != nil {
-					countContributions[i] = prepareGatherContribution(parentCtx, rsc2, nil, i, stripKeys)
-				} else if fr.Capture != nil {
-					body, derr := encoding.DecompressResponseBody(
-						fr.Capture.Header().Get(headers.NameContentEncoding),
-						fr.Capture.Body(),
-					)
-					if derr != nil {
-						logger.Warn("tsm avg count gather decode failure", logging.Pairs{
-							"member": i, "error": derr,
-						})
-						return
-					}
-					countContributions[i] = prepareGatherContribution(parentCtx, rsc2, body, i, stripKeys)
-				}
-			},
-		})
-		return err
-	})
-	if err := eg.Wait(); err != nil && parentCtx.Err() == nil {
-		logger.Warn("tsm avg gather failure", logging.Pairs{"error": err})
-	}
-	if parentCtx.Err() != nil {
-		return
-	}
-	for _, member := range mergeGatherContributions(parentCtx, sumAccum, sumContributions) {
-		results[member].failed = true
-	}
-	if parentCtx.Err() != nil {
-		return
-	}
-	mergeGatherContributions(parentCtx, countAccum, countContributions)
-	if parentCtx.Err() != nil {
-		return
-	}
-
-	// Finalize: divide sum totals by count totals to obtain the weighted
-	// average. If either side fanned out to zero usable responses the
-	// surviving accumulator is unfinalized and not a true average — surface
-	// that to the client via a Prometheus warning rather than returning
-	// silently-wrong numbers (D2).
-	sumTS := sumAccum.GetTSData()
-	countTS := countAccum.GetTSData()
-	const (
-		warnCountFailed = "trickster: weighted-avg count fanout returned no usable responses; values are unfinalized sums and not a true average"
-		warnSumFailed   = "trickster: weighted-avg sum fanout returned no usable responses; values are unfinalized counts and not a true average"
-	)
-	switch {
-	case sumTS != nil && countTS != nil:
-		if sumDS, ok := sumTS.(*dataset.DataSet); ok {
-			if countDS, ok := countTS.(*dataset.DataSet); ok {
-				pruneUnpairedWeightedAvgSeries(sumDS, countDS, query)
-				if parentCtx.Err() != nil {
-					return
-				}
-				sumDS.FinalizeWeightedAvg(countDS, query)
-			}
-		}
-	case sumTS != nil && countTS == nil:
-		if sumDS, ok := sumTS.(*dataset.DataSet); ok {
-			sumDS.Warnings = append(sumDS.Warnings, warnCountFailed)
-		}
-	case sumTS == nil && countTS != nil:
-		// Promote countTS into the response slot so the client sees a body
-		// (with a warning) instead of nothing. The sum-side mrf still
-		// writes — it just marshals whichever DataSet the accumulator now
-		// holds.
-		if countDS, ok := countTS.(*dataset.DataSet); ok {
-			countDS.Warnings = append(countDS.Warnings, warnSumFailed)
-		}
-		sumAccum.SetTSData(countTS)
-	}
-
-	if parentCtx.Err() != nil {
-		return
-	}
-	if finalizer != nil {
-		finalizer.FinalizeTSMMerge(query, sumAccum.GetTSData())
-	}
-	if parentCtx.Err() != nil {
-		return
-	}
-
-	// Aggregate status and headers from sum-query results (count results are
-	// only used for the arithmetic and do not affect the response envelope).
-	mrf, winnerHeaders := pickWinner(results)
-	statusCode, statusHeader, has2xx, hasNon2xx := aggregateStatus(results)
-	if has2xx && hasNon2xx {
-		statusHeader = headers.MergeResultHeaderVals(statusHeader, "engine=ALB; status=phit")
-	}
-
-	// See serveStandard for the rationale -- carry the winner's custom
-	// response headers through the fanout so backend-set headers like
-	// `X-Test-Origin` survive the merge. (#970)
-	if mrf == nil {
-		failures.HandleBadGateway(w, r)
-		return
-	}
-	mergeMultiValuedHeaders(w.Header(), results, winnerHeaders)
-	if winnerHeaders != nil {
-		headers.Merge(w.Header(), winnerHeaders)
-	}
-
-	if statusHeader != "" {
-		w.Header().Set(headers.NameTricksterResult, statusHeader)
-	}
-
-	if statusCode == 0 {
-		statusCode = http.StatusOK
-	}
-	// Write the finalized sum accumulator (which now contains weighted averages)
-	// using the RespondFunc from the sum queries.
-	if mrf != nil {
-		mrf(w, r, sumAccum, statusCode)
-	}
 }

--- a/pkg/backends/alb/mech/tsm/time_series_merge_finalizer_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_finalizer_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/trickstercache/trickster/v2/pkg/backends"
 	"github.com/trickstercache/trickster/v2/pkg/backends/alb/pool"
 	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
 	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
@@ -47,12 +48,11 @@ type finalizerStubBackend struct {
 	query string
 }
 
-func (b *finalizerStubBackend) ClassifyMerge(string) (int, bool, string) {
-	return int(dataset.MergeStrategyDedup), false, ""
-}
-
-func (b *finalizerStubBackend) RewriteForWeightedAvg(r *http.Request, _ string) (*http.Request, *http.Request) {
-	return r, r
+func (b *finalizerStubBackend) PlanTSMMerge(r *http.Request, query string) (*backends.TSMMergePlan, error) {
+	plan := defaultTSMMergePlan(r, query)
+	plan.Finalizer = backends.TSMFinalizerSpec{Enabled: true, Query: query}
+	plan.AllowSingleMemberBypass = false
+	return plan, nil
 }
 
 func (b *finalizerStubBackend) FinalizeTSMMerge(query string, ts timeseries.Timeseries) {
@@ -85,19 +85,29 @@ type prometheusSortBackend struct {
 
 func (b *prometheusSortBackend) Configuration() *bo.Options { return nil }
 
-func (b *rankRewriteFinalizerStubBackend) ClassifyMerge(string) (int, bool, string) {
-	return int(dataset.MergeStrategySum), false, ""
-}
-
-func (b *rankRewriteFinalizerStubBackend) RewriteForTSMMerge(
-	r *http.Request, _ string,
-) (*http.Request, string) {
+func (b *rankRewriteFinalizerStubBackend) PlanTSMMerge(
+	r *http.Request, query string,
+) (*backends.TSMMergePlan, error) {
 	next, err := request.Clone(r)
 	if err != nil {
-		return r, b.innerQuery
+		return nil, err
 	}
 	params.SetRequestValues(next, url.Values{"query": {b.innerQuery}})
-	return next, b.innerQuery
+	return &backends.TSMMergePlan{
+		OriginalQuery: query,
+		Variants: []backends.TSMQueryVariant{{
+			Name:              "primary",
+			Request:           next,
+			MergeStrategy:     int(dataset.MergeStrategySum),
+			ResponseAuthority: true,
+		}},
+		Reduction: backends.TSMReductionSpec{
+			Kind:          backends.TSMReductionStandard,
+			InputVariants: []string{"primary"},
+		},
+		Finalizer:    backends.TSMFinalizerSpec{Enabled: true, Query: query},
+		Completeness: backends.TSMCompletenessResponseAuthority,
+	}, nil
 }
 
 type queryRecorder struct {

--- a/pkg/backends/alb/mech/tsm/time_series_merge_serve_weighted_avg_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_serve_weighted_avg_test.go
@@ -17,17 +17,26 @@
 package tsm
 
 import (
+	"context"
+	"errors"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends"
+	"github.com/trickstercache/trickster/v2/pkg/backends/alb/names"
+	"github.com/trickstercache/trickster/v2/pkg/backends/alb/options"
 	"github.com/trickstercache/trickster/v2/pkg/backends/alb/pool"
 	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
+	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
+	prop "github.com/trickstercache/trickster/v2/pkg/backends/prometheus/options"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/params"
@@ -43,52 +52,79 @@ type weightedAvgStubBackend struct {
 	stripKeysStubBackend
 }
 
-func (b *weightedAvgStubBackend) ClassifyMerge(query string) (int, bool, string) {
-	if strings.HasPrefix(query, "avg(") {
-		return int(dataset.MergeStrategySum), true, ""
+func (b *weightedAvgStubBackend) PlanTSMMerge(r *http.Request, query string) (*backends.TSMMergePlan, error) {
+	if !strings.HasPrefix(query, "avg(") {
+		plan := defaultTSMMergePlan(r, query)
+		if strings.HasPrefix(query, "stddev(") {
+			plan.UnsupportedWarning = "unsupported stddev merge"
+			plan.AllowSingleMemberBypass = false
+		}
+		return plan, nil
 	}
-	return int(dataset.MergeStrategyDedup), false, ""
-}
-
-func (b *weightedAvgStubBackend) RewriteForWeightedAvg(r *http.Request, query string) (*http.Request, *http.Request) {
 	sumReq, err := request.Clone(r)
 	if err != nil {
-		return r, r
+		return nil, err
 	}
 	countReq, err := request.Clone(r)
 	if err != nil {
-		return sumReq, sumReq
+		return nil, err
 	}
 	sumQP := url.Values{"query": {strings.Replace(query, "avg(", "sum(", 1)}}
 	countQP := url.Values{"query": {strings.Replace(query, "avg(", "count(", 1)}}
 	params.SetRequestValues(sumReq, sumQP)
 	params.SetRequestValues(countReq, countQP)
-	return sumReq, countReq
+	return &backends.TSMMergePlan{
+		OriginalQuery: query,
+		Variants: []backends.TSMQueryVariant{
+			{
+				Name:              "avg-sum",
+				Request:           sumReq,
+				MergeStrategy:     int(dataset.MergeStrategySum),
+				ResponseAuthority: true,
+			},
+			{
+				Name:          "avg-count",
+				Request:       countReq,
+				MergeStrategy: int(dataset.MergeStrategySum),
+			},
+		},
+		Reduction: backends.TSMReductionSpec{
+			Kind:          backends.TSMReductionWeightedAverage,
+			InputVariants: []string{"avg-sum", "avg-count"},
+		},
+		Completeness: backends.TSMCompletenessAllVariants,
+	}, nil
 }
 
 type weightedAvgRankStubBackend struct {
 	weightedAvgStubBackend
 	mu    sync.Mutex
 	query string
+	calls int
 }
 
-func (b *weightedAvgRankStubBackend) ClassifyMerge(query string) (int, bool, string) {
-	if strings.HasPrefix(query, "topk(") {
-		return int(dataset.MergeStrategySum), true, ""
-	}
-	return b.weightedAvgStubBackend.ClassifyMerge(query)
-}
-
-func (b *weightedAvgRankStubBackend) RewriteForWeightedAvg(r *http.Request, query string) (*http.Request, *http.Request) {
+func (b *weightedAvgRankStubBackend) PlanTSMMerge(r *http.Request, query string) (*backends.TSMMergePlan, error) {
+	originalQuery := query
+	finalize := false
 	if strings.HasPrefix(query, "topk(") {
 		query = "avg(requests)"
+		finalize = true
 	}
-	return b.weightedAvgStubBackend.RewriteForWeightedAvg(r, query)
+	plan, err := b.weightedAvgStubBackend.PlanTSMMerge(r, query)
+	if err != nil {
+		return nil, err
+	}
+	plan.OriginalQuery = originalQuery
+	if finalize {
+		plan.Finalizer = backends.TSMFinalizerSpec{Enabled: true, Query: originalQuery}
+	}
+	return plan, nil
 }
 
 func (b *weightedAvgRankStubBackend) FinalizeTSMMerge(query string, ts timeseries.Timeseries) {
 	b.mu.Lock()
 	b.query = query
+	b.calls++
 	b.mu.Unlock()
 
 	if ds, ok := ts.(*dataset.DataSet); ok && ds != nil {
@@ -102,16 +138,26 @@ func (b *weightedAvgRankStubBackend) Query() string {
 	return b.query
 }
 
+func (b *weightedAvgRankStubBackend) FinalizerCalls() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.calls
+}
+
 type weightedAvgMemberSpec struct {
 	sumValue   string
 	countValue string
 }
 
 func weightedAvgDataSet(value string) *dataset.DataSet {
+	return weightedAvgDataSetWithTags(value, dataset.Tags{})
+}
+
+func weightedAvgDataSetWithTags(value string, tags dataset.Tags) *dataset.DataSet {
 	return &dataset.DataSet{
 		Results: dataset.Results{{
 			SeriesList: dataset.SeriesList{{
-				Header: dataset.SeriesHeader{Name: "requests", Tags: dataset.Tags{}},
+				Header: dataset.SeriesHeader{Name: "requests", Tags: maps.Clone(tags)},
 				Points: dataset.Points{{
 					Epoch:  epoch.Epoch(100),
 					Size:   32,
@@ -120,6 +166,47 @@ func weightedAvgDataSet(value string) *dataset.DataSet {
 			}},
 		}},
 	}
+}
+
+func taggedWeightedAvgRespondFunc(
+	w http.ResponseWriter,
+	_ *http.Request,
+	accum *merge.Accumulator,
+	statusCode int,
+) {
+	ds, _ := accum.GetTSData().(*dataset.DataSet)
+	seriesCount := 0
+	value := ""
+	if ds != nil && len(ds.Results) > 0 && ds.Results[0] != nil {
+		seriesCount = len(ds.Results[0].SeriesList)
+		if seriesCount > 0 && len(ds.Results[0].SeriesList[0].Points) > 0 {
+			point := ds.Results[0].SeriesList[0].Points[0]
+			if len(point.Values) > 0 {
+				value = formatAny(point.Values[0])
+			}
+		}
+	}
+	w.WriteHeader(statusCode)
+	_, _ = w.Write([]byte("series=" + strconv.Itoa(seriesCount) + ";value=" + value))
+}
+
+func taggedWeightedAvgMemberHandler(spec weightedAvgMemberSpec, tags dataset.Tags) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		qp, _, _ := params.GetRequestValues(r)
+		query := qp.Get("query")
+		value := spec.sumValue
+		if strings.HasPrefix(query, "count(") {
+			value = spec.countValue
+		}
+		rsc := request.GetResources(r)
+		if rsc != nil {
+			rsc.TS = weightedAvgDataSetWithTags(value, tags)
+			rsc.MergeFunc = merge.TimeseriesMergeFuncWithStrategy(nil, rsc.TSMergeStrategy)
+			rsc.BatchMergeFunc = merge.TimeseriesBatchMergeFuncWithStrategy(rsc.TSMergeStrategy)
+			rsc.MergeRespondFunc = taggedWeightedAvgRespondFunc
+		}
+		w.WriteHeader(http.StatusOK)
+	})
 }
 
 func weightedAvgRespondFunc(w http.ResponseWriter, _ *http.Request, accum *merge.Accumulator, statusCode int) {
@@ -218,6 +305,80 @@ func weightedAvgEmptySideHandler(failCount bool) http.Handler {
 	})
 }
 
+func weightedAvgFailVariantHandler(spec weightedAvgMemberSpec, variant, mode string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		qp, _, _ := params.GetRequestValues(r)
+		query := qp.Get("query")
+		isCount := strings.HasPrefix(query, "count(")
+		currentVariant := "avg-sum"
+		value := spec.sumValue
+		if isCount {
+			currentVariant = "avg-count"
+			value = spec.countValue
+		}
+		rsc := request.GetResources(r)
+		if rsc != nil {
+			rsc.MergeRespondFunc = weightedAvgRespondFunc
+		}
+		if currentVariant == variant {
+			switch mode {
+			case "status":
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			case "parse":
+				if rsc != nil {
+					rsc.MergeFunc = merge.TimeseriesMergeFuncWithStrategy(nil, rsc.TSMergeStrategy)
+					rsc.TimeRangeQuery = &timeseries.TimeRangeQuery{Statement: query}
+					rsc.TSUnmarshaler = func([]byte, *timeseries.TimeRangeQuery) (timeseries.Timeseries, error) {
+						return nil, errors.New("parse failure")
+					}
+				}
+				_, _ = w.Write([]byte("malformed"))
+				return
+			case "panic":
+				panic("variant panic")
+			case "transport":
+				if capture := request.GetUpstreamShortReadCapture(r.Context()); capture != nil {
+					capture.Mark()
+				}
+				w.WriteHeader(http.StatusOK)
+				return
+			case "capture":
+				if rsc != nil {
+					rsc.MergeFunc = merge.TimeseriesMergeFuncWithStrategy(nil, rsc.TSMergeStrategy)
+				}
+				_, _ = w.Write([]byte(strings.Repeat("x", 256)))
+				return
+			}
+		}
+		if rsc != nil {
+			rsc.TS = weightedAvgDataSet(value)
+			rsc.MergeFunc = merge.TimeseriesMergeFuncWithStrategy(nil, rsc.TSMergeStrategy)
+			rsc.BatchMergeFunc = merge.TimeseriesBatchMergeFuncWithStrategy(rsc.TSMergeStrategy)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func delayedWeightedAvgMemberHandler(spec weightedAvgMemberSpec, sumDelay, countDelay time.Duration) http.Handler {
+	base := weightedAvgMemberHandler(spec)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		qp, _, _ := params.GetRequestValues(r)
+		delay := sumDelay
+		if strings.HasPrefix(qp.Get("query"), "count(") {
+			delay = countDelay
+		}
+		if delay > 0 {
+			select {
+			case <-time.After(delay):
+			case <-r.Context().Done():
+				return
+			}
+		}
+		base.ServeHTTP(w, r)
+	})
+}
+
 func newWeightedAvgTarget(h http.Handler) *pool.Target {
 	st := &healthcheck.Status{}
 	st.Set(healthcheck.StatusPassing)
@@ -247,13 +408,26 @@ func newWeightedAvgRankPool(handlers []http.Handler, be *weightedAvgRankStubBack
 	return p
 }
 
-func newWeightedAvgRequest(t *testing.T, query string) *http.Request {
+func newWeightedAvgRequest(t testing.TB, query string) *http.Request {
 	t.Helper()
 	r := albpool.NewParentGET(t)
 	r.URL.RawQuery = "query=" + url.QueryEscape(query)
 	rsc := request.NewResources(nil, nil, nil, nil, nil, nil)
 	rsc.TimeRangeQuery = &timeseries.TimeRangeQuery{Statement: query}
 	return request.SetResources(r, rsc)
+}
+
+func standardPlanMemberHandler(value string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rsc := request.GetResources(r)
+		if rsc != nil {
+			rsc.TS = weightedAvgDataSet(value)
+			rsc.MergeFunc = merge.TimeseriesMergeFuncWithStrategy(nil, rsc.TSMergeStrategy)
+			rsc.BatchMergeFunc = merge.TimeseriesBatchMergeFuncWithStrategy(rsc.TSMergeStrategy)
+			rsc.MergeRespondFunc = weightedAvgRespondFunc
+		}
+		w.WriteHeader(http.StatusOK)
+	})
 }
 
 func TestServeWeightedAvg(t *testing.T) {
@@ -271,7 +445,11 @@ func TestServeWeightedAvg(t *testing.T) {
 		h.SetPool(p)
 
 		w := httptest.NewRecorder()
-		h.ServeHTTP(w, newWeightedAvgRequest(t, "avg(requests)"))
+		albpool.RequireFanoutAttemptDelta(t, names.MechanismTSM, "avg-sum", 1, func() {
+			albpool.RequireFanoutAttemptDelta(t, names.MechanismTSM, "avg-count", 1, func() {
+				h.ServeHTTP(w, newWeightedAvgRequest(t, "avg(requests)"))
+			})
+		})
 
 		if w.Code != http.StatusOK {
 			t.Fatalf("status: want 200 got %d body=%q", w.Code, w.Body.String())
@@ -282,33 +460,330 @@ func TestServeWeightedAvg(t *testing.T) {
 		}
 	})
 
-	t.Run("count_fanout_empty_warns_unfinalized_sums", func(t *testing.T) {
-		p := newWeightedAvgPool([]http.Handler{
-			weightedAvgEmptySideHandler(true),
-			weightedAvgEmptySideHandler(true),
-		})
+	t.Run("unsupported_single_member_plan_preserves_warning", func(t *testing.T) {
+		p := newWeightedAvgPool([]http.Handler{standardPlanMemberHandler("10")})
 		defer p.Stop()
-		albpool.WaitHealthy(t, p, 2)
-
+		albpool.WaitHealthy(t, p, 1)
 		h := &handler{mergePaths: []string{"/"}}
 		h.SetPool(p)
-
 		w := httptest.NewRecorder()
-		h.ServeHTTP(w, newWeightedAvgRequest(t, "avg(requests)"))
-
-		if w.Code != http.StatusOK {
-			t.Fatalf("status: want 200 got %d body=%q", w.Code, w.Body.String())
-		}
-		body := w.Body.String()
-		if !strings.Contains(body, "100=20") {
-			t.Fatalf("body: want unfinalized merged sum 100=20, got %q", body)
-		}
-		if !strings.Contains(body, "count fanout returned no usable responses") {
-			t.Fatalf("body: want count-fanout warning, got %q", body)
+		h.ServeHTTP(w, newWeightedAvgRequest(t, "stddev(requests)"))
+		if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "unsupported stddev merge") {
+			t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
 		}
 	})
 
-	t.Run("sum_fanout_empty_promotes_count_with_warning", func(t *testing.T) {
+	t.Run("degraded_pool_preserves_warning", func(t *testing.T) {
+		healthy := newWeightedAvgTarget(
+			weightedAvgMemberHandler(weightedAvgMemberSpec{sumValue: "60", countValue: "3"}),
+		)
+		failingStatus := &healthcheck.Status{}
+		failingStatus.Set(healthcheck.StatusInitializing)
+		failing := pool.NewTarget(
+			weightedAvgMemberHandler(weightedAvgMemberSpec{sumValue: "40", countValue: "1"}),
+			failingStatus,
+			&weightedAvgStubBackend{},
+		)
+		p := pool.New(pool.Targets{healthy, failing}, -1)
+		p.RefreshHealthy()
+		defer p.Stop()
+		albpool.WaitHealthy(t, p, 1)
+		h := &handler{mergePaths: []string{"/"}}
+		h.SetPool(p)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newWeightedAvgRequest(t, "avg(requests)"))
+		if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "100=20") ||
+			!strings.Contains(w.Body.String(), "served from 1 of 2 pool members") {
+			t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("multi_variant_plan_strips_injected_labels", func(t *testing.T) {
+		specs := []weightedAvgMemberSpec{
+			{sumValue: "60", countValue: "3"},
+			{sumValue: "40", countValue: "1"},
+		}
+		targets := make(pool.Targets, len(specs))
+		for i, spec := range specs {
+			region := "region-" + strconv.Itoa(i)
+			status := &healthcheck.Status{}
+			status.Set(healthcheck.StatusPassing)
+			backend := &weightedAvgStubBackend{stripKeysStubBackend: stripKeysStubBackend{
+				cfg: &bo.Options{Prometheus: &prop.Options{Labels: map[string]string{
+					"region": region,
+				}}},
+			}}
+			targets[i] = pool.NewTarget(
+				taggedWeightedAvgMemberHandler(spec, dataset.Tags{"region": region}),
+				status,
+				backend,
+			)
+		}
+		p := pool.New(targets, -1)
+		p.RefreshHealthy()
+		defer p.Stop()
+		albpool.WaitHealthy(t, p, len(specs))
+		h := &handler{mergePaths: []string{"/"}}
+		h.SetPool(p)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newWeightedAvgRequest(t, "avg(requests)"))
+		if w.Code != http.StatusOK || w.Body.String() != "series=1;value=25" {
+			t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+		}
+	})
+
+	for _, test := range []struct {
+		name           string
+		missingVariant string
+		mode           string
+	}{
+		{"count status failure", "avg-count", "status"},
+		{"count parse failure", "avg-count", "parse"},
+		{"count panic", "avg-count", "panic"},
+		{"count transport failure", "avg-count", "transport"},
+		{"count capture failure", "avg-count", "capture"},
+		{"sum status failure", "avg-sum", "status"},
+	} {
+		t.Run("member_completeness_"+strings.ReplaceAll(test.name, " ", "_"), func(t *testing.T) {
+			p := newWeightedAvgPool([]http.Handler{
+				weightedAvgMemberHandler(weightedAvgMemberSpec{sumValue: "60", countValue: "3"}),
+				weightedAvgFailVariantHandler(
+					weightedAvgMemberSpec{sumValue: "40", countValue: "1"},
+					test.missingVariant, test.mode,
+				),
+			})
+			defer p.Stop()
+			albpool.WaitHealthy(t, p, 2)
+
+			h := &handler{mergePaths: []string{"/"}, maxCaptureBytes: 32}
+			h.SetPool(p)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, newWeightedAvgRequest(t, "avg(requests)"))
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status: want 200 got %d body=%q", w.Code, w.Body.String())
+			}
+			body := w.Body.String()
+			if !strings.Contains(body, "100=20") {
+				t.Fatalf("body: incomplete member affected result: %q", body)
+			}
+			if strings.Contains(body, "100=25") {
+				t.Fatalf("body: incomplete member was included: %q", body)
+			}
+			if !strings.Contains(body, "pool member 1") ||
+				!strings.Contains(body, `variant "`+test.missingVariant+`"`) {
+				t.Fatalf("body: missing member/variant warning: %q", body)
+			}
+			if got := w.Header().Get(headers.NameTricksterResult); !strings.Contains(got, "status=phit") {
+				t.Fatalf("result header: want phit, got %q", got)
+			}
+		})
+	}
+
+	t.Run("completion_order_does_not_change_reduction", func(t *testing.T) {
+		orders := []struct {
+			sum0, count0 time.Duration
+			sum1, count1 time.Duration
+		}{
+			{sum0: 30 * time.Millisecond, count1: 20 * time.Millisecond},
+			{count0: 30 * time.Millisecond, sum1: 20 * time.Millisecond},
+		}
+		for i, order := range orders {
+			p := newWeightedAvgPool([]http.Handler{
+				delayedWeightedAvgMemberHandler(
+					weightedAvgMemberSpec{sumValue: "60", countValue: "3"},
+					order.sum0, order.count0,
+				),
+				delayedWeightedAvgMemberHandler(
+					weightedAvgMemberSpec{sumValue: "40", countValue: "1"},
+					order.sum1, order.count1,
+				),
+			})
+			albpool.WaitHealthy(t, p, 2)
+			h := &handler{mergePaths: []string{"/"}}
+			h.SetPool(p)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, newWeightedAvgRequest(t, "avg(requests)"))
+			p.Stop()
+			if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "100=25") {
+				t.Fatalf("order %d: status=%d body=%q", i, w.Code, w.Body.String())
+			}
+		}
+	})
+
+	t.Run("variants_share_query_concurrency_limit", func(t *testing.T) {
+		var current, maximum atomic.Int32
+		wrap := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				n := current.Add(1)
+				for old := maximum.Load(); n > old && !maximum.CompareAndSwap(old, n); old = maximum.Load() {
+				}
+				defer current.Add(-1)
+				time.Sleep(10 * time.Millisecond)
+				next.ServeHTTP(w, r)
+			})
+		}
+		p := newWeightedAvgPool([]http.Handler{
+			wrap(weightedAvgMemberHandler(weightedAvgMemberSpec{sumValue: "60", countValue: "3"})),
+			wrap(weightedAvgMemberHandler(weightedAvgMemberSpec{sumValue: "40", countValue: "1"})),
+		})
+		defer p.Stop()
+		albpool.WaitHealthy(t, p, 2)
+		limit := 1
+		h := &handler{
+			mergePaths: []string{"/"},
+			tsmOptions: options.TimeSeriesMergeOptions{
+				ConcurrencyOptions: options.ConcurrencyOptions{QueryConcurrencyLimit: &limit},
+			},
+		}
+		h.SetPool(p)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newWeightedAvgRequest(t, "avg(requests)"))
+		if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "100=25") {
+			t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+		}
+		if got := maximum.Load(); got != 1 {
+			t.Fatalf("maximum in-flight requests: got %d want 1", got)
+		}
+	})
+
+	t.Run("fanout_capture_budget_is_independent_per_variant", func(t *testing.T) {
+		p := newWeightedAvgPool([]http.Handler{
+			weightedAvgMemberHandler(weightedAvgMemberSpec{sumValue: "60", countValue: "3"}),
+			weightedAvgMemberHandler(weightedAvgMemberSpec{sumValue: "40", countValue: "1"}),
+		})
+		defer p.Stop()
+		albpool.WaitHealthy(t, p, 2)
+		h := &handler{
+			mergePaths:            []string{"/"},
+			maxCaptureBytes:       64,
+			maxFanoutCaptureBytes: 64,
+		}
+		h.SetPool(p)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newWeightedAvgRequest(t, "avg(requests)"))
+		if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "100=20") {
+			t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+		}
+		if !strings.Contains(w.Body.String(), "pool member 1") {
+			t.Fatalf("body: want excluded second member warning, got %q", w.Body.String())
+		}
+	})
+
+	t.Run("response_authority_controls_headers", func(t *testing.T) {
+		member := func(id string, spec weightedAvgMemberSpec) http.Handler {
+			base := weightedAvgMemberHandler(spec)
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				qp, _, _ := params.GetRequestValues(r)
+				variant := "sum"
+				if strings.HasPrefix(qp.Get("query"), "count(") {
+					variant = "count"
+				}
+				w.Header().Set("X-Plan-Authority", variant+"-"+id)
+				w.Header().Add(headers.NameSetCookie, variant+"-"+id+"=1")
+				if id == "a" && variant == "sum" {
+					w.Header().Add(headers.NameSetCookie, "sum-a-extra=1")
+				}
+				base.ServeHTTP(w, r)
+			})
+		}
+		p := newWeightedAvgPool([]http.Handler{
+			member("a", weightedAvgMemberSpec{sumValue: "60", countValue: "3"}),
+			member("b", weightedAvgMemberSpec{sumValue: "40", countValue: "1"}),
+		})
+		defer p.Stop()
+		albpool.WaitHealthy(t, p, 2)
+		h := &handler{mergePaths: []string{"/"}}
+		h.SetPool(p)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newWeightedAvgRequest(t, "avg(requests)"))
+		if got := w.Header().Get("X-Plan-Authority"); got != "sum-a" {
+			t.Fatalf("authority header: got %q want %q", got, "sum-a")
+		}
+		cookies := w.Header().Values(headers.NameSetCookie)
+		if strings.Join(cookies, ",") != "sum-a=1,sum-a-extra=1" {
+			t.Fatalf("authority cookies: got %v", cookies)
+		}
+	})
+
+	t.Run("all_authority_fanout_failures_return_bad_gateway", func(t *testing.T) {
+		p := newWeightedAvgPool([]http.Handler{
+			weightedAvgFailVariantHandler(weightedAvgMemberSpec{sumValue: "60", countValue: "3"}, "avg-sum", "panic"),
+			weightedAvgFailVariantHandler(weightedAvgMemberSpec{sumValue: "40", countValue: "1"}, "avg-sum", "panic"),
+		})
+		defer p.Stop()
+		albpool.WaitHealthy(t, p, 2)
+		h := &handler{mergePaths: []string{"/"}}
+		h.SetPool(p)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newWeightedAvgRequest(t, "avg(requests)"))
+		if w.Code != http.StatusBadGateway {
+			t.Fatalf("status: got %d want 502 body=%q", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("cancellation_stops_all_variants", func(t *testing.T) {
+		started := make(chan struct{}, 1)
+		blocking := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-r.Context().Done()
+		})
+		p := newWeightedAvgPool([]http.Handler{blocking, blocking})
+		defer p.Stop()
+		albpool.WaitHealthy(t, p, 2)
+		h := &handler{mergePaths: []string{"/"}}
+		h.SetPool(p)
+		r := newWeightedAvgRequest(t, "avg(requests)")
+		ctx, cancel := context.WithCancel(r.Context())
+		r = r.WithContext(ctx)
+		done := make(chan struct{})
+		go func() {
+			h.ServeHTTP(httptest.NewRecorder(), r)
+			close(done)
+		}()
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("fanout did not start")
+		}
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("ServeHTTP did not return after cancellation")
+		}
+	})
+
+	t.Run("count_fanout_empty_excludes_unpaired_members", func(t *testing.T) {
+		p := newWeightedAvgPool([]http.Handler{
+			weightedAvgEmptySideHandler(true),
+			weightedAvgEmptySideHandler(true),
+		})
+		defer p.Stop()
+		albpool.WaitHealthy(t, p, 2)
+
+		h := &handler{mergePaths: []string{"/"}}
+		h.SetPool(p)
+
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newWeightedAvgRequest(t, "avg(requests)"))
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status: want 200 got %d body=%q", w.Code, w.Body.String())
+		}
+		body := w.Body.String()
+		if !strings.Contains(body, "MERGED:empty") {
+			t.Fatalf("body: want empty paired result, got %q", body)
+		}
+		if !strings.Contains(body, `variant "avg-count" returned no usable response`) {
+			t.Fatalf("body: want missing avg-count warning, got %q", body)
+		}
+	})
+
+	t.Run("sum_fanout_empty_excludes_unpaired_members", func(t *testing.T) {
 		p := newWeightedAvgPool([]http.Handler{
 			weightedAvgEmptySideHandler(false),
 			weightedAvgEmptySideHandler(false),
@@ -326,11 +801,35 @@ func TestServeWeightedAvg(t *testing.T) {
 			t.Fatalf("status: want 200 got %d body=%q", w.Code, w.Body.String())
 		}
 		body := w.Body.String()
-		if !strings.Contains(body, "100=4") {
-			t.Fatalf("body: want promoted merged count 100=4, got %q", body)
+		if !strings.Contains(body, "MERGED:empty") {
+			t.Fatalf("body: want empty paired result, got %q", body)
 		}
-		if !strings.Contains(body, "sum fanout returned no usable responses") {
-			t.Fatalf("body: want sum-fanout warning, got %q", body)
+		if !strings.Contains(body, `variant "avg-sum" returned no usable response`) {
+			t.Fatalf("body: want missing avg-sum warning, got %q", body)
+		}
+	})
+
+	t.Run("all_variants_empty_preserves_completeness_warnings", func(t *testing.T) {
+		empty := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if rsc := request.GetResources(r); rsc != nil {
+				rsc.MergeRespondFunc = weightedAvgRespondFunc
+			}
+			w.WriteHeader(http.StatusOK)
+		})
+		p := newWeightedAvgPool([]http.Handler{empty, empty})
+		defer p.Stop()
+		albpool.WaitHealthy(t, p, 2)
+		h := &handler{mergePaths: []string{"/"}}
+		h.SetPool(p)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newWeightedAvgRequest(t, "avg(requests)"))
+		body := w.Body.String()
+		if w.Code != http.StatusOK || !strings.Contains(body, "MERGED:empty") {
+			t.Fatalf("status=%d body=%q", w.Code, body)
+		}
+		if !strings.Contains(body, `variant "avg-sum"`) ||
+			!strings.Contains(body, `variant "avg-count"`) {
+			t.Fatalf("body: missing completeness warnings: %q", body)
 		}
 	})
 
@@ -416,7 +915,55 @@ func TestServeWeightedAvg(t *testing.T) {
 		if got := be.Query(); got != query {
 			t.Fatalf("finalizer query got %q want %q", got, query)
 		}
+		if got := be.FinalizerCalls(); got != 1 {
+			t.Fatalf("finalizer calls got %d want 1", got)
+		}
 	})
+}
+
+func BenchmarkServeMergePlan(b *testing.B) {
+	benchmarks := []struct {
+		name     string
+		query    string
+		handlers []http.Handler
+	}{
+		{
+			name:  "standard_one_variant",
+			query: "up",
+			handlers: []http.Handler{
+				standardPlanMemberHandler("10"), standardPlanMemberHandler("20"),
+				standardPlanMemberHandler("30"), standardPlanMemberHandler("40"),
+			},
+		},
+		{
+			name:  "weighted_average_two_variants",
+			query: "avg(requests)",
+			handlers: []http.Handler{
+				weightedAvgMemberHandler(weightedAvgMemberSpec{sumValue: "10", countValue: "1"}),
+				weightedAvgMemberHandler(weightedAvgMemberSpec{sumValue: "20", countValue: "2"}),
+				weightedAvgMemberHandler(weightedAvgMemberSpec{sumValue: "30", countValue: "3"}),
+				weightedAvgMemberHandler(weightedAvgMemberSpec{sumValue: "40", countValue: "4"}),
+			},
+		},
+	}
+	for _, benchmark := range benchmarks {
+		b.Run(benchmark.name, func(b *testing.B) {
+			p := newWeightedAvgPool(benchmark.handlers)
+			defer p.Stop()
+			albpool.WaitHealthy(b, p, len(benchmark.handlers))
+			h := &handler{mergePaths: []string{"/"}}
+			h.SetPool(p)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				w := httptest.NewRecorder()
+				h.ServeHTTP(w, newWeightedAvgRequest(b, benchmark.query))
+				if w.Code != http.StatusOK {
+					b.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+				}
+			}
+		})
+	}
 }
 
 // Compile-time check that the stub satisfies TSMMergeProvider.

--- a/pkg/backends/alb/mech/tsm/time_series_merge_serve_weighted_avg_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_serve_weighted_avg_test.go
@@ -77,20 +77,20 @@ func (b *weightedAvgStubBackend) PlanTSMMerge(r *http.Request, query string) (*b
 		OriginalQuery: query,
 		Variants: []backends.TSMQueryVariant{
 			{
-				Name:              "avg-sum",
+				Name:              backends.TSMVariantWeightedAverageSum,
 				Request:           sumReq,
 				MergeStrategy:     int(dataset.MergeStrategySum),
 				ResponseAuthority: true,
 			},
 			{
-				Name:          "avg-count",
+				Name:          backends.TSMVariantWeightedAverageCount,
 				Request:       countReq,
 				MergeStrategy: int(dataset.MergeStrategySum),
 			},
 		},
 		Reduction: backends.TSMReductionSpec{
 			Kind:          backends.TSMReductionWeightedAverage,
-			InputVariants: []string{"avg-sum", "avg-count"},
+			InputVariants: backends.TSMReductionWeightedAverageVariants(),
 		},
 		Completeness: backends.TSMCompletenessAllVariants,
 	}, nil
@@ -310,10 +310,10 @@ func weightedAvgFailVariantHandler(spec weightedAvgMemberSpec, variant, mode str
 		qp, _, _ := params.GetRequestValues(r)
 		query := qp.Get("query")
 		isCount := strings.HasPrefix(query, "count(")
-		currentVariant := "avg-sum"
+		currentVariant := backends.TSMVariantWeightedAverageSum
 		value := spec.sumValue
 		if isCount {
-			currentVariant = "avg-count"
+			currentVariant = backends.TSMVariantWeightedAverageCount
 			value = spec.countValue
 		}
 		rsc := request.GetResources(r)
@@ -323,6 +323,15 @@ func weightedAvgFailVariantHandler(spec weightedAvgMemberSpec, variant, mode str
 		if currentVariant == variant {
 			switch mode {
 			case "status":
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			case "status-data":
+				if rsc != nil {
+					rsc.TS = weightedAvgDataSet(value)
+					rsc.MergeFunc = merge.TimeseriesMergeFuncWithStrategy(nil, rsc.TSMergeStrategy)
+					rsc.BatchMergeFunc = merge.TimeseriesBatchMergeFuncWithStrategy(
+						rsc.TSMergeStrategy)
+				}
 				w.WriteHeader(http.StatusServiceUnavailable)
 				return
 			case "parse":
@@ -445,11 +454,13 @@ func TestServeWeightedAvg(t *testing.T) {
 		h.SetPool(p)
 
 		w := httptest.NewRecorder()
-		albpool.RequireFanoutAttemptDelta(t, names.MechanismTSM, "avg-sum", 1, func() {
-			albpool.RequireFanoutAttemptDelta(t, names.MechanismTSM, "avg-count", 1, func() {
-				h.ServeHTTP(w, newWeightedAvgRequest(t, "avg(requests)"))
+		albpool.RequireFanoutAttemptDelta(t, names.MechanismTSM,
+			backends.TSMVariantWeightedAverageSum, 1, func() {
+				albpool.RequireFanoutAttemptDelta(t, names.MechanismTSM,
+					backends.TSMVariantWeightedAverageCount, 1, func() {
+						h.ServeHTTP(w, newWeightedAvgRequest(t, "avg(requests)"))
+					})
 			})
-		})
 
 		if w.Code != http.StatusOK {
 			t.Fatalf("status: want 200 got %d body=%q", w.Code, w.Body.String())
@@ -537,12 +548,14 @@ func TestServeWeightedAvg(t *testing.T) {
 		missingVariant string
 		mode           string
 	}{
-		{"count status failure", "avg-count", "status"},
-		{"count parse failure", "avg-count", "parse"},
-		{"count panic", "avg-count", "panic"},
-		{"count transport failure", "avg-count", "transport"},
-		{"count capture failure", "avg-count", "capture"},
-		{"sum status failure", "avg-sum", "status"},
+		{"count status failure", backends.TSMVariantWeightedAverageCount, "status"},
+		{"count status with data failure", backends.TSMVariantWeightedAverageCount, "status-data"},
+		{"count parse failure", backends.TSMVariantWeightedAverageCount, "parse"},
+		{"count panic", backends.TSMVariantWeightedAverageCount, "panic"},
+		{"count transport failure", backends.TSMVariantWeightedAverageCount, "transport"},
+		{"count capture failure", backends.TSMVariantWeightedAverageCount, "capture"},
+		{"sum status failure", backends.TSMVariantWeightedAverageSum, "status"},
+		{"sum status with data failure", backends.TSMVariantWeightedAverageSum, "status-data"},
 	} {
 		t.Run("member_completeness_"+strings.ReplaceAll(test.name, " ", "_"), func(t *testing.T) {
 			p := newWeightedAvgPool([]http.Handler{
@@ -579,6 +592,33 @@ func TestServeWeightedAvg(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("non_2xx_dataset_seeds_empty_error_response", func(t *testing.T) {
+		p := newWeightedAvgPool([]http.Handler{
+			weightedAvgFailVariantHandler(
+				weightedAvgMemberSpec{sumValue: "60", countValue: "3"},
+				backends.TSMVariantWeightedAverageSum, "status-data",
+			),
+		})
+		defer p.Stop()
+		albpool.WaitHealthy(t, p, 1)
+
+		h := &handler{mergePaths: []string{"/"}}
+		h.SetPool(p)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newWeightedAvgRequest(t, "avg(requests)"))
+
+		if w.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status: want 503 got %d body=%q", w.Code, w.Body.String())
+		}
+		body := w.Body.String()
+		if !strings.Contains(body, "MERGED:empty") || strings.Contains(body, "100=") {
+			t.Fatalf("body: error dataset entered reduction: %q", body)
+		}
+		if !strings.Contains(body, `variant "`+backends.TSMVariantWeightedAverageSum+`"`) {
+			t.Fatalf("body: missing failed-variant warning: %q", body)
+		}
+	})
 
 	t.Run("completion_order_does_not_change_reduction", func(t *testing.T) {
 		orders := []struct {
@@ -708,8 +748,10 @@ func TestServeWeightedAvg(t *testing.T) {
 
 	t.Run("all_authority_fanout_failures_return_bad_gateway", func(t *testing.T) {
 		p := newWeightedAvgPool([]http.Handler{
-			weightedAvgFailVariantHandler(weightedAvgMemberSpec{sumValue: "60", countValue: "3"}, "avg-sum", "panic"),
-			weightedAvgFailVariantHandler(weightedAvgMemberSpec{sumValue: "40", countValue: "1"}, "avg-sum", "panic"),
+			weightedAvgFailVariantHandler(weightedAvgMemberSpec{sumValue: "60", countValue: "3"},
+				backends.TSMVariantWeightedAverageSum, "panic"),
+			weightedAvgFailVariantHandler(weightedAvgMemberSpec{sumValue: "40", countValue: "1"},
+				backends.TSMVariantWeightedAverageSum, "panic"),
 		})
 		defer p.Stop()
 		albpool.WaitHealthy(t, p, 2)
@@ -778,7 +820,8 @@ func TestServeWeightedAvg(t *testing.T) {
 		if !strings.Contains(body, "MERGED:empty") {
 			t.Fatalf("body: want empty paired result, got %q", body)
 		}
-		if !strings.Contains(body, `variant "avg-count" returned no usable response`) {
+		if !strings.Contains(body, `variant "`+backends.TSMVariantWeightedAverageCount+
+			`" returned no usable response`) {
 			t.Fatalf("body: want missing avg-count warning, got %q", body)
 		}
 	})
@@ -804,7 +847,8 @@ func TestServeWeightedAvg(t *testing.T) {
 		if !strings.Contains(body, "MERGED:empty") {
 			t.Fatalf("body: want empty paired result, got %q", body)
 		}
-		if !strings.Contains(body, `variant "avg-sum" returned no usable response`) {
+		if !strings.Contains(body, `variant "`+backends.TSMVariantWeightedAverageSum+
+			`" returned no usable response`) {
 			t.Fatalf("body: want missing avg-sum warning, got %q", body)
 		}
 	})
@@ -827,8 +871,8 @@ func TestServeWeightedAvg(t *testing.T) {
 		if w.Code != http.StatusOK || !strings.Contains(body, "MERGED:empty") {
 			t.Fatalf("status=%d body=%q", w.Code, body)
 		}
-		if !strings.Contains(body, `variant "avg-sum"`) ||
-			!strings.Contains(body, `variant "avg-count"`) {
+		if !strings.Contains(body, `variant "`+backends.TSMVariantWeightedAverageSum+`"`) ||
+			!strings.Contains(body, `variant "`+backends.TSMVariantWeightedAverageCount+`"`) {
 			t.Fatalf("body: missing completeness warnings: %q", body)
 		}
 	})

--- a/pkg/backends/prometheus/tsm_provider.go
+++ b/pkg/backends/prometheus/tsm_provider.go
@@ -17,13 +17,14 @@
 package prometheus
 
 import (
+	"errors"
+	"fmt"
 	"maps"
 	"net/http"
 	"net/url"
 
+	"github.com/trickstercache/trickster/v2/pkg/backends"
 	"github.com/trickstercache/trickster/v2/pkg/backends/prometheus/promql"
-	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
-	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/params"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
@@ -33,14 +34,110 @@ import (
 // expression, used in both GET (query string) and POST (request body) requests.
 const promQueryParam = "query"
 
-// ClassifyMerge implements backends.TSMMergeProvider for the Prometheus backend.
-// It inspects the outermost PromQL aggregation operator and returns the merge
-// strategy (as the int value of dataset.MergeStrategy), whether a dual-query
-// weighted average is required, and an optional warning for operators whose
-// results cannot be correctly merged across shards.
-func (c *Client) ClassifyMerge(query string) (strategy int, needsDualQuery bool, warning string) {
-	query, _ = tsmInnerQuery(query)
-	return classifyPromMerge(query)
+// PlanTSMMerge constructs the complete TSM execution plan for a Prometheus
+// request. Query syntax and wire-format rewriting stay provider-owned; the ALB
+// executor only consumes variants and reduction metadata.
+func (c *Client) PlanTSMMerge(r *http.Request, query string) (*backends.TSMMergePlan, error) {
+	if r == nil {
+		return nil, errors.New("cannot plan a nil request")
+	}
+	fanoutQuery, rewritten := tsmInnerQuery(query)
+	finalizer := tsmFinalizer(query)
+
+	strategy := int(dataset.MergeStrategyDedup)
+	unsupportedWarning := ""
+	reduction := backends.TSMReductionSpec{
+		Kind:          backends.TSMReductionStandard,
+		InputVariants: []string{"primary"},
+	}
+	completeness := backends.TSMCompletenessResponseAuthority
+
+	agg, found := promql.OuterAggregator(fanoutQuery)
+	if found {
+		switch agg {
+		case "sum", "count", "count_values":
+			strategy = int(dataset.MergeStrategySum)
+		case "avg":
+			return weightedAveragePlan(r, query, fanoutQuery, finalizer)
+		case "min":
+			strategy = int(dataset.MergeStrategyMin)
+		case "max":
+			strategy = int(dataset.MergeStrategyMax)
+		case "stddev", "stdvar", "quantile", "topk", "bottomk", "limitk", "limit_ratio":
+			unsupportedWarning = `trickster: outer aggregator "` + agg + `" cannot be correctly ` +
+				`merged across fanout backends; results may be inaccurate`
+		}
+	}
+
+	variantRequest := r
+	var err error
+	if rewritten {
+		variantRequest, err = rewritePromQueryParam(r, fanoutQuery)
+		if err != nil {
+			return nil, fmt.Errorf("prepare tsm primary variant: %w", err)
+		}
+	}
+
+	plan := &backends.TSMMergePlan{
+		OriginalQuery: query,
+		Variants: []backends.TSMQueryVariant{{
+			Name:              "primary",
+			Request:           variantRequest,
+			MergeStrategy:     strategy,
+			ResponseAuthority: true,
+		}},
+		Reduction:          reduction,
+		Finalizer:          finalizer,
+		Completeness:       completeness,
+		UnsupportedWarning: unsupportedWarning,
+	}
+	plan.AllowSingleMemberBypass = !rewritten && !finalizer.Enabled && unsupportedWarning == ""
+	if err := plan.Validate(); err != nil {
+		return nil, err
+	}
+	return plan, nil
+}
+
+func weightedAveragePlan(r *http.Request, originalQuery, fanoutQuery string,
+	finalizer backends.TSMFinalizerSpec,
+) (*backends.TSMMergePlan, error) {
+	sumQuery := promql.ReplaceOuterAggregator(fanoutQuery, "avg", "sum")
+	countQuery := promql.ReplaceOuterAggregator(fanoutQuery, "avg", "count")
+	sumReq, err := rewritePromQueryParam(r, sumQuery)
+	if err != nil {
+		return nil, fmt.Errorf("prepare tsm avg-sum variant: %w", err)
+	}
+	countReq, err := rewritePromQueryParam(r, countQuery)
+	if err != nil {
+		return nil, fmt.Errorf("prepare tsm avg-count variant: %w", err)
+	}
+
+	plan := &backends.TSMMergePlan{
+		OriginalQuery: originalQuery,
+		Variants: []backends.TSMQueryVariant{
+			{
+				Name:              "avg-sum",
+				Request:           sumReq,
+				MergeStrategy:     int(dataset.MergeStrategySum),
+				ResponseAuthority: true,
+			},
+			{
+				Name:          "avg-count",
+				Request:       countReq,
+				MergeStrategy: int(dataset.MergeStrategySum),
+			},
+		},
+		Reduction: backends.TSMReductionSpec{
+			Kind:          backends.TSMReductionWeightedAverage,
+			InputVariants: []string{"avg-sum", "avg-count"},
+		},
+		Finalizer:    finalizer,
+		Completeness: backends.TSMCompletenessAllVariants,
+	}
+	if err := plan.Validate(); err != nil {
+		return nil, err
+	}
+	return plan, nil
 }
 
 func tsmInnerQuery(query string) (string, bool) {
@@ -55,66 +152,24 @@ func tsmInnerQuery(query string) (string, bool) {
 	return query, false
 }
 
-func classifyPromMerge(query string) (strategy int, needsDualQuery bool, warning string) {
-	agg, found := promql.OuterAggregator(query)
-	if !found {
-		return int(dataset.MergeStrategyDedup), false, ""
+func tsmFinalizer(query string) backends.TSMFinalizerSpec {
+	if _, ok := promql.ParseRankAggregation(query); ok {
+		return backends.TSMFinalizerSpec{Enabled: true, Query: query}
 	}
-	switch agg {
-	case "sum", "count", "count_values":
-		return int(dataset.MergeStrategySum), false, ""
-	case "avg":
-		// needsDualQuery=true: TSM fires two sub-queries (sum + count) per shard
-		// and calls FinalizeWeightedAvg(..., originalQuery) to compute the weighted mean.
-		// MergeStrategySum is used during accumulation; the final division happens
-		// after all shards have responded.
-		return int(dataset.MergeStrategySum), true, ""
-	case "min":
-		return int(dataset.MergeStrategyMin), false, ""
-	case "max":
-		return int(dataset.MergeStrategyMax), false, ""
-	case "stddev", "stdvar", "quantile", "topk", "bottomk", "limitk", "limit_ratio":
-		return int(dataset.MergeStrategyDedup), false,
-			`trickster: outer aggregator "` + agg + `" cannot be correctly ` +
-				`merged across fanout backends; results may be inaccurate`
-	default: // covers "group"
-		return int(dataset.MergeStrategyDedup), false, ""
+	if _, ok := promql.ParseSortWrapper(query); ok {
+		return backends.TSMFinalizerSpec{Enabled: true, Query: query}
 	}
+	return backends.TSMFinalizerSpec{}
 }
 
-// RewriteForTSMMerge removes Prometheus operations that must run after TSM
-// fanout. The shards receive the inner query; FinalizeTSMMerge later applies
-// the original rank and/or sort operation to the merged result.
-func (c *Client) RewriteForTSMMerge(r *http.Request, query string) (*http.Request, string) {
-	innerQuery, ok := tsmInnerQuery(query)
-	if !ok {
-		return r, query
-	}
-	return rewritePromQueryParam(r, innerQuery, "tsm finalizer"), innerQuery
-}
-
-// RewriteForWeightedAvg implements backends.TSMMergeProvider for the Prometheus
-// backend. It returns two copies of r — one with the outer "avg" aggregator
-// replaced by "sum" and one by "count" — with the rewritten expression injected
-// into the Prometheus "query" parameter. Both GET (query string) and POST
-// (request body) encodings are handled transparently by params.SetRequestValues.
-func (c *Client) RewriteForWeightedAvg(r *http.Request, query string) (*http.Request, *http.Request) {
-	query, _ = tsmInnerQuery(query)
-
-	sumQuery := promql.ReplaceOuterAggregator(query, "avg", "sum")
-	countQuery := promql.ReplaceOuterAggregator(query, "avg", "count")
-	sumReq := rewritePromQueryParam(r, sumQuery, "avg aggregator sumReq")
-	countReq := rewritePromQueryParam(r, countQuery, "avg aggregator countReq")
-
-	return sumReq, countReq
-}
-
-func rewritePromQueryParam(r *http.Request, query, cloneName string) *http.Request {
+func rewritePromQueryParam(r *http.Request, query string) (*http.Request, error) {
 	qp, _, _ := params.GetRequestValues(r)
 	req, err := request.Clone(r)
 	if err != nil {
-		logger.Error("failed to clone "+cloneName, logging.Pairs{"error": err})
-		return r
+		return nil, err
+	}
+	if req == nil {
+		return nil, errors.New("cannot rewrite a nil request")
 	}
 	nextQP := maps.Clone(qp)
 	if nextQP == nil {
@@ -122,5 +177,7 @@ func rewritePromQueryParam(r *http.Request, query, cloneName string) *http.Reque
 	}
 	nextQP.Set(promQueryParam, query)
 	params.SetRequestValues(req, nextQP)
-	return req
+	return req, nil
 }
+
+var _ backends.TSMMergeProvider = (*Client)(nil)

--- a/pkg/backends/prometheus/tsm_provider.go
+++ b/pkg/backends/prometheus/tsm_provider.go
@@ -105,31 +105,33 @@ func weightedAveragePlan(r *http.Request, originalQuery, fanoutQuery string,
 	countQuery := promql.ReplaceOuterAggregator(fanoutQuery, "avg", "count")
 	sumReq, err := rewritePromQueryParam(r, sumQuery)
 	if err != nil {
-		return nil, fmt.Errorf("prepare tsm avg-sum variant: %w", err)
+		return nil, fmt.Errorf("prepare tsm %s variant: %w",
+			backends.TSMVariantWeightedAverageSum, err)
 	}
 	countReq, err := rewritePromQueryParam(r, countQuery)
 	if err != nil {
-		return nil, fmt.Errorf("prepare tsm avg-count variant: %w", err)
+		return nil, fmt.Errorf("prepare tsm %s variant: %w",
+			backends.TSMVariantWeightedAverageCount, err)
 	}
 
 	plan := &backends.TSMMergePlan{
 		OriginalQuery: originalQuery,
 		Variants: []backends.TSMQueryVariant{
 			{
-				Name:              "avg-sum",
+				Name:              backends.TSMVariantWeightedAverageSum,
 				Request:           sumReq,
 				MergeStrategy:     int(dataset.MergeStrategySum),
 				ResponseAuthority: true,
 			},
 			{
-				Name:          "avg-count",
+				Name:          backends.TSMVariantWeightedAverageCount,
 				Request:       countReq,
 				MergeStrategy: int(dataset.MergeStrategySum),
 			},
 		},
 		Reduction: backends.TSMReductionSpec{
 			Kind:          backends.TSMReductionWeightedAverage,
-			InputVariants: []string{"avg-sum", "avg-count"},
+			InputVariants: backends.TSMReductionWeightedAverageVariants(),
 		},
 		Finalizer:    finalizer,
 		Completeness: backends.TSMCompletenessAllVariants,

--- a/pkg/backends/prometheus/tsm_provider_test.go
+++ b/pkg/backends/prometheus/tsm_provider_test.go
@@ -168,8 +168,9 @@ func TestPlanTSMMergeContents(t *testing.T) {
 		if plan.OriginalQuery != query {
 			t.Fatalf("original query: got %q", plan.OriginalQuery)
 		}
-		if len(plan.Variants) != 2 || plan.Variants[0].Name != "avg-sum" ||
-			plan.Variants[1].Name != "avg-count" {
+		if len(plan.Variants) != 2 ||
+			plan.Variants[0].Name != backends.TSMVariantWeightedAverageSum ||
+			plan.Variants[1].Name != backends.TSMVariantWeightedAverageCount {
 			t.Fatalf("variants: %#v", plan.Variants)
 		}
 		if plan.Variants[0].Request == plan.Variants[1].Request ||
@@ -186,10 +187,12 @@ func TestPlanTSMMergeContents(t *testing.T) {
 			}
 		}
 		if !plan.Variants[0].ResponseAuthority || plan.Variants[1].ResponseAuthority {
-			t.Fatal("avg-sum must be the sole response authority")
+			t.Fatalf("%s must be the sole response authority",
+				backends.TSMVariantWeightedAverageSum)
 		}
 		if plan.Reduction.Kind != backends.TSMReductionWeightedAverage ||
-			strings.Join(plan.Reduction.InputVariants, ",") != "avg-sum,avg-count" {
+			strings.Join(plan.Reduction.InputVariants, ",") !=
+				strings.Join(backends.TSMReductionWeightedAverageVariants(), ",") {
 			t.Fatalf("reduction: %#v", plan.Reduction)
 		}
 		if plan.Completeness != backends.TSMCompletenessAllVariants {

--- a/pkg/backends/prometheus/tsm_provider_test.go
+++ b/pkg/backends/prometheus/tsm_provider_test.go
@@ -19,6 +19,7 @@ package prometheus
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -26,85 +27,221 @@ import (
 	"testing"
 	"time"
 
+	"github.com/trickstercache/trickster/v2/pkg/backends"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/params"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
 )
 
-func TestClassifyMerge(t *testing.T) {
+func TestPlanTSMMergeStrategies(t *testing.T) {
+	const (
+		standard = backends.TSMReductionStandard
+		weighted = backends.TSMReductionWeightedAverage
+	)
 	tests := []struct {
 		query          string
 		wantStrategy   int
-		wantDualQuery  bool
-		wantWarnSubstr string // non-empty means a warning containing this substring is expected
+		wantReduction  backends.TSMReductionKind
+		wantWarnSubstr string
 	}{
-		// no outer aggregator → dedup
-		{"up", int(dataset.MergeStrategyDedup), false, ""},
-		{"rate(http_requests_total[5m])", int(dataset.MergeStrategyDedup), false, ""},
-		// sum family → sum, no dual query
-		{"sum(up)", int(dataset.MergeStrategySum), false, ""},
-		{"sum by (job) (up)", int(dataset.MergeStrategySum), false, ""},
-		{"count(up)", int(dataset.MergeStrategySum), false, ""},
-		{"count_values(\"code\", http_requests_total)", int(dataset.MergeStrategySum), false, ""},
-		// avg → sum strategy + dual query
-		{"avg(up)", int(dataset.MergeStrategySum), true, ""},
-		{"avg by (region) (up)", int(dataset.MergeStrategySum), true, ""},
-		// min / max
-		{"min(up)", int(dataset.MergeStrategyMin), false, ""},
-		{"max(up)", int(dataset.MergeStrategyMax), false, ""},
-		// rank aggregators are finalized after merge
-		{"topk(5, up)", int(dataset.MergeStrategyDedup), false, ""},
-		{"topk(5, sum by (service) (up))", int(dataset.MergeStrategySum), false, ""},
-		{"topk(5, avg by (service) (up))", int(dataset.MergeStrategySum), true, ""},
-		{"sort_desc(topk(5, max(up)))", int(dataset.MergeStrategyMax), false, ""},
-		{"bottomk(5, up)", int(dataset.MergeStrategyDedup), false, ""},
-		{"sort_desc(topk(5, up))", int(dataset.MergeStrategyDedup), false, ""},
-		// sort wrappers preserve the inner aggregation strategy
-		{"sort(sum(up))", int(dataset.MergeStrategySum), false, ""},
-		{"sort_desc(count by (service) (up))", int(dataset.MergeStrategySum), false, ""},
-		{"sort(avg by (service) (up))", int(dataset.MergeStrategySum), true, ""},
-		{"sort(min(up))", int(dataset.MergeStrategyMin), false, ""},
-		{"sort_desc(max(up))", int(dataset.MergeStrategyMax), false, ""},
-		{"sort(up)", int(dataset.MergeStrategyDedup), false, ""},
-		// unsupported aggregators → dedup + warning containing the operator name
-		{"stddev(up)", int(dataset.MergeStrategyDedup), false, "stddev"},
-		{"stdvar(up)", int(dataset.MergeStrategyDedup), false, "stdvar"},
-		{"quantile(0.9, up)", int(dataset.MergeStrategyDedup), false, "quantile"},
-		{"topk(5, stddev(up))", int(dataset.MergeStrategyDedup), false, "stddev"},
-		{"sort_desc(stddev(up))", int(dataset.MergeStrategyDedup), false, "stddev"},
-		{"topk(k, up)", int(dataset.MergeStrategyDedup), false, "topk"},
-		{"limitk(5, up)", int(dataset.MergeStrategyDedup), false, "limitk"},
-		{"limit_ratio(0.5, up)", int(dataset.MergeStrategyDedup), false, "limit_ratio"},
-		// group → default → dedup, no warning
-		{"group(up)", int(dataset.MergeStrategyDedup), false, ""},
+		// Queries without an outer aggregation use deduplication.
+		{"up", int(dataset.MergeStrategyDedup), standard, ""},
+		{"rate(http_requests_total[5m])", int(dataset.MergeStrategyDedup), standard, ""},
+		// Sum, count, and count_values accumulate shard values.
+		{"sum(up)", int(dataset.MergeStrategySum), standard, ""},
+		{"sum by (job) (up)", int(dataset.MergeStrategySum), standard, ""},
+		{"count(up)", int(dataset.MergeStrategySum), standard, ""},
+		{"count_values(\"code\", http_requests_total)", int(dataset.MergeStrategySum), standard, ""},
+		// Average uses paired sum and count variants.
+		{"avg(up)", int(dataset.MergeStrategySum), weighted, ""},
+		{"avg by (region) (up)", int(dataset.MergeStrategySum), weighted, ""},
+		{"min(up)", int(dataset.MergeStrategyMin), standard, ""},
+		{"max(up)", int(dataset.MergeStrategyMax), standard, ""},
+		// Rank aggregations are rewritten and finalized after merge.
+		{"topk(5, up)", int(dataset.MergeStrategyDedup), standard, ""},
+		{"topk(5, sum by (service) (up))", int(dataset.MergeStrategySum), standard, ""},
+		{"topk(5, avg by (service) (up))", int(dataset.MergeStrategySum), weighted, ""},
+		{"sort_desc(topk(5, max(up)))", int(dataset.MergeStrategyMax), standard, ""},
+		{"bottomk(5, up)", int(dataset.MergeStrategyDedup), standard, ""},
+		{"sort_desc(topk(5, up))", int(dataset.MergeStrategyDedup), standard, ""},
+		// Sort wrappers preserve the inner aggregation strategy.
+		{"sort(sum(up))", int(dataset.MergeStrategySum), standard, ""},
+		{"sort_desc(count by (service) (up))", int(dataset.MergeStrategySum), standard, ""},
+		{"sort(avg by (service) (up))", int(dataset.MergeStrategySum), weighted, ""},
+		{"sort(min(up))", int(dataset.MergeStrategyMin), standard, ""},
+		{"sort_desc(max(up))", int(dataset.MergeStrategyMax), standard, ""},
+		{"sort(up)", int(dataset.MergeStrategyDedup), standard, ""},
+		// Unsupported aggregations fall back to deduplication with a warning.
+		{"stddev(up)", int(dataset.MergeStrategyDedup), standard, "stddev"},
+		{"stdvar(up)", int(dataset.MergeStrategyDedup), standard, "stdvar"},
+		{"quantile(0.9, up)", int(dataset.MergeStrategyDedup), standard, "quantile"},
+		{"topk(5, stddev(up))", int(dataset.MergeStrategyDedup), standard, "stddev"},
+		{"sort_desc(stddev(up))", int(dataset.MergeStrategyDedup), standard, "stddev"},
+		{"topk(k, up)", int(dataset.MergeStrategyDedup), standard, "topk"},
+		{"limitk(5, up)", int(dataset.MergeStrategyDedup), standard, "limitk"},
+		{"limit_ratio(0.5, up)", int(dataset.MergeStrategyDedup), standard, "limit_ratio"},
+		{"group(up)", int(dataset.MergeStrategyDedup), standard, ""},
 	}
 
 	c := &Client{}
-	for _, tt := range tests {
-		t.Run(tt.query, func(t *testing.T) {
-			strategy, dualQuery, warning := c.ClassifyMerge(tt.query)
-			if strategy != tt.wantStrategy {
-				t.Errorf("strategy: got %d, want %d", strategy, tt.wantStrategy)
+	for _, test := range tests {
+		t.Run(test.query, func(t *testing.T) {
+			r, _ := http.NewRequest(http.MethodGet,
+				"http://example.com/api/v1/query?query="+url.QueryEscape(test.query), nil)
+			plan, err := c.PlanTSMMerge(r, test.query)
+			if err != nil {
+				t.Fatalf("PlanTSMMerge: %v", err)
 			}
-			if dualQuery != tt.wantDualQuery {
-				t.Errorf("needsDualQuery: got %v, want %v", dualQuery, tt.wantDualQuery)
+			if err := plan.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
 			}
-			if tt.wantWarnSubstr != "" {
-				if !strings.Contains(warning, tt.wantWarnSubstr) {
-					t.Errorf("warning %q does not contain %q", warning, tt.wantWarnSubstr)
+			wantVariants := 1
+			if test.wantReduction == weighted {
+				wantVariants = 2
+			}
+			if len(plan.Variants) != wantVariants {
+				t.Fatalf("variant count: got %d want %d", len(plan.Variants), wantVariants)
+			}
+			for i, variant := range plan.Variants {
+				if variant.MergeStrategy != test.wantStrategy {
+					t.Errorf("variant %d strategy: got %d want %d",
+						i, variant.MergeStrategy, test.wantStrategy)
 				}
-			} else if warning != "" {
-				t.Errorf("expected no warning, got %q", warning)
+			}
+			if plan.Reduction.Kind != test.wantReduction {
+				t.Errorf("reduction: got %d want %d", plan.Reduction.Kind, test.wantReduction)
+			}
+			if test.wantWarnSubstr != "" {
+				if !strings.Contains(plan.UnsupportedWarning, test.wantWarnSubstr) {
+					t.Errorf("warning %q does not contain %q",
+						plan.UnsupportedWarning, test.wantWarnSubstr)
+				}
+			} else if plan.UnsupportedWarning != "" {
+				t.Errorf("expected no warning, got %q", plan.UnsupportedWarning)
 			}
 		})
 	}
 }
 
-// TestRewriteForWeightedAvgPOST verifies that the sum and count requests
+func mustTSMMergePlan(t *testing.T, r *http.Request, query string) *backends.TSMMergePlan {
+	t.Helper()
+	plan, err := (&Client{}).PlanTSMMerge(r, query)
+	if err != nil {
+		t.Fatalf("PlanTSMMerge: %v", err)
+	}
+	return plan
+}
+
+func TestPlanTSMMergeContents(t *testing.T) {
+	t.Run("unchanged primary", func(t *testing.T) {
+		const query = "sum by (job) (up)"
+		r, _ := http.NewRequest(http.MethodGet,
+			"http://example.com/api/v1/query?query="+url.QueryEscape(query), nil)
+		plan := mustTSMMergePlan(t, r, query)
+		if len(plan.Variants) != 1 || plan.Variants[0].Name != "primary" {
+			t.Fatalf("variants: %#v", plan.Variants)
+		}
+		if plan.Variants[0].Request != r {
+			t.Fatal("unchanged primary request was cloned")
+		}
+		if !plan.Variants[0].ResponseAuthority {
+			t.Fatal("primary is not response authority")
+		}
+		if plan.Reduction.Kind != backends.TSMReductionStandard ||
+			len(plan.Reduction.InputVariants) != 1 || plan.Reduction.InputVariants[0] != "primary" {
+			t.Fatalf("reduction: %#v", plan.Reduction)
+		}
+		if plan.Completeness != backends.TSMCompletenessResponseAuthority {
+			t.Fatalf("completeness: %d", plan.Completeness)
+		}
+		if !plan.AllowSingleMemberBypass {
+			t.Fatal("safe unchanged primary did not allow a single-member bypass")
+		}
+	})
+
+	t.Run("weighted average under rank finalizer", func(t *testing.T) {
+		const query = "topk(5, avg by (service) (requests))"
+		r, _ := http.NewRequest(http.MethodGet,
+			"http://example.com/api/v1/query?query="+url.QueryEscape(query), nil)
+		plan := mustTSMMergePlan(t, r, query)
+		if plan.OriginalQuery != query {
+			t.Fatalf("original query: got %q", plan.OriginalQuery)
+		}
+		if len(plan.Variants) != 2 || plan.Variants[0].Name != "avg-sum" ||
+			plan.Variants[1].Name != "avg-count" {
+			t.Fatalf("variants: %#v", plan.Variants)
+		}
+		if plan.Variants[0].Request == plan.Variants[1].Request ||
+			plan.Variants[0].Request == r || plan.Variants[1].Request == r {
+			t.Fatal("weighted-average variant requests are not independent clones")
+		}
+		for i, want := range []string{
+			"sum by (service) (requests)",
+			"count by (service) (requests)",
+		} {
+			values, _, _ := params.GetRequestValues(plan.Variants[i].Request)
+			if got := values.Get(promQueryParam); got != want {
+				t.Fatalf("variant %d query: got %q want %q", i, got, want)
+			}
+		}
+		if !plan.Variants[0].ResponseAuthority || plan.Variants[1].ResponseAuthority {
+			t.Fatal("avg-sum must be the sole response authority")
+		}
+		if plan.Reduction.Kind != backends.TSMReductionWeightedAverage ||
+			strings.Join(plan.Reduction.InputVariants, ",") != "avg-sum,avg-count" {
+			t.Fatalf("reduction: %#v", plan.Reduction)
+		}
+		if plan.Completeness != backends.TSMCompletenessAllVariants {
+			t.Fatalf("completeness: %d", plan.Completeness)
+		}
+		if !plan.Finalizer.Enabled || plan.Finalizer.Query != query {
+			t.Fatalf("finalizer: %#v", plan.Finalizer)
+		}
+		if plan.AllowSingleMemberBypass {
+			t.Fatal("weighted-average plan allowed a single-member bypass")
+		}
+	})
+
+	t.Run("unsupported fallback", func(t *testing.T) {
+		const query = "stddev(up)"
+		r, _ := http.NewRequest(http.MethodGet,
+			"http://example.com/api/v1/query?query="+url.QueryEscape(query), nil)
+		plan := mustTSMMergePlan(t, r, query)
+		if plan.Variants[0].MergeStrategy != int(dataset.MergeStrategyDedup) {
+			t.Fatalf("strategy: %d", plan.Variants[0].MergeStrategy)
+		}
+		if !strings.Contains(plan.UnsupportedWarning, "stddev") {
+			t.Fatalf("warning: %q", plan.UnsupportedWarning)
+		}
+		if plan.AllowSingleMemberBypass {
+			t.Fatal("unsupported fallback allowed a single-member bypass")
+		}
+	})
+}
+
+type failingTSMRequestBody struct{}
+
+func (failingTSMRequestBody) Read([]byte) (int, error) { return 0, errors.New("read failure") }
+func (failingTSMRequestBody) Close() error             { return nil }
+
+func TestPlanTSMMergeRejectsUncloneableRequest(t *testing.T) {
+	r, _ := http.NewRequest(http.MethodPost,
+		"http://example.com/api/v1/query_range?query=avg%28up%29",
+		failingTSMRequestBody{})
+	r.Header.Set(headers.NameContentType, headers.ValueXFormURLEncoded)
+	if _, err := (&Client{}).PlanTSMMerge(r, "avg(up)"); err == nil {
+		t.Fatal("uncloneable request unexpectedly produced a plan")
+	}
+	if _, err := (&Client{}).PlanTSMMerge(nil, "avg(up)"); err == nil {
+		t.Fatal("nil request unexpectedly produced a plan")
+	}
+}
+
+// TestPlanTSMMergeWeightedAveragePOST verifies that the sum and count requests
 // produced for a POST query carry the rewritten query in both the body and
-// rsc.RequestBody — not the stale original avg body.
-func TestRewriteForWeightedAvgPOST(t *testing.T) {
+// rsc.RequestBody, not the stale original avg body.
+func TestPlanTSMMergeWeightedAveragePOST(t *testing.T) {
 	const origBody = "query=avg%28up%29&start=1000&end=2000&step=15"
 	r, _ := http.NewRequest(http.MethodPost,
 		"http://example.com/api/v1/query_range",
@@ -115,8 +252,8 @@ func TestRewriteForWeightedAvgPOST(t *testing.T) {
 	rsc := &request.Resources{RequestBody: []byte(origBody)}
 	r = request.SetResources(r, rsc)
 
-	c := &Client{}
-	sumReq, countReq := c.RewriteForWeightedAvg(r, "avg(up)")
+	plan := mustTSMMergePlan(t, r, "avg(up)")
+	sumReq, countReq := plan.Variants[0].Request, plan.Variants[1].Request
 
 	for _, tc := range []struct {
 		name  string
@@ -182,15 +319,15 @@ func TestRewriteForWeightedAvgPOST(t *testing.T) {
 	}
 }
 
-// TestRewriteForWeightedAvg_GET verifies that for a GET request the rewritten
+// TestPlanTSMMergeWeightedAverageGET verifies that for a GET request the rewritten
 // query lands in r.URL.RawQuery and that no body is written.
-func TestRewriteForWeightedAvgGET(t *testing.T) {
+func TestPlanTSMMergeWeightedAverageGET(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodGet,
 		"http://example.com/api/v1/query_range?query=avg%28up%29&start=1000&end=2000&step=15",
 		nil)
 
-	c := &Client{}
-	sumReq, countReq := c.RewriteForWeightedAvg(r, "avg(up)")
+	plan := mustTSMMergePlan(t, r, "avg(up)")
+	sumReq, countReq := plan.Variants[0].Request, plan.Variants[1].Request
 
 	for _, tc := range []struct {
 		name  string
@@ -231,7 +368,7 @@ func TestRewriteForWeightedAvgGET(t *testing.T) {
 	}
 }
 
-func TestRewriteForTSMMergeRankAggregationPOST(t *testing.T) {
+func TestPlanTSMMergeRankAggregationPOST(t *testing.T) {
 	const (
 		query    = "topk(5, sum(up))"
 		wantQ    = "sum(up)"
@@ -245,7 +382,10 @@ func TestRewriteForTSMMergeRankAggregationPOST(t *testing.T) {
 	r.Header.Set(headers.NameContentType, headers.ValueXFormURLEncoded)
 	r = request.SetResources(r, &request.Resources{RequestBody: []byte(origBody)})
 
-	rewritten, rewrittenQuery := (&Client{}).RewriteForTSMMerge(r, query)
+	plan := mustTSMMergePlan(t, r, query)
+	rewritten := plan.Variants[0].Request
+	rewrittenValues, _, _ := params.GetRequestValues(rewritten)
+	rewrittenQuery := rewrittenValues.Get(promQueryParam)
 	if rewrittenQuery != wantQ {
 		t.Fatalf("rewritten query got %q want %q", rewrittenQuery, wantQ)
 	}
@@ -293,7 +433,7 @@ func TestRewriteForTSMMergeRankAggregationPOST(t *testing.T) {
 	}
 }
 
-func TestRewriteForTSMMergeSortWrapperPOST(t *testing.T) {
+func TestPlanTSMMergeSortWrapperPOST(t *testing.T) {
 	const (
 		query    = "sort_desc(sum by (service) (requests))"
 		wantQ    = "sum by (service) (requests)"
@@ -305,7 +445,10 @@ func TestRewriteForTSMMergeSortWrapperPOST(t *testing.T) {
 	r.Header.Set(headers.NameContentType, headers.ValueXFormURLEncoded)
 	r = request.SetResources(r, &request.Resources{RequestBody: []byte(origBody)})
 
-	rewritten, rewrittenQuery := (&Client{}).RewriteForTSMMerge(r, query)
+	plan := mustTSMMergePlan(t, r, query)
+	rewritten := plan.Variants[0].Request
+	rewrittenValues, _, _ := params.GetRequestValues(rewritten)
+	rewrittenQuery := rewrittenValues.Get(promQueryParam)
 	if rewrittenQuery != wantQ {
 		t.Fatalf("rewritten query got %q want %q", rewrittenQuery, wantQ)
 	}
@@ -327,12 +470,15 @@ func TestRewriteForTSMMergeSortWrapperPOST(t *testing.T) {
 	}
 }
 
-func TestRewriteForTSMMergePreservesNonAggregationSort(t *testing.T) {
+func TestPlanTSMMergePreservesNonAggregationSort(t *testing.T) {
 	const query = "sort(up)"
 	r, _ := http.NewRequest(http.MethodGet,
 		"http://example.com/api/v1/query?query="+url.QueryEscape(query), nil)
 
-	rewritten, rewrittenQuery := (&Client{}).RewriteForTSMMerge(r, query)
+	plan := mustTSMMergePlan(t, r, query)
+	rewritten := plan.Variants[0].Request
+	rewrittenValues, _, _ := params.GetRequestValues(rewritten)
+	rewrittenQuery := rewrittenValues.Get(promQueryParam)
 	if rewritten != r {
 		t.Fatal("non-aggregation sort unexpectedly cloned the request")
 	}
@@ -341,13 +487,14 @@ func TestRewriteForTSMMergePreservesNonAggregationSort(t *testing.T) {
 	}
 }
 
-func TestRewriteForWeightedAvgRankAggregationGET(t *testing.T) {
+func TestPlanTSMMergeWeightedAverageRankAggregationGET(t *testing.T) {
 	const query = "topk(5, avg by (service) (requests))"
 	r, _ := http.NewRequest(http.MethodGet,
 		"http://example.com/api/v1/query_range?query="+url.QueryEscape(query)+"&start=1000&end=2000&step=15",
 		nil)
 
-	sumReq, countReq := (&Client{}).RewriteForWeightedAvg(r, query)
+	plan := mustTSMMergePlan(t, r, query)
+	sumReq, countReq := plan.Variants[0].Request, plan.Variants[1].Request
 	for _, tc := range []struct {
 		name  string
 		req   *http.Request
@@ -368,12 +515,13 @@ func TestRewriteForWeightedAvgRankAggregationGET(t *testing.T) {
 	}
 }
 
-func TestRewriteForWeightedAvgSortWrapperGET(t *testing.T) {
+func TestPlanTSMMergeWeightedAverageSortWrapperGET(t *testing.T) {
 	const query = "sort_desc(avg by (service) (requests))"
 	r, _ := http.NewRequest(http.MethodGet,
 		"http://example.com/api/v1/query?query="+url.QueryEscape(query), nil)
 
-	sumReq, countReq := (&Client{}).RewriteForWeightedAvg(r, query)
+	plan := mustTSMMergePlan(t, r, query)
+	sumReq, countReq := plan.Variants[0].Request, plan.Variants[1].Request
 	for _, tc := range []struct {
 		name  string
 		req   *http.Request

--- a/pkg/backends/tsm_merge_provider.go
+++ b/pkg/backends/tsm_merge_provider.go
@@ -16,32 +16,184 @@
 
 package backends
 
-import "net/http"
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
 
-// TSMMergeProvider is an optional interface that a Backend may implement to
-// participate in Time Series Merge (TSM) scatter/gather with query-aware merge
-// strategies.
-//
-// If a backend does not implement TSMMergeProvider, TSM falls back to
-// deduplication for all queries.
+// TSMReductionKind identifies how accumulated query variants are combined.
+// It describes data flow rather than a provider-specific query operator.
+type TSMReductionKind int
+
+const (
+	// TSMReductionStandard returns the sole variant accumulator unchanged.
+	TSMReductionStandard TSMReductionKind = iota
+	// TSMReductionWeightedAverage divides an accumulated sum variant by its
+	// paired count variant.
+	TSMReductionWeightedAverage
+)
+
+// TSMCompletenessPolicy determines which per-member contributions may enter
+// global accumulation.
+type TSMCompletenessPolicy int
+
+const (
+	// TSMCompletenessResponseAuthority requires the response-authority variant.
+	// It is the policy used by standard one-variant plans.
+	TSMCompletenessResponseAuthority TSMCompletenessPolicy = iota
+	// TSMCompletenessAllVariants requires every variant from the same member.
+	TSMCompletenessAllVariants
+)
+
+// TSMReductionSpec describes the reduction performed after variant
+// accumulation.
+type TSMReductionSpec struct {
+	Kind          TSMReductionKind
+	InputVariants []string
+}
+
+// TSMFinalizerSpec identifies optional provider finalization after reduction.
+type TSMFinalizerSpec struct {
+	Enabled bool
+	Query   string
+}
+
+// TSMQueryVariant is one provider-prepared request in a merge plan.
+type TSMQueryVariant struct {
+	Name              string
+	Request           *http.Request
+	MergeStrategy     int
+	ResponseAuthority bool
+}
+
+// TSMMergePlan is the complete execution plan for one TSM request.
+type TSMMergePlan struct {
+	OriginalQuery           string
+	Variants                []TSMQueryVariant
+	Reduction               TSMReductionSpec
+	Finalizer               TSMFinalizerSpec
+	Completeness            TSMCompletenessPolicy
+	UnsupportedWarning      string
+	AllowSingleMemberBypass bool
+}
+
+// ResponseAuthority returns the index of the variant that supplies response
+// status, headers, and marshaling behavior.
+func (p *TSMMergePlan) ResponseAuthority() (int, bool) {
+	if p == nil {
+		return 0, false
+	}
+	for i := range p.Variants {
+		if p.Variants[i].ResponseAuthority {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// Validate rejects plans whose execution semantics are ambiguous or unsafe.
+func (p *TSMMergePlan) Validate() error {
+	if p == nil {
+		return errors.New("tsm merge plan is nil")
+	}
+	if len(p.Variants) == 0 {
+		return errors.New("tsm merge plan has no query variants")
+	}
+
+	names := make(map[string]struct{}, len(p.Variants))
+	requestPointers := make(map[*http.Request]struct{}, len(p.Variants))
+	authorities := 0
+	for i, variant := range p.Variants {
+		if variant.Name == "" {
+			return fmt.Errorf("tsm merge plan variant %d has no name", i)
+		}
+		if _, ok := names[variant.Name]; ok {
+			return fmt.Errorf("tsm merge plan has duplicate variant name %q", variant.Name)
+		}
+		names[variant.Name] = struct{}{}
+		if variant.Request == nil {
+			return fmt.Errorf("tsm merge plan variant %q has no request", variant.Name)
+		}
+		if _, ok := requestPointers[variant.Request]; ok {
+			return fmt.Errorf("tsm merge plan variants share request %q", variant.Name)
+		}
+		requestPointers[variant.Request] = struct{}{}
+		// dataset.MergeStrategy currently defines values 0 through 5. Keep the
+		// shallow backends package independent of dataset while rejecting values
+		// that the merge layer would otherwise silently treat as deduplication.
+		if variant.MergeStrategy < 0 || variant.MergeStrategy > 5 {
+			return fmt.Errorf("tsm merge plan variant %q has invalid merge strategy %d",
+				variant.Name, variant.MergeStrategy)
+		}
+		if variant.ResponseAuthority {
+			authorities++
+		}
+	}
+	if authorities != 1 {
+		return fmt.Errorf("tsm merge plan must have exactly one response authority; got %d", authorities)
+	}
+
+	switch p.Reduction.Kind {
+	case TSMReductionStandard:
+		if len(p.Variants) != 1 {
+			return errors.New("standard tsm reduction requires exactly one variant")
+		}
+		if len(p.Reduction.InputVariants) != 1 ||
+			p.Reduction.InputVariants[0] != p.Variants[0].Name {
+			return errors.New("standard tsm reduction must name its sole input variant")
+		}
+		if p.Completeness != TSMCompletenessResponseAuthority {
+			return errors.New("standard tsm reduction requires response-authority completeness")
+		}
+	case TSMReductionWeightedAverage:
+		if len(p.Variants) != 2 {
+			return errors.New("weighted-average tsm reduction requires exactly two variants")
+		}
+		if p.OriginalQuery == "" {
+			return errors.New("weighted-average tsm reduction requires the original query")
+		}
+		if len(p.Reduction.InputVariants) != 2 {
+			return errors.New("weighted-average tsm reduction requires two named inputs")
+		}
+		if p.Completeness != TSMCompletenessAllVariants {
+			return errors.New("weighted-average tsm reduction requires all-variant completeness")
+		}
+		authority, _ := p.ResponseAuthority()
+		if p.Reduction.InputVariants[0] != p.Variants[authority].Name {
+			return errors.New("weighted-average tsm reduction must use response authority as its first input")
+		}
+	default:
+		return fmt.Errorf("tsm merge plan has invalid reduction kind %d", p.Reduction.Kind)
+	}
+	seenInputs := make(map[string]struct{}, len(p.Reduction.InputVariants))
+	for _, name := range p.Reduction.InputVariants {
+		if _, ok := names[name]; !ok {
+			return fmt.Errorf("tsm merge plan reduction references unknown variant %q", name)
+		}
+		if _, ok := seenInputs[name]; ok {
+			return fmt.Errorf("tsm merge plan reduction repeats variant %q", name)
+		}
+		seenInputs[name] = struct{}{}
+	}
+
+	if p.Finalizer.Enabled && p.Finalizer.Query == "" {
+		return errors.New("tsm merge plan finalizer has no query")
+	}
+	if !p.Finalizer.Enabled && p.Finalizer.Query != "" {
+		return errors.New("tsm merge plan has a finalizer query but finalization is disabled")
+	}
+	if p.AllowSingleMemberBypass &&
+		(len(p.Variants) != 1 || p.Reduction.Kind != TSMReductionStandard ||
+			p.Finalizer.Enabled || p.UnsupportedWarning != "") {
+		return errors.New("tsm merge plan has an unsafe single-member bypass")
+	}
+	return nil
+}
+
+// TSMMergeProvider prepares a validated execution plan for every TSM request.
+// Provider-specific query parsing, request cloning, and wire rewriting belong
+// in plan construction so the executor remains independent of query syntax.
 type TSMMergeProvider interface {
-	// ClassifyMerge inspects the query string and returns:
-	//   - strategy: the merge strategy to use for fanout accumulation, as the
-	//     underlying int value of dataset.MergeStrategy (avoids importing the
-	//     dataset package here and breaking the shallow backends import graph).
-	//   - needsDualQuery: true when a weighted arithmetic mean is required
-	//     (i.e. the outer aggregator is "avg"). TSM will fire two sub-queries —
-	//     a "sum" variant and a "count" variant — and divide after gathering.
-	//   - warning: non-empty when the aggregator cannot be correctly merged
-	//     across fanout shards (e.g. stddev, quantile). TSM will fall back to
-	//     deduplication and surface this warning in the response.
-	ClassifyMerge(query string) (strategy int, needsDualQuery bool, warning string)
-
-	// RewriteForWeightedAvg returns two modified copies of r — one with the
-	// outer aggregator replaced by its "sum" equivalent and one by its "count"
-	// equivalent. Both copies have the replacement injected in whatever way the
-	// provider's wire protocol requires (URL query parameter, POST body, header,
-	// etc.). The returned requests must be safe for concurrent use; they should
-	// not share any mutable state with each other or with r.
-	RewriteForWeightedAvg(r *http.Request, query string) (sumReq, countReq *http.Request)
+	PlanTSMMerge(r *http.Request, query string) (*TSMMergePlan, error)
 }

--- a/pkg/backends/tsm_merge_provider.go
+++ b/pkg/backends/tsm_merge_provider.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
 )
 
 // TSMReductionKind identifies how accumulated query variants are combined.
@@ -34,6 +36,19 @@ const (
 	TSMReductionWeightedAverage
 )
 
+const (
+	// TSMVariantWeightedAverageSum is the summed-value input to weighted average.
+	TSMVariantWeightedAverageSum = "avg-sum"
+	// TSMVariantWeightedAverageCount is the summed-count input to weighted average.
+	TSMVariantWeightedAverageCount = "avg-count"
+)
+
+// TSMReductionWeightedAverageVariants returns weighted-average input names in
+// the positional order required by the reducer: sum, then count.
+func TSMReductionWeightedAverageVariants() []string {
+	return []string{TSMVariantWeightedAverageSum, TSMVariantWeightedAverageCount}
+}
+
 // TSMCompletenessPolicy determines which per-member contributions may enter
 // global accumulation.
 type TSMCompletenessPolicy int
@@ -47,7 +62,8 @@ const (
 )
 
 // TSMReductionSpec describes the reduction performed after variant
-// accumulation.
+// accumulation. InputVariants is ordered according to the reduction kind's
+// positional contract; use its reduction-specific helper when available.
 type TSMReductionSpec struct {
 	Kind          TSMReductionKind
 	InputVariants []string
@@ -101,17 +117,17 @@ func (p *TSMMergePlan) Validate() error {
 		return errors.New("tsm merge plan has no query variants")
 	}
 
-	names := make(map[string]struct{}, len(p.Variants))
+	variantsByName := make(map[string]TSMQueryVariant, len(p.Variants))
 	requestPointers := make(map[*http.Request]struct{}, len(p.Variants))
 	authorities := 0
 	for i, variant := range p.Variants {
 		if variant.Name == "" {
 			return fmt.Errorf("tsm merge plan variant %d has no name", i)
 		}
-		if _, ok := names[variant.Name]; ok {
+		if _, ok := variantsByName[variant.Name]; ok {
 			return fmt.Errorf("tsm merge plan has duplicate variant name %q", variant.Name)
 		}
-		names[variant.Name] = struct{}{}
+		variantsByName[variant.Name] = variant
 		if variant.Request == nil {
 			return fmt.Errorf("tsm merge plan variant %q has no request", variant.Name)
 		}
@@ -119,10 +135,8 @@ func (p *TSMMergePlan) Validate() error {
 			return fmt.Errorf("tsm merge plan variants share request %q", variant.Name)
 		}
 		requestPointers[variant.Request] = struct{}{}
-		// dataset.MergeStrategy currently defines values 0 through 5. Keep the
-		// shallow backends package independent of dataset while rejecting values
-		// that the merge layer would otherwise silently treat as deduplication.
-		if variant.MergeStrategy < 0 || variant.MergeStrategy > 5 {
+		if variant.MergeStrategy < 0 ||
+			variant.MergeStrategy > int(dataset.MaxMergeStrategyValue) {
 			return fmt.Errorf("tsm merge plan variant %q has invalid merge strategy %d",
 				variant.Name, variant.MergeStrategy)
 		}
@@ -153,8 +167,19 @@ func (p *TSMMergePlan) Validate() error {
 		if p.OriginalQuery == "" {
 			return errors.New("weighted-average tsm reduction requires the original query")
 		}
-		if len(p.Reduction.InputVariants) != 2 {
+		expectedInputs := TSMReductionWeightedAverageVariants()
+		if len(p.Reduction.InputVariants) != len(expectedInputs) {
 			return errors.New("weighted-average tsm reduction requires two named inputs")
+		}
+		for i, expected := range expectedInputs {
+			if p.Reduction.InputVariants[i] != expected {
+				return fmt.Errorf("weighted-average tsm reduction input %d must be %q", i, expected)
+			}
+		}
+		for _, name := range expectedInputs {
+			if variantsByName[name].MergeStrategy != int(dataset.MergeStrategySum) {
+				return fmt.Errorf("weighted-average tsm variant %q must use sum merge strategy", name)
+			}
 		}
 		if p.Completeness != TSMCompletenessAllVariants {
 			return errors.New("weighted-average tsm reduction requires all-variant completeness")
@@ -168,7 +193,7 @@ func (p *TSMMergePlan) Validate() error {
 	}
 	seenInputs := make(map[string]struct{}, len(p.Reduction.InputVariants))
 	for _, name := range p.Reduction.InputVariants {
-		if _, ok := names[name]; !ok {
+		if _, ok := variantsByName[name]; !ok {
 			return fmt.Errorf("tsm merge plan reduction references unknown variant %q", name)
 		}
 		if _, ok := seenInputs[name]; ok {

--- a/pkg/backends/tsm_merge_provider_test.go
+++ b/pkg/backends/tsm_merge_provider_test.go
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package backends
+
+import (
+	"net/http"
+	"testing"
+)
+
+func testTSMRequest(path string) *http.Request {
+	r, _ := http.NewRequest(http.MethodGet, "http://example.com/"+path, nil)
+	return r
+}
+
+func validStandardTSMPlan() *TSMMergePlan {
+	return &TSMMergePlan{
+		OriginalQuery: "sum(up)",
+		Variants: []TSMQueryVariant{{
+			Name:              "primary",
+			Request:           testTSMRequest("primary"),
+			MergeStrategy:     1,
+			ResponseAuthority: true,
+		}},
+		Reduction: TSMReductionSpec{
+			Kind:          TSMReductionStandard,
+			InputVariants: []string{"primary"},
+		},
+		Completeness:            TSMCompletenessResponseAuthority,
+		AllowSingleMemberBypass: true,
+	}
+}
+
+func validWeightedAverageTSMPlan() *TSMMergePlan {
+	return &TSMMergePlan{
+		OriginalQuery: "avg(up)",
+		Variants: []TSMQueryVariant{
+			{
+				Name:              "avg-sum",
+				Request:           testTSMRequest("sum"),
+				MergeStrategy:     1,
+				ResponseAuthority: true,
+			},
+			{
+				Name:          "avg-count",
+				Request:       testTSMRequest("count"),
+				MergeStrategy: 1,
+			},
+		},
+		Reduction: TSMReductionSpec{
+			Kind:          TSMReductionWeightedAverage,
+			InputVariants: []string{"avg-sum", "avg-count"},
+		},
+		Completeness: TSMCompletenessAllVariants,
+	}
+}
+
+func TestTSMMergePlanValidate(t *testing.T) {
+	if err := validStandardTSMPlan().Validate(); err != nil {
+		t.Fatalf("valid standard plan: %v", err)
+	}
+	if err := validWeightedAverageTSMPlan().Validate(); err != nil {
+		t.Fatalf("valid weighted-average plan: %v", err)
+	}
+	var nilPlan *TSMMergePlan
+	if err := nilPlan.Validate(); err == nil {
+		t.Fatal("nil plan unexpectedly validated")
+	}
+
+	tests := []struct {
+		name   string
+		plan   func() *TSMMergePlan
+		mutate func(*TSMMergePlan)
+	}{
+		{"zero variants", validStandardTSMPlan, func(p *TSMMergePlan) { p.Variants = nil }},
+		{"empty variant name", validStandardTSMPlan, func(p *TSMMergePlan) { p.Variants[0].Name = "" }},
+		{"nil request", validStandardTSMPlan, func(p *TSMMergePlan) { p.Variants[0].Request = nil }},
+		{"invalid low strategy", validStandardTSMPlan, func(p *TSMMergePlan) { p.Variants[0].MergeStrategy = -1 }},
+		{"invalid high strategy", validStandardTSMPlan, func(p *TSMMergePlan) { p.Variants[0].MergeStrategy = 6 }},
+		{"missing authority", validStandardTSMPlan, func(p *TSMMergePlan) { p.Variants[0].ResponseAuthority = false }},
+		{"standard missing reduction input", validStandardTSMPlan, func(p *TSMMergePlan) { p.Reduction.InputVariants = nil }},
+		{"standard wrong completeness", validStandardTSMPlan, func(p *TSMMergePlan) { p.Completeness = TSMCompletenessAllVariants }},
+		{"invalid reduction", validStandardTSMPlan, func(p *TSMMergePlan) { p.Reduction.Kind = 99 }},
+		{"enabled finalizer missing query", validStandardTSMPlan, func(p *TSMMergePlan) { p.Finalizer.Enabled = true }},
+		{"disabled finalizer with query", validStandardTSMPlan, func(p *TSMMergePlan) { p.Finalizer.Query = "sum(up)" }},
+		{"bypass with warning", validStandardTSMPlan, func(p *TSMMergePlan) { p.UnsupportedWarning = "inexact" }},
+		{"duplicate variant name", validWeightedAverageTSMPlan, func(p *TSMMergePlan) { p.Variants[1].Name = "avg-sum" }},
+		{"shared variant request", validWeightedAverageTSMPlan, func(p *TSMMergePlan) { p.Variants[1].Request = p.Variants[0].Request }},
+		{"multiple authorities", validWeightedAverageTSMPlan, func(p *TSMMergePlan) { p.Variants[1].ResponseAuthority = true }},
+		{"weighted missing reduction input", validWeightedAverageTSMPlan, func(p *TSMMergePlan) { p.Reduction.InputVariants = []string{"avg-sum"} }},
+		{"weighted missing original query", validWeightedAverageTSMPlan, func(p *TSMMergePlan) { p.OriginalQuery = "" }},
+		{"weighted duplicate reduction input", validWeightedAverageTSMPlan, func(p *TSMMergePlan) { p.Reduction.InputVariants[1] = "avg-sum" }},
+		{"weighted unknown reduction input", validWeightedAverageTSMPlan, func(p *TSMMergePlan) { p.Reduction.InputVariants[1] = "missing" }},
+		{"weighted wrong completeness", validWeightedAverageTSMPlan, func(p *TSMMergePlan) { p.Completeness = TSMCompletenessResponseAuthority }},
+		{"weighted authority not first input", validWeightedAverageTSMPlan, func(p *TSMMergePlan) {
+			p.Variants[0].ResponseAuthority = false
+			p.Variants[1].ResponseAuthority = true
+		}},
+		{"multi variant bypass", validWeightedAverageTSMPlan, func(p *TSMMergePlan) { p.AllowSingleMemberBypass = true }},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			plan := test.plan()
+			test.mutate(plan)
+			if err := plan.Validate(); err == nil {
+				t.Fatal("invalid plan unexpectedly validated")
+			}
+		})
+	}
+}
+
+func TestTSMMergePlanResponseAuthority(t *testing.T) {
+	plan := validWeightedAverageTSMPlan()
+	index, ok := plan.ResponseAuthority()
+	if !ok || index != 0 {
+		t.Fatalf("authority: got (%d, %v), want (0, true)", index, ok)
+	}
+	plan.Variants[0].ResponseAuthority = false
+	if _, ok := plan.ResponseAuthority(); ok {
+		t.Fatal("missing authority unexpectedly reported")
+	}
+}

--- a/pkg/backends/tsm_merge_provider_test.go
+++ b/pkg/backends/tsm_merge_provider_test.go
@@ -19,6 +19,8 @@ package backends
 import (
 	"net/http"
 	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
 )
 
 func testTSMRequest(path string) *http.Request {
@@ -32,7 +34,7 @@ func validStandardTSMPlan() *TSMMergePlan {
 		Variants: []TSMQueryVariant{{
 			Name:              "primary",
 			Request:           testTSMRequest("primary"),
-			MergeStrategy:     1,
+			MergeStrategy:     int(dataset.MergeStrategySum),
 			ResponseAuthority: true,
 		}},
 		Reduction: TSMReductionSpec{
@@ -49,20 +51,20 @@ func validWeightedAverageTSMPlan() *TSMMergePlan {
 		OriginalQuery: "avg(up)",
 		Variants: []TSMQueryVariant{
 			{
-				Name:              "avg-sum",
+				Name:              TSMVariantWeightedAverageSum,
 				Request:           testTSMRequest("sum"),
-				MergeStrategy:     1,
+				MergeStrategy:     int(dataset.MergeStrategySum),
 				ResponseAuthority: true,
 			},
 			{
-				Name:          "avg-count",
+				Name:          TSMVariantWeightedAverageCount,
 				Request:       testTSMRequest("count"),
-				MergeStrategy: 1,
+				MergeStrategy: int(dataset.MergeStrategySum),
 			},
 		},
 		Reduction: TSMReductionSpec{
 			Kind:          TSMReductionWeightedAverage,
-			InputVariants: []string{"avg-sum", "avg-count"},
+			InputVariants: TSMReductionWeightedAverageVariants(),
 		},
 		Completeness: TSMCompletenessAllVariants,
 	}
@@ -74,6 +76,11 @@ func TestTSMMergePlanValidate(t *testing.T) {
 	}
 	if err := validWeightedAverageTSMPlan().Validate(); err != nil {
 		t.Fatalf("valid weighted-average plan: %v", err)
+	}
+	maxStrategyPlan := validStandardTSMPlan()
+	maxStrategyPlan.Variants[0].MergeStrategy = int(dataset.MaxMergeStrategyValue)
+	if err := maxStrategyPlan.Validate(); err != nil {
+		t.Fatalf("maximum merge strategy: %v", err)
 	}
 	var nilPlan *TSMMergePlan
 	if err := nilPlan.Validate(); err == nil {
@@ -89,7 +96,9 @@ func TestTSMMergePlanValidate(t *testing.T) {
 		{"empty variant name", validStandardTSMPlan, func(p *TSMMergePlan) { p.Variants[0].Name = "" }},
 		{"nil request", validStandardTSMPlan, func(p *TSMMergePlan) { p.Variants[0].Request = nil }},
 		{"invalid low strategy", validStandardTSMPlan, func(p *TSMMergePlan) { p.Variants[0].MergeStrategy = -1 }},
-		{"invalid high strategy", validStandardTSMPlan, func(p *TSMMergePlan) { p.Variants[0].MergeStrategy = 6 }},
+		{"invalid high strategy", validStandardTSMPlan, func(p *TSMMergePlan) {
+			p.Variants[0].MergeStrategy = int(dataset.MaxMergeStrategyValue) + 1
+		}},
 		{"missing authority", validStandardTSMPlan, func(p *TSMMergePlan) { p.Variants[0].ResponseAuthority = false }},
 		{"standard missing reduction input", validStandardTSMPlan, func(p *TSMMergePlan) { p.Reduction.InputVariants = nil }},
 		{"standard wrong completeness", validStandardTSMPlan, func(p *TSMMergePlan) { p.Completeness = TSMCompletenessAllVariants }},
@@ -97,13 +106,29 @@ func TestTSMMergePlanValidate(t *testing.T) {
 		{"enabled finalizer missing query", validStandardTSMPlan, func(p *TSMMergePlan) { p.Finalizer.Enabled = true }},
 		{"disabled finalizer with query", validStandardTSMPlan, func(p *TSMMergePlan) { p.Finalizer.Query = "sum(up)" }},
 		{"bypass with warning", validStandardTSMPlan, func(p *TSMMergePlan) { p.UnsupportedWarning = "inexact" }},
-		{"duplicate variant name", validWeightedAverageTSMPlan, func(p *TSMMergePlan) { p.Variants[1].Name = "avg-sum" }},
+		{"duplicate variant name", validWeightedAverageTSMPlan, func(p *TSMMergePlan) {
+			p.Variants[1].Name = TSMVariantWeightedAverageSum
+		}},
 		{"shared variant request", validWeightedAverageTSMPlan, func(p *TSMMergePlan) { p.Variants[1].Request = p.Variants[0].Request }},
 		{"multiple authorities", validWeightedAverageTSMPlan, func(p *TSMMergePlan) { p.Variants[1].ResponseAuthority = true }},
-		{"weighted missing reduction input", validWeightedAverageTSMPlan, func(p *TSMMergePlan) { p.Reduction.InputVariants = []string{"avg-sum"} }},
+		{"weighted missing reduction input", validWeightedAverageTSMPlan, func(p *TSMMergePlan) {
+			p.Reduction.InputVariants = []string{TSMVariantWeightedAverageSum}
+		}},
 		{"weighted missing original query", validWeightedAverageTSMPlan, func(p *TSMMergePlan) { p.OriginalQuery = "" }},
-		{"weighted duplicate reduction input", validWeightedAverageTSMPlan, func(p *TSMMergePlan) { p.Reduction.InputVariants[1] = "avg-sum" }},
+		{"weighted reversed reduction inputs", validWeightedAverageTSMPlan, func(p *TSMMergePlan) {
+			p.Reduction.InputVariants[0], p.Reduction.InputVariants[1] =
+				p.Reduction.InputVariants[1], p.Reduction.InputVariants[0]
+		}},
+		{"weighted duplicate reduction input", validWeightedAverageTSMPlan, func(p *TSMMergePlan) {
+			p.Reduction.InputVariants[1] = TSMVariantWeightedAverageSum
+		}},
 		{"weighted unknown reduction input", validWeightedAverageTSMPlan, func(p *TSMMergePlan) { p.Reduction.InputVariants[1] = "missing" }},
+		{"weighted sum wrong merge strategy", validWeightedAverageTSMPlan, func(p *TSMMergePlan) {
+			p.Variants[0].MergeStrategy = int(dataset.MergeStrategyDedup)
+		}},
+		{"weighted count wrong merge strategy", validWeightedAverageTSMPlan, func(p *TSMMergePlan) {
+			p.Variants[1].MergeStrategy = int(dataset.MergeStrategyCount)
+		}},
 		{"weighted wrong completeness", validWeightedAverageTSMPlan, func(p *TSMMergePlan) { p.Completeness = TSMCompletenessResponseAuthority }},
 		{"weighted authority not first input", validWeightedAverageTSMPlan, func(p *TSMMergePlan) {
 			p.Variants[0].ResponseAuthority = false

--- a/pkg/parsing/lex/sql/token_test.go
+++ b/pkg/parsing/lex/sql/token_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/trickstercache/trickster/v2/pkg/parsing/token"
-	testutil "github.com/trickstercache/trickster/v2/pkg/testutil"
 )
 
 func TestIsKeyword(t *testing.T) {
@@ -107,7 +106,12 @@ func TestIsVerb(t *testing.T) {
 	}
 }
 
-var zeroTime = time.Time{}
+const tokenTestEpoch2020 int64 = 1577836800
+
+var (
+	zeroTime      = time.Time{}
+	tokenTime2020 = time.Unix(tokenTestEpoch2020, 0)
+)
 
 func TestTokenToTime(t *testing.T) {
 	tests := []struct {
@@ -117,8 +121,8 @@ func TestTokenToTime(t *testing.T) {
 		variance time.Duration
 	}{
 		{&token.Token{Typ: token.String, Val: "invalid time"}, zeroTime, ErrInvalidInputLength, 0},
-		{&token.Token{Typ: token.String, Val: "2020-01-01 00:00:00"}, testutil.Time2020, nil, 0},
-		{&token.Token{Typ: token.Number, Val: strconv.FormatInt(testutil.Epoch2020, 10)}, testutil.Time2020, nil, 0},
+		{&token.Token{Typ: token.String, Val: "2020-01-01 00:00:00"}, tokenTime2020, nil, 0},
+		{&token.Token{Typ: token.Number, Val: strconv.FormatInt(tokenTestEpoch2020, 10)}, tokenTime2020, nil, 0},
 		{&token.Token{Typ: token.Number, Val: "not a number"}, zeroTime, strconv.ErrSyntax, 0},
 		{&token.Token{Typ: token.Identifier, Val: "x"}, time.Now(), nil, time.Second},
 	}

--- a/pkg/timeseries/dataset/merge_strategy.go
+++ b/pkg/timeseries/dataset/merge_strategy.go
@@ -49,6 +49,8 @@ const (
 	MergeStrategyMax
 	// MergeStrategyCount counts the number of values at matching epochs.
 	MergeStrategyCount
+	// MaxMergeStrategyValue is the largest valid MergeStrategy value.
+	MaxMergeStrategyValue = MergeStrategyCount
 )
 
 // ParseMergeStrategy converts a string to a MergeStrategy.


### PR DESCRIPTION
## Description

Closes #1073.

This introduces one planning model for every TSM time-series request:

- replace the classification tuple and separate request rewriters with a validated `TSMMergePlan` covering variants, reduction, completeness, response authority, finalization, warnings, and single-member bypass safety
- keep the existing one-variant fanout as a plan-selected fast path, while multi-variant plans use a generic executor that collects by variant and member before accumulation
- migrate weighted `avg` to the generic executor and exclude both sides of a member when either `avg-sum` or `avg-count` is unusable, so reduction never combines different member sets
- share the configured query concurrency limit across variants while retaining independent per-variant fanout capture budgets and metric labels
- preserve response-authority headers/status, partial-hit reporting, cancellation, injected-label stripping, deterministic member order, finalizer ordering, empty responses, and all-authority-failed `502` behavior
- remove the legacy dual-query flag, weighted-average rewrite method, and dedicated weighted-average executor

The new operators from #1069-#1072 are intentionally not included here.

## Type of Change

- - [ ] Bug fix
- - [x] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.

## Tests

- affected package tests and race tests for `backends`, Prometheus planning, TSM, and fanout
- `golangci-lint` with the repository configuration
- multi-variant failure coverage for status, parse, transport, panic, cancellation, capture limits, degraded pools, response authority, injected labels, and completion-order determinism
- plan validation coverage and standard/two-variant executor benchmarks