### PR TITLE
feat: support limit_ratio in ALB TSM

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.5
 require (
 	github.com/alicebob/miniredis/v2 v2.37.0
 	github.com/andybalholm/brotli v1.2.2
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/dgraph-io/badger/v4 v4.9.4
 	github.com/dgraph-io/ristretto/v2 v2.4.2
 	github.com/influxdata/influxdb v1.12.4
@@ -80,7 +81,6 @@ require (
 	github.com/catenacyber/perfsprint v0.10.1 // indirect
 	github.com/ccojocar/zxcvbn-go v1.0.4 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charithe/durationcheck v0.0.11 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/lipgloss v1.1.0 // indirect

--- a/pkg/backends/alb/mech/tsm/merge_plan.go
+++ b/pkg/backends/alb/mech/tsm/merge_plan.go
@@ -430,6 +430,9 @@ func reducePlan(
 	indexes := make(map[string]int, len(plan.Variants))
 	for i, variant := range plan.Variants {
 		indexes[variant.Name] = i
+		if ds, ok := accumulators[i].GetTSData().(*dataset.DataSet); ok && ds != nil {
+			ds.FinalizeValueMerge(variant.MergeStrategy)
+		}
 	}
 
 	switch plan.Reduction.Kind {

--- a/pkg/backends/alb/mech/tsm/merge_plan.go
+++ b/pkg/backends/alb/mech/tsm/merge_plan.go
@@ -62,6 +62,9 @@ func planNeedsLabelStripping(plan *tsmerge.TSMMergePlan) bool {
 	if plan == nil || len(plan.Variants) > 1 {
 		return plan != nil
 	}
+	if plan.StripInjectedLabels {
+		return true
+	}
 	for _, variant := range plan.Variants {
 		if tsmerge.Strategy(variant.MergeStrategy) != tsmerge.StrategyDedup {
 			return true

--- a/pkg/backends/alb/mech/tsm/time_series_merge.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge.go
@@ -331,8 +331,9 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Collect injected label keys from pool backends so they can be stripped
 	// before merging. This ensures series from different backends hash
 	// identically despite having different injected labels (e.g., region tags).
-	// Stripping is only needed when a non-dedup strategy is in play. The set
-	// is cached and reused across requests until the pool is replaced.
+	// Stripping is needed for non-dedup strategies and plans that explicitly
+	// require routing labels to be removed before logical selection. The set is
+	// cached and reused across requests until the pool is replaced.
 	var stripKeys []string
 	if planNeedsLabelStripping(plan) {
 		stripKeys = h.computeStripKeys(hl)

--- a/pkg/backends/alb/mech/tsm/time_series_merge.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge.go
@@ -822,10 +822,7 @@ func pruneUnpairedWeightedAvgSeries(sumDS, countDS *dataset.DataSet, pairingQuer
 		return
 	}
 	pairingHash := func(sh *dataset.SeriesHeader) dataset.Hash {
-		if pairingQueryStatement == "" {
-			return sh.CalculateHash()
-		}
-		return sh.CalculateHashWithQueryStatement(pairingQueryStatement)
+		return sumDS.PairingHash(sh, pairingQueryStatement)
 	}
 	countSeries := make(map[int]map[dataset.Hash]struct{}, len(countDS.Results))
 	for _, r := range countDS.Results {

--- a/pkg/backends/alb/mech/tsm/time_series_merge_limit_ratio_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_limit_ratio_test.go
@@ -1,0 +1,393 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tsm
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/backends/alb/pool"
+	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
+	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
+	"github.com/trickstercache/trickster/v2/pkg/backends/prometheus"
+	prop "github.com/trickstercache/trickster/v2/pkg/backends/prometheus/options"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/params"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/epoch"
+)
+
+type prometheusLimitRatioBackend struct {
+	*prometheus.Client
+	cfg *bo.Options
+}
+
+func (b *prometheusLimitRatioBackend) Configuration() *bo.Options { return b.cfg }
+
+func limitRatioBackend(labels map[string]string) *prometheusLimitRatioBackend {
+	var cfg *bo.Options
+	if labels != nil {
+		cfg = &bo.Options{Prometheus: &prop.Options{Labels: labels}}
+	}
+	return &prometheusLimitRatioBackend{Client: &prometheus.Client{}, cfg: cfg}
+}
+
+func limitRatioMemberHandler(values map[string]string, extraTags dataset.Tags,
+	qr *queryRecorder,
+) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queryValues, _, _ := params.GetRequestValues(r)
+		query := queryValues.Get("query")
+		if qr != nil {
+			qr.Append(query)
+		}
+
+		seriesList := make(dataset.SeriesList, 0, len(values))
+		for service, value := range values {
+			tags := dataset.Tags{"service": service}
+			tags.Merge(extraTags.Clone())
+			seriesList = append(seriesList, &dataset.Series{
+				Header: dataset.SeriesHeader{
+					Name:           "requests",
+					Tags:           tags,
+					QueryStatement: query,
+				},
+				Points: dataset.Points{{
+					Epoch:  epoch.Epoch(100),
+					Size:   32,
+					Values: []any{value},
+				}},
+			})
+		}
+
+		rsc := request.GetResources(r)
+		if rsc != nil {
+			rsc.TS = &dataset.DataSet{Results: dataset.Results{{SeriesList: seriesList}}}
+			rsc.MergeFunc = merge.TimeseriesMergeFuncWithStrategy(nil, rsc.TSMergeStrategy)
+			rsc.BatchMergeFunc = merge.TimeseriesBatchMergeFuncWithStrategy(rsc.TSMergeStrategy)
+			rsc.MergeRespondFunc = limitRatioRespondFunc
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func limitRatioHistogramMemberHandler(histogram string, qr *queryRecorder) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queryValues, _, _ := params.GetRequestValues(r)
+		query := queryValues.Get("query")
+		if qr != nil {
+			qr.Append(query)
+		}
+
+		fieldName := "histogram"
+		value := histogram
+		if strings.HasPrefix(strings.TrimSpace(query), "count") {
+			fieldName = "value"
+			value = "1"
+		}
+		series := &dataset.Series{
+			Header: dataset.SeriesHeader{
+				Name:            "native_histogram",
+				Tags:            dataset.Tags{"service": "api"},
+				QueryStatement:  query,
+				ValueFieldsList: timeseries.FieldDefinitions{{Name: fieldName, DataType: timeseries.String}},
+			},
+			Points: dataset.Points{{
+				Epoch:  epoch.Epoch(100),
+				Size:   len(value) + 32,
+				Values: []any{value},
+			}},
+		}
+
+		rsc := request.GetResources(r)
+		if rsc != nil {
+			rsc.TS = &dataset.DataSet{Results: dataset.Results{{SeriesList: dataset.SeriesList{series}}}}
+			rsc.MergeFunc = merge.TimeseriesMergeFuncWithStrategy(nil, rsc.TSMergeStrategy)
+			rsc.BatchMergeFunc = merge.TimeseriesBatchMergeFuncWithStrategy(rsc.TSMergeStrategy)
+			rsc.MergeRespondFunc = limitRatioRespondFunc
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func limitRatioCaptureFailureHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rsc := request.GetResources(r)
+		if rsc != nil {
+			rsc.MergeFunc = merge.TimeseriesMergeFuncWithStrategy(nil, rsc.TSMergeStrategy)
+			rsc.BatchMergeFunc = merge.TimeseriesBatchMergeFuncWithStrategy(rsc.TSMergeStrategy)
+			rsc.MergeRespondFunc = limitRatioRespondFunc
+		}
+		_, _ = w.Write([]byte(strings.Repeat("x", 256)))
+	})
+}
+
+func limitRatioRespondFunc(w http.ResponseWriter, _ *http.Request,
+	accum *merge.Accumulator, statusCode int,
+) {
+	if statusCode == 0 {
+		statusCode = http.StatusOK
+	}
+	ds, _ := accum.GetTSData().(*dataset.DataSet)
+	parts := make([]string, 0)
+	if ds != nil {
+		for _, result := range ds.Results {
+			if result == nil {
+				continue
+			}
+			for _, series := range result.SeriesList {
+				if series == nil || len(series.Points) == 0 || len(series.Points[0].Values) == 0 {
+					continue
+				}
+				name := series.Header.Tags["service"]
+				if replica := series.Header.Tags["replica"]; replica != "" {
+					name += "[" + replica + "]"
+				}
+				parts = append(parts, fmt.Sprintf("%s=%v", name,
+					series.Points[0].Values[0]))
+			}
+		}
+	}
+	w.WriteHeader(statusCode)
+	_, _ = w.Write([]byte(strings.Join(parts, ",") + "|warnings=" +
+		strings.Join(dsWarnings(ds), ",")))
+}
+
+func newLimitRatioTarget(h http.Handler, backend *prometheusLimitRatioBackend) *pool.Target {
+	status := &healthcheck.Status{}
+	status.Set(healthcheck.StatusPassing)
+	return pool.NewTarget(h, status, backend)
+}
+
+func serveLimitRatio(t *testing.T, targets pool.Targets, query string,
+	configure ...func(*handler),
+) *httptest.ResponseRecorder {
+	t.Helper()
+	p := pool.New(targets, -1)
+	p.RefreshHealthy()
+	t.Cleanup(p.Stop)
+
+	h := &handler{mergePaths: []string{"/"}}
+	for _, apply := range configure {
+		apply(h)
+	}
+	h.SetPool(p)
+	req := newTestMergeRequest(t)
+	req.URL.RawQuery = "query=" + url.QueryEscape(query)
+	rsc := request.GetResources(req)
+	rsc.TimeRangeQuery = &timeseries.TimeRangeQuery{Statement: query}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	return w
+}
+
+func TestTSMLimitRatioMergesInnerAggregationBeforeSampling(t *testing.T) {
+	logger.SetLogger(testLogger)
+	const (
+		query = "sort_desc(limit_ratio(0.5, count by (service) (requests)))"
+		inner = "count by (service) (requests)"
+	)
+	qr := &queryRecorder{}
+	targets := pool.Targets{
+		newLimitRatioTarget(limitRatioMemberHandler(
+			map[string]string{"c": "2", "d": "10"},
+			dataset.Tags{"region": "a"}, qr),
+			limitRatioBackend(map[string]string{"region": "a"})),
+		newLimitRatioTarget(limitRatioMemberHandler(
+			map[string]string{"c": "3", "d": "1"},
+			dataset.Tags{"region": "b"}, qr),
+			limitRatioBackend(map[string]string{"region": "b"})),
+	}
+
+	w := serveLimitRatio(t, targets, query)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status got %d want 200 body=%q", w.Code, w.Body.String())
+	}
+	if got, want := w.Body.String(), "d=11|warnings="; got != want {
+		t.Fatalf("body got %q want %q", got, want)
+	}
+	queries := qr.Queries()
+	if len(queries) != 2 {
+		t.Fatalf("fanout queries got %v want two entries", queries)
+	}
+	for _, got := range queries {
+		if got != inner {
+			t.Fatalf("fanout query got %q want %q", got, inner)
+		}
+	}
+}
+
+func TestTSMLimitRatioHistogramInnerAggregationsRetainFallback(t *testing.T) {
+	logger.SetLogger(testLogger)
+	histograms := []string{
+		`{"count":"10","sum":"3.14","schema":3,"zero_threshold":0.001,"zero_count":"2",` +
+			`"positive_spans":[{"offset":0,"length":1}],"positive_deltas":[1]}`,
+		`{"count":"20","sum":"6.28","schema":3,"zero_threshold":0.001,"zero_count":"4",` +
+			`"positive_spans":[{"offset":0,"length":1}],"positive_deltas":[2]}`,
+	}
+	for _, operator := range []string{"sum", "avg"} {
+		t.Run(operator, func(t *testing.T) {
+			query := "limit_ratio(-1, " + operator + " by (service) (native_histogram))"
+			qr := &queryRecorder{}
+			targets := pool.Targets{
+				newLimitRatioTarget(limitRatioHistogramMemberHandler(histograms[0], qr), limitRatioBackend(nil)),
+				newLimitRatioTarget(limitRatioHistogramMemberHandler(histograms[1], qr), limitRatioBackend(nil)),
+			}
+
+			w := serveLimitRatio(t, targets, query)
+			body := w.Body.String()
+			if w.Code != http.StatusOK || strings.Contains(body, "NaN") ||
+				(!strings.Contains(body, histograms[0]) && !strings.Contains(body, histograms[1])) {
+				t.Fatalf("status=%d body=%q", w.Code, body)
+			}
+			if !strings.Contains(body, "native-histogram-aware") {
+				t.Fatalf("body missing compatibility warning: %q", body)
+			}
+			queries := qr.Queries()
+			if len(queries) != 2 || queries[0] != query || queries[1] != query {
+				t.Fatalf("fanout queries got %v want two unchanged queries", queries)
+			}
+		})
+	}
+}
+
+func TestTSMLimitRatioStripsInjectedLabelsBeforeHADedup(t *testing.T) {
+	logger.SetLogger(testLogger)
+	const query = "limit_ratio(-1, up)"
+	qr := &queryRecorder{}
+	targets := pool.Targets{
+		newLimitRatioTarget(
+			limitRatioMemberHandler(map[string]string{"api": "1"},
+				dataset.Tags{"replica": "a"}, qr),
+			limitRatioBackend(map[string]string{"replica": "a"}),
+		),
+		newLimitRatioTarget(
+			limitRatioMemberHandler(map[string]string{"api": "1"},
+				dataset.Tags{"replica": "b"}, qr),
+			limitRatioBackend(map[string]string{"replica": "b"}),
+		),
+	}
+
+	w := serveLimitRatio(t, targets, query)
+
+	if got, want := w.Body.String(), "api=1|warnings="; got != want {
+		t.Fatalf("body got %q want %q", got, want)
+	}
+	queries := qr.Queries()
+	if len(queries) != 2 || queries[0] != query || queries[1] != query {
+		t.Fatalf("fanout queries got %v want two unchanged queries", queries)
+	}
+}
+
+func TestTSMLimitRatioSingleMemberBypassRespectsLabelCleanup(t *testing.T) {
+	logger.SetLogger(testLogger)
+	const query = "limit_ratio(-1, up)"
+
+	t.Run("no configured labels uses direct proxy", func(t *testing.T) {
+		direct := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("direct"))
+		})
+		w := serveLimitRatio(t, pool.Targets{
+			newLimitRatioTarget(direct, limitRatioBackend(nil)),
+		}, query)
+		if got, want := w.Body.String(), "direct"; got != want {
+			t.Fatalf("body got %q want %q", got, want)
+		}
+	})
+
+	t.Run("configured labels force merge cleanup", func(t *testing.T) {
+		w := serveLimitRatio(t, pool.Targets{
+			newLimitRatioTarget(
+				limitRatioMemberHandler(map[string]string{"api": "1"},
+					dataset.Tags{"replica": "a"}, nil),
+				limitRatioBackend(map[string]string{"replica": "a"}),
+			),
+		}, query)
+		if got, want := w.Body.String(), "api=1|warnings="; got != want {
+			t.Fatalf("body got %q want %q", got, want)
+		}
+	})
+}
+
+func TestTSMLimitRatioIsIndependentOfPoolOrder(t *testing.T) {
+	logger.SetLogger(testLogger)
+	const query = "sort(limit_ratio(-1, up))"
+	backend := limitRatioBackend(nil)
+	handlers := []http.Handler{
+		limitRatioMemberHandler(map[string]string{"api": "2"}, nil, nil),
+		limitRatioMemberHandler(map[string]string{"worker": "1"}, nil, nil),
+	}
+	for _, order := range [][2]int{{0, 1}, {1, 0}} {
+		targets := pool.Targets{
+			newLimitRatioTarget(handlers[order[0]], backend),
+			newLimitRatioTarget(handlers[order[1]], backend),
+		}
+		w := serveLimitRatio(t, targets, query)
+		if got, want := w.Body.String(), "worker=1,api=2|warnings="; got != want {
+			t.Fatalf("order %v body got %q want %q", order, got, want)
+		}
+	}
+}
+
+func TestTSMLimitRatioSurfacesPartialAndCaptureFailures(t *testing.T) {
+	logger.SetLogger(testLogger)
+	const query = "limit_ratio(-1, up)"
+	backend := limitRatioBackend(nil)
+	tests := []struct {
+		name      string
+		failed    http.Handler
+		configure func(*handler)
+	}{
+		{"status", stubFailHandler(http.StatusInternalServerError), nil},
+		{"capture", limitRatioCaptureFailureHandler(), func(h *handler) {
+			h.maxCaptureBytes = 32
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			targets := pool.Targets{
+				newLimitRatioTarget(limitRatioMemberHandler(
+					map[string]string{"api": "1"}, nil, nil), backend),
+				newLimitRatioTarget(tt.failed, backend),
+			}
+			var configure []func(*handler)
+			if tt.configure != nil {
+				configure = append(configure, tt.configure)
+			}
+			w := serveLimitRatio(t, targets, query, configure...)
+
+			if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "api=1") {
+				t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+			}
+			if !strings.Contains(w.Body.String(), "tsm partial failure") {
+				t.Fatalf("body missing partial warning: %q", w.Body.String())
+			}
+			if got := w.Header().Get(headers.NameTricksterResult); !strings.Contains(got, "phit") {
+				t.Fatalf("result header got %q want phit", got)
+			}
+		})
+	}
+}

--- a/pkg/backends/alb/mech/tsm/time_series_merge_limit_ratio_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_limit_ratio_test.go
@@ -17,7 +17,9 @@
 package tsm
 
 import (
+	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -28,6 +30,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
 	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
 	"github.com/trickstercache/trickster/v2/pkg/backends/prometheus"
+	prommodel "github.com/trickstercache/trickster/v2/pkg/backends/prometheus/model"
 	prop "github.com/trickstercache/trickster/v2/pkg/backends/prometheus/options"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
@@ -101,29 +104,23 @@ func limitRatioHistogramMemberHandler(histogram string, qr *queryRecorder) http.
 			qr.Append(query)
 		}
 
-		fieldName := "histogram"
-		value := histogram
+		resultValue := `"histogram":[100,` + histogram + `]`
 		if strings.HasPrefix(strings.TrimSpace(query), "count") {
-			fieldName = "value"
-			value = "1"
+			resultValue = `"value":[100,"1"]`
 		}
-		series := &dataset.Series{
-			Header: dataset.SeriesHeader{
-				Name:            "native_histogram",
-				Tags:            dataset.Tags{"service": "api"},
-				QueryStatement:  query,
-				ValueFieldsList: timeseries.FieldDefinitions{{Name: fieldName, DataType: timeseries.String}},
-			},
-			Points: dataset.Points{{
-				Epoch:  epoch.Epoch(100),
-				Size:   len(value) + 32,
-				Values: []any{value},
-			}},
+		body := `{"status":"success","data":{"resultType":"vector","result":[{` +
+			`"metric":{"service":"api"},` + resultValue + `}]}}`
+		ts, err := prommodel.UnmarshalTimeseries([]byte(body), &timeseries.TimeRangeQuery{
+			Statement: query,
+		})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
 		}
 
 		rsc := request.GetResources(r)
 		if rsc != nil {
-			rsc.TS = &dataset.DataSet{Results: dataset.Results{{SeriesList: dataset.SeriesList{series}}}}
+			rsc.TS = ts
 			rsc.MergeFunc = merge.TimeseriesMergeFuncWithStrategy(nil, rsc.TSMergeStrategy)
 			rsc.BatchMergeFunc = merge.TimeseriesBatchMergeFuncWithStrategy(rsc.TSMergeStrategy)
 			rsc.MergeRespondFunc = limitRatioRespondFunc
@@ -240,7 +237,39 @@ func TestTSMLimitRatioMergesInnerAggregationBeforeSampling(t *testing.T) {
 	}
 }
 
-func TestTSMLimitRatioHistogramInnerAggregationsRetainFallback(t *testing.T) {
+func TestTSMLimitRatioMergesInnerFloatSumBeforeSampling(t *testing.T) {
+	logger.SetLogger(testLogger)
+	const (
+		query = "limit_ratio(-1, sum by (service) (requests))"
+		inner = "sum by (service) (requests)"
+	)
+	qr := &queryRecorder{}
+	targets := pool.Targets{
+		newLimitRatioTarget(limitRatioMemberHandler(
+			map[string]string{"c": "2", "d": "10"}, nil, qr),
+			limitRatioBackend(nil)),
+		newLimitRatioTarget(limitRatioMemberHandler(
+			map[string]string{"c": "3", "d": "1"}, nil, qr),
+			limitRatioBackend(nil)),
+	}
+
+	w := serveLimitRatio(t, targets, query)
+
+	if got, want := w.Body.String(), "c=5,d=11|warnings="; got != want {
+		t.Fatalf("body got %q want %q", got, want)
+	}
+	queries := qr.Queries()
+	if len(queries) != 2 {
+		t.Fatalf("fanout queries got %v want two entries", queries)
+	}
+	for _, got := range queries {
+		if got != inner {
+			t.Fatalf("fanout query got %q want %q", got, inner)
+		}
+	}
+}
+
+func TestTSMLimitRatioHistogramInnerAggregationsUseExactReduction(t *testing.T) {
 	logger.SetLogger(testLogger)
 	histograms := []string{
 		`{"count":"10","sum":"3.14","schema":3,"zero_threshold":0.001,"zero_count":"2",` +
@@ -259,16 +288,48 @@ func TestTSMLimitRatioHistogramInnerAggregationsRetainFallback(t *testing.T) {
 
 			w := serveLimitRatio(t, targets, query)
 			body := w.Body.String()
-			if w.Code != http.StatusOK || strings.Contains(body, "NaN") ||
-				(!strings.Contains(body, histograms[0]) && !strings.Contains(body, histograms[1])) {
+			if w.Code != http.StatusOK || strings.Contains(body, "NaN") {
 				t.Fatalf("status=%d body=%q", w.Code, body)
 			}
-			if !strings.Contains(body, "native-histogram-aware") {
-				t.Fatalf("body missing compatibility warning: %q", body)
+			if strings.Contains(body, "warnings=PromQL") ||
+				strings.Contains(body, "native-histogram-aware") {
+				t.Fatalf("body has unexpected warning: %q", body)
 			}
+			value := strings.TrimSuffix(strings.TrimPrefix(body, "api="), "|warnings=")
+			var histogram struct {
+				Count   string  `json:"count"`
+				Sum     string  `json:"sum"`
+				Buckets [][]any `json:"buckets"`
+			}
+			if err := json.Unmarshal([]byte(value), &histogram); err != nil {
+				t.Fatalf("decode merged histogram %q: %v", value, err)
+			}
+			wantCount, wantSum := "30", "9.42"
+			wantZero, wantPositive := "6", "3"
+			if operator == "avg" {
+				wantCount, wantSum = "15", "4.71"
+				wantZero, wantPositive = "3", "1.5"
+			}
+			if histogram.Count != wantCount || histogram.Sum != wantSum ||
+				len(histogram.Buckets) != 2 ||
+				histogram.Buckets[0][3] != wantZero ||
+				histogram.Buckets[1][3] != wantPositive {
+				t.Fatalf("merged histogram got %#v", histogram)
+			}
+
 			queries := qr.Queries()
-			if len(queries) != 2 || queries[0] != query || queries[1] != query {
-				t.Fatalf("fanout queries got %v want two unchanged queries", queries)
+			wantQueries := map[string]int{
+				"sum by (service) (native_histogram)": 2,
+			}
+			if operator == "avg" {
+				wantQueries["count by (service) (native_histogram)"] = 2
+			}
+			gotQueries := make(map[string]int, len(wantQueries))
+			for _, got := range queries {
+				gotQueries[got]++
+			}
+			if !maps.Equal(gotQueries, wantQueries) {
+				t.Fatalf("fanout queries got %v want %v", gotQueries, wantQueries)
 			}
 		})
 	}

--- a/pkg/backends/alb/mech/tsm/time_series_merge_stripkeys_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_stripkeys_test.go
@@ -26,7 +26,23 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
 	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
 	prop "github.com/trickstercache/trickster/v2/pkg/backends/prometheus/options"
+	tsmerge "github.com/trickstercache/trickster/v2/pkg/timeseries/merge"
 )
+
+func TestPlanNeedsLabelStrippingExplicitly(t *testing.T) {
+	plan := &tsmerge.TSMMergePlan{
+		Variants: []tsmerge.TSMQueryVariant{{
+			MergeStrategy: int(tsmerge.StrategyDedup),
+		}},
+	}
+	if planNeedsLabelStripping(plan) {
+		t.Fatal("plain dedup plan unexpectedly strips injected labels")
+	}
+	plan.StripInjectedLabels = true
+	if !planNeedsLabelStripping(plan) {
+		t.Fatal("explicit label stripping was ignored")
+	}
+}
 
 func mkStripKeysTarget(labels map[string]string) *pool.Target {
 	be := &stripKeysStubBackend{

--- a/pkg/backends/prometheus/model/histogram_operations.go
+++ b/pkg/backends/prometheus/model/histogram_operations.go
@@ -1,0 +1,521 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"slices"
+	"strconv"
+
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/epoch"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/merge"
+)
+
+const mixedFloatHistogramWarning = "PromQL warning: encountered a mix of histograms and floats for aggregation"
+
+var prometheusValueOperations dataset.ValueMergeOperations = prometheusHistogramOperations{}
+
+type prometheusHistogramOperations struct{}
+
+type normalizedHistogram struct {
+	count   float64
+	sum     float64
+	buckets []normalizedHistogramBucket
+}
+
+type normalizedHistogramBucket struct {
+	lower          float64
+	upper          float64
+	count          float64
+	lowerInclusive bool
+	upperInclusive bool
+}
+
+func (prometheusHistogramOperations) MergeValues(dst, src any,
+	strategy merge.Strategy,
+) (any, bool) {
+	if strategy != merge.StrategySum && strategy != merge.StrategyAvg {
+		return nil, false
+	}
+	left, err := parseNormalizedHistogram(dst)
+	if err != nil {
+		return nil, false
+	}
+	right, err := parseNormalizedHistogram(src)
+	if err != nil {
+		return nil, false
+	}
+	left.count += right.count
+	left.sum += right.sum
+	left.buckets = coarsenHistogramBuckets(left.buckets, right.buckets)
+	value, err := marshalNormalizedHistogram(left)
+	return value, err == nil
+}
+
+func (prometheusHistogramOperations) DivideValue(value any, divisor float64) (any, bool) {
+	if divisor == 0 {
+		return nil, false
+	}
+	histogram, err := parseNormalizedHistogram(value)
+	if err != nil {
+		return nil, false
+	}
+	histogram.count /= divisor
+	histogram.sum /= divisor
+	for i := range histogram.buckets {
+		histogram.buckets[i].count /= divisor
+	}
+	value, err = marshalNormalizedHistogram(histogram)
+	return value, err == nil
+}
+
+func (prometheusHistogramOperations) PairingHash(header *dataset.SeriesHeader,
+	queryStatement string,
+) dataset.Hash {
+	clone := header.Clone()
+	clone.ValueFieldsList = nil
+	if queryStatement == "" {
+		queryStatement = clone.QueryStatement
+	}
+	return clone.CalculateHashWithQueryStatement(queryStatement)
+}
+
+func (ops prometheusHistogramOperations) FinalizeMerge(ds *dataset.DataSet,
+	strategy merge.Strategy,
+) {
+	if strategy != merge.StrategySum && strategy != merge.StrategyAvg {
+		return
+	}
+	mixedSamples := 0
+	for _, result := range ds.Results {
+		if result == nil {
+			continue
+		}
+		type sampleGroup struct {
+			floats     []*dataset.Series
+			histograms []*dataset.Series
+		}
+		groups := make(map[dataset.Hash]*sampleGroup, len(result.SeriesList))
+		for _, series := range result.SeriesList {
+			if series == nil {
+				continue
+			}
+			hash := ops.PairingHash(&series.Header, "")
+			group := groups[hash]
+			if group == nil {
+				group = &sampleGroup{}
+				groups[hash] = group
+			}
+			if isHistogramSeries(series) {
+				group.histograms = append(group.histograms, series)
+			} else {
+				group.floats = append(group.floats, series)
+			}
+		}
+		for _, group := range groups {
+			if len(group.floats) == 0 || len(group.histograms) == 0 {
+				continue
+			}
+			sampleTypes := make(map[epoch.Epoch]uint8)
+			for _, series := range group.floats {
+				for _, point := range series.Points {
+					sampleTypes[point.Epoch] |= 1
+				}
+			}
+			for _, series := range group.histograms {
+				for _, point := range series.Points {
+					sampleTypes[point.Epoch] |= 2
+				}
+			}
+			mixedEpochs := make(map[epoch.Epoch]struct{})
+			for sampleEpoch, sampleType := range sampleTypes {
+				if sampleType == 3 {
+					mixedEpochs[sampleEpoch] = struct{}{}
+				}
+			}
+			if len(mixedEpochs) == 0 {
+				continue
+			}
+			mixedSamples += len(mixedEpochs)
+			for _, series := range append(group.floats, group.histograms...) {
+				kept := series.Points[:0]
+				for _, point := range series.Points {
+					if _, mixed := mixedEpochs[point.Epoch]; !mixed {
+						kept = append(kept, point)
+					}
+				}
+				series.Points = kept
+				series.PointSize = kept.Size()
+			}
+		}
+		kept := result.SeriesList[:0]
+		for _, series := range result.SeriesList {
+			if series != nil && len(series.Points) > 0 {
+				kept = append(kept, series)
+			}
+		}
+		result.SeriesList = kept
+	}
+	if mixedSamples > 0 && !slices.Contains(ds.Warnings, mixedFloatHistogramWarning) {
+		ds.Warnings = append(ds.Warnings, mixedFloatHistogramWarning)
+	}
+}
+
+func isHistogramSeries(series *dataset.Series) bool {
+	return len(series.Header.ValueFieldsList) == 1 &&
+		series.Header.ValueFieldsList[0].Name == fieldNameHistogram
+}
+
+func parseNormalizedHistogram(value any) (normalizedHistogram, error) {
+	raw, ok := value.(string)
+	if !ok {
+		return normalizedHistogram{}, fmt.Errorf("histogram value has type %T", value)
+	}
+	var wire WFHistogram
+	if err := json.Unmarshal([]byte(raw), &wire); err != nil {
+		return normalizedHistogram{}, err
+	}
+	count, err := parseHistogramNumber(wire.Count, false)
+	if err != nil {
+		return normalizedHistogram{}, fmt.Errorf("parse histogram count: %w", err)
+	}
+	sum, err := parseHistogramNumber(wire.Sum, false)
+	if err != nil {
+		return normalizedHistogram{}, fmt.Errorf("parse histogram sum: %w", err)
+	}
+	out := normalizedHistogram{count: count, sum: sum}
+	if len(wire.Buckets) > 0 {
+		out.buckets, err = parseExplicitHistogramBuckets(wire.Buckets)
+		if err != nil {
+			return normalizedHistogram{}, err
+		}
+		return out, nil
+	}
+	zeroCount, err := parseHistogramNumber(wire.ZeroCount, true)
+	if err != nil {
+		return normalizedHistogram{}, fmt.Errorf("parse histogram zero count: %w", err)
+	}
+	if zeroCount != 0 {
+		out.buckets = append(out.buckets, normalizedHistogramBucket{
+			lower:          -wire.ZeroThreshold,
+			upper:          wire.ZeroThreshold,
+			count:          zeroCount,
+			lowerInclusive: true,
+			upperInclusive: true,
+		})
+	}
+	if err := appendSpanHistogramBuckets(&out.buckets, wire.NegativeSpans,
+		wire.NegativeDeltas, wire.NegativeCounts, false, wire.Schema,
+		wire.CustomValues); err != nil {
+		return normalizedHistogram{}, fmt.Errorf("parse negative histogram buckets: %w", err)
+	}
+	if err := appendSpanHistogramBuckets(&out.buckets, wire.PositiveSpans,
+		wire.PositiveDeltas, wire.PositiveCounts, true, wire.Schema,
+		wire.CustomValues); err != nil {
+		return normalizedHistogram{}, fmt.Errorf("parse positive histogram buckets: %w", err)
+	}
+	for i := range out.buckets {
+		switch {
+		case out.buckets[i].lower > 0 &&
+			out.buckets[i].lower < wire.ZeroThreshold:
+			out.buckets[i].lower = wire.ZeroThreshold
+		case out.buckets[i].upper < 0 &&
+			out.buckets[i].upper > -wire.ZeroThreshold:
+			out.buckets[i].upper = -wire.ZeroThreshold
+		}
+	}
+	slices.SortFunc(out.buckets, compareHistogramBuckets)
+	return out, nil
+}
+
+func parseExplicitHistogramBuckets(wireBuckets [][]any) ([]normalizedHistogramBucket, error) {
+	buckets := make([]normalizedHistogramBucket, 0, len(wireBuckets))
+	for _, wireBucket := range wireBuckets {
+		if len(wireBucket) != 4 {
+			return nil, fmt.Errorf("histogram bucket has %d fields", len(wireBucket))
+		}
+		boundaries, err := histogramNumber(wireBucket[0])
+		if err != nil || boundaries != math.Trunc(boundaries) || boundaries < 0 || boundaries > 3 {
+			return nil, fmt.Errorf("invalid histogram bucket boundaries %v", wireBucket[0])
+		}
+		lower, err := histogramNumber(wireBucket[1])
+		if err != nil {
+			return nil, fmt.Errorf("parse histogram lower bound: %w", err)
+		}
+		upper, err := histogramNumber(wireBucket[2])
+		if err != nil {
+			return nil, fmt.Errorf("parse histogram upper bound: %w", err)
+		}
+		count, err := histogramNumber(wireBucket[3])
+		if err != nil {
+			return nil, fmt.Errorf("parse histogram bucket count: %w", err)
+		}
+		if math.IsNaN(lower) || math.IsNaN(upper) || lower > upper {
+			return nil, fmt.Errorf("invalid histogram bucket interval %v", wireBucket)
+		}
+		mode := int(boundaries)
+		buckets = append(buckets, normalizedHistogramBucket{
+			lower:          lower,
+			upper:          upper,
+			count:          count,
+			lowerInclusive: mode == 1 || mode == 3,
+			upperInclusive: mode == 0 || mode == 3,
+		})
+	}
+	slices.SortFunc(buckets, compareHistogramBuckets)
+	return buckets, nil
+}
+
+func appendSpanHistogramBuckets(dst *[]normalizedHistogramBucket,
+	spans []WFHistogramSpan, deltas []int64, counts []string, positive bool,
+	schema int, customValues []float64,
+) error {
+	bucketCount := 0
+	for _, span := range spans {
+		bucketCount += int(span.Length)
+	}
+	if bucketCount == 0 {
+		return nil
+	}
+	usingCounts := len(counts) > 0
+	if usingCounts {
+		if len(counts) != bucketCount {
+			return fmt.Errorf("span count %d does not match bucket count %d",
+				len(counts), bucketCount)
+		}
+	} else if len(deltas) != bucketCount {
+		return fmt.Errorf("span delta count %d does not match bucket count %d",
+			len(deltas), bucketCount)
+	}
+
+	var index int32
+	var absoluteCount float64
+	position := 0
+	for _, span := range spans {
+		index += span.Offset
+		for range span.Length {
+			var count float64
+			var err error
+			if usingCounts {
+				count, err = parseHistogramNumber(counts[position], false)
+				if err != nil {
+					return err
+				}
+			} else {
+				absoluteCount += float64(deltas[position])
+				count = absoluteCount
+			}
+			if count != 0 {
+				bucket, err := spanHistogramBucket(index, count, positive,
+					schema, customValues)
+				if err != nil {
+					return err
+				}
+				*dst = append(*dst, bucket)
+			}
+			index++
+			position++
+		}
+	}
+	return nil
+}
+
+func spanHistogramBucket(index int32, count float64, positive bool,
+	schema int, customValues []float64,
+) (normalizedHistogramBucket, error) {
+	if schema != -53 && (schema < -4 || schema > 8) {
+		return normalizedHistogramBucket{}, fmt.Errorf("invalid histogram schema %d", schema)
+	}
+	lowerBound, err := histogramBucketBound(index-1, schema, customValues)
+	if err != nil {
+		return normalizedHistogramBucket{}, err
+	}
+	upperBound, err := histogramBucketBound(index, schema, customValues)
+	if err != nil {
+		return normalizedHistogramBucket{}, err
+	}
+	if positive {
+		return normalizedHistogramBucket{
+			lower:          lowerBound,
+			upper:          upperBound,
+			count:          count,
+			lowerInclusive: schema == -53 && index == 0,
+			upperInclusive: true,
+		}, nil
+	}
+	return normalizedHistogramBucket{
+		lower:          -upperBound,
+		upper:          -lowerBound,
+		count:          count,
+		lowerInclusive: true,
+		upperInclusive: false,
+	}, nil
+}
+
+func histogramBucketBound(index int32, schema int, customValues []float64) (float64, error) {
+	if schema == -53 {
+		index64 := int64(index)
+		customValuesLength := int64(len(customValues))
+		switch {
+		case index == -1:
+			return math.Inf(-1), nil
+		case index64 == customValuesLength:
+			return math.Inf(1), nil
+		case index < -1 || index64 > customValuesLength:
+			return 0, fmt.Errorf("custom histogram bucket index %d out of range", index)
+		default:
+			return customValues[index], nil
+		}
+	}
+	if schema < 0 {
+		exponent := int(index) << -schema
+		if exponent == 1024 {
+			return math.MaxFloat64, nil
+		}
+		return math.Ldexp(1, exponent), nil
+	}
+	fractionMask := int32(1<<schema) - 1
+	if index&fractionMask == 0 && (int(index)>>schema)+1 == 1025 {
+		return math.MaxFloat64, nil
+	}
+	return math.Exp2(float64(index) * math.Exp2(float64(-schema))), nil
+}
+
+func coarsenHistogramBuckets(left, right []normalizedHistogramBucket) []normalizedHistogramBucket {
+	buckets := make([]normalizedHistogramBucket, 0, len(left)+len(right))
+	buckets = append(buckets, left...)
+	buckets = append(buckets, right...)
+	if len(buckets) < 2 {
+		return buckets
+	}
+	slices.SortFunc(buckets, compareHistogramBuckets)
+	// The HTTP API omits empty buckets. Merging overlapping intervals into
+	// connected components produces a common layout without splitting any
+	// source bucket or inventing a distribution within it.
+	merged := buckets[:1]
+	for _, next := range buckets[1:] {
+		current := &merged[len(merged)-1]
+		if histogramBucketsOverlap(*current, next) {
+			current.count += next.count
+			if next.lower == current.lower {
+				current.lowerInclusive = current.lowerInclusive || next.lowerInclusive
+			}
+			if next.upper > current.upper {
+				current.upper = next.upper
+				current.upperInclusive = next.upperInclusive
+			} else if next.upper == current.upper {
+				current.upperInclusive = current.upperInclusive || next.upperInclusive
+			}
+			continue
+		}
+		merged = append(merged, next)
+	}
+	return merged
+}
+
+func compareHistogramBuckets(left, right normalizedHistogramBucket) int {
+	switch {
+	case left.lower < right.lower:
+		return -1
+	case left.lower > right.lower:
+		return 1
+	case left.upper < right.upper:
+		return -1
+	case left.upper > right.upper:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func histogramBucketsOverlap(left, right normalizedHistogramBucket) bool {
+	return right.lower < left.upper ||
+		(right.lower == left.upper && left.upperInclusive && right.lowerInclusive)
+}
+
+func marshalNormalizedHistogram(histogram normalizedHistogram) (string, error) {
+	wire := struct {
+		Count   string  `json:"count"`
+		Sum     string  `json:"sum"`
+		Buckets [][]any `json:"buckets,omitempty"`
+	}{
+		Count: formatHistogramNumber(histogram.count),
+		Sum:   formatHistogramNumber(histogram.sum),
+	}
+	for _, bucket := range histogram.buckets {
+		if bucket.count == 0 {
+			continue
+		}
+		boundaries := 2
+		switch {
+		case bucket.lowerInclusive && bucket.upperInclusive:
+			boundaries = 3
+		case bucket.lowerInclusive:
+			boundaries = 1
+		case bucket.upperInclusive:
+			boundaries = 0
+		}
+		wire.Buckets = append(wire.Buckets, []any{
+			boundaries,
+			formatHistogramNumber(bucket.lower),
+			formatHistogramNumber(bucket.upper),
+			formatHistogramNumber(bucket.count),
+		})
+	}
+	data, err := json.Marshal(wire)
+	return string(data), err
+}
+
+func parseHistogramNumber(value string, optional bool) (float64, error) {
+	if value == "" && optional {
+		return 0, nil
+	}
+	return strconv.ParseFloat(value, 64)
+}
+
+func histogramNumber(value any) (float64, error) {
+	switch typed := value.(type) {
+	case string:
+		return strconv.ParseFloat(typed, 64)
+	case float64:
+		return typed, nil
+	case float32:
+		return float64(typed), nil
+	case int:
+		return float64(typed), nil
+	case int32:
+		return float64(typed), nil
+	case int64:
+		return float64(typed), nil
+	case json.Number:
+		return typed.Float64()
+	default:
+		return 0, fmt.Errorf("value has type %T", value)
+	}
+}
+
+func formatHistogramNumber(value float64) string {
+	format := byte('f')
+	absolute := math.Abs(value)
+	if absolute != 0 && (absolute < 1e-6 || absolute >= 1e21) {
+		format = 'e'
+	}
+	return strconv.FormatFloat(value, format, -1, 64)
+}

--- a/pkg/backends/prometheus/model/histogram_operations_test.go
+++ b/pkg/backends/prometheus/model/histogram_operations_test.go
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package model
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/epoch"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/merge"
+)
+
+func TestPrometheusHistogramOperationsMergeExplicitBuckets(t *testing.T) {
+	left := `{"count":"10","sum":"20","buckets":[` +
+		`[0,"0","1","4"],[0,"1","2","6"]]}`
+	right := `{"count":"8","sum":"14","buckets":[[0,"0","2","8"]]}`
+
+	value, handled := prometheusValueOperations.MergeValues(left, right, merge.StrategySum)
+	require.True(t, handled)
+	histogram, err := parseNormalizedHistogram(value)
+	require.NoError(t, err)
+	require.Equal(t, 18.0, histogram.count)
+	require.Equal(t, 34.0, histogram.sum)
+	require.Len(t, histogram.buckets, 1)
+	require.Equal(t, 0.0, histogram.buckets[0].lower)
+	require.Equal(t, 2.0, histogram.buckets[0].upper)
+	require.Equal(t, 18.0, histogram.buckets[0].count)
+}
+
+func TestPrometheusHistogramOperationsDatasetMergeUpdatesSize(t *testing.T) {
+	leftValue := `{"count":"1","sum":"1","buckets":[[0,"0","1","1"]]}`
+	rightValue := `{"count":"2","sum":"3","buckets":[[0,"0","1","2"]]}`
+	newDataSet := func(value string) *dataset.DataSet {
+		return &dataset.DataSet{
+			ValueOperations: prometheusValueOperations,
+			Results: dataset.Results{{SeriesList: dataset.SeriesList{{
+				Header: dataset.SeriesHeader{
+					Tags:            dataset.Tags{"service": "api"},
+					QueryStatement:  "sum by (service) (requests)",
+					ValueFieldsList: timeseries.FieldDefinitions{{Name: fieldNameHistogram}},
+				},
+				Points: dataset.Points{{
+					Epoch:  epoch.Epoch(1),
+					Size:   len(value) + 32,
+					Values: []any{value},
+				}},
+			}}}},
+		}
+	}
+	left := newDataSet(leftValue)
+	left.MergeWithStrategy(true, int(merge.StrategySum), newDataSet(rightValue))
+
+	series := left.Results[0].SeriesList[0]
+	value := series.Points[0].Values[0].(string)
+	require.Equal(t, len(value)+32, series.Points[0].Size)
+	require.Equal(t, series.Points.Size(), series.PointSize)
+}
+
+func TestPrometheusHistogramOperationsMergeSpanBuckets(t *testing.T) {
+	left := `{"count":"10","sum":"20","schema":0,"zero_threshold":0.1,` +
+		`"zero_count":"1","positive_spans":[{"offset":0,"length":2}],` +
+		`"positive_deltas":[2,3]}`
+	right := `{"count":"8","sum":"14","schema":0,"zero_threshold":0.1,` +
+		`"zero_count":"2","positive_spans":[{"offset":1,"length":1}],` +
+		`"positive_deltas":[4]}`
+
+	value, handled := prometheusValueOperations.MergeValues(left, right, merge.StrategySum)
+	require.True(t, handled)
+	histogram, err := parseNormalizedHistogram(value)
+	require.NoError(t, err)
+	require.Equal(t, 18.0, histogram.count)
+	require.Equal(t, 34.0, histogram.sum)
+	require.Len(t, histogram.buckets, 3)
+	require.Equal(t, 3.0, histogram.buckets[0].count)
+	require.Equal(t, 2.0, histogram.buckets[1].count)
+	require.Equal(t, 9.0, histogram.buckets[2].count)
+}
+
+func TestHistogramBucketBoundPreservesInfinityBucket(t *testing.T) {
+	for _, test := range []struct {
+		schema        int
+		lastFinite    int32
+		firstInfinite int32
+	}{
+		{schema: 0, lastFinite: 1024, firstInfinite: 1025},
+		{schema: -1, lastFinite: 512, firstInfinite: 513},
+	} {
+		finite, err := histogramBucketBound(test.lastFinite, test.schema, nil)
+		require.NoError(t, err)
+		require.Equal(t, math.MaxFloat64, finite)
+		infinite, err := histogramBucketBound(test.firstInfinite, test.schema, nil)
+		require.NoError(t, err)
+		require.True(t, math.IsInf(infinite, 1))
+	}
+}
+
+func TestPrometheusHistogramOperationsDivide(t *testing.T) {
+	value := `{"count":"18","sum":"34","buckets":[[0,"0","2","18"]]}`
+
+	divided, handled := prometheusValueOperations.DivideValue(value, 2)
+	require.True(t, handled)
+	histogram, err := parseNormalizedHistogram(divided)
+	require.NoError(t, err)
+	require.Equal(t, 9.0, histogram.count)
+	require.Equal(t, 17.0, histogram.sum)
+	require.Equal(t, 9.0, histogram.buckets[0].count)
+}
+
+func TestPrometheusHistogramOperationsMergeOrderIndependent(t *testing.T) {
+	histograms := []string{
+		`{"count":"3","sum":"4","buckets":[` +
+			`[0,"0","1","1"],[0,"1","2","2"]]}`,
+		`{"count":"3","sum":"5","buckets":[[0,"0","2","3"]]}`,
+		`{"count":"4","sum":"12","buckets":[[0,"2","4","4"]]}`,
+	}
+	for _, order := range [][3]int{
+		{0, 1, 2},
+		{0, 2, 1},
+		{1, 0, 2},
+		{1, 2, 0},
+		{2, 0, 1},
+		{2, 1, 0},
+	} {
+		value := any(histograms[order[0]])
+		for _, index := range order[1:] {
+			var handled bool
+			value, handled = prometheusValueOperations.MergeValues(
+				value, histograms[index], merge.StrategySum,
+			)
+			require.True(t, handled, "order %v", order)
+		}
+		histogram, err := parseNormalizedHistogram(value)
+		require.NoError(t, err)
+		require.Equal(t, 10.0, histogram.count, "order %v", order)
+		require.Equal(t, 21.0, histogram.sum, "order %v", order)
+		require.Len(t, histogram.buckets, 2, "order %v", order)
+		require.Equal(t, 6.0, histogram.buckets[0].count, "order %v", order)
+		require.Equal(t, 4.0, histogram.buckets[1].count, "order %v", order)
+	}
+}
+
+func TestPrometheusHistogramOperationsDropMixedSamples(t *testing.T) {
+	header := dataset.SeriesHeader{
+		Name:           "requests",
+		Tags:           dataset.Tags{"service": "api"},
+		QueryStatement: "sum by (service) (requests)",
+	}
+	floatHeader := header.Clone()
+	floatHeader.ValueFieldsList = timeseries.FieldDefinitions{{Name: "value"}}
+	histogramHeader := header.Clone()
+	histogramHeader.ValueFieldsList = timeseries.FieldDefinitions{{Name: fieldNameHistogram}}
+	ds := &dataset.DataSet{
+		ValueOperations: prometheusValueOperations,
+		Results: dataset.Results{{SeriesList: dataset.SeriesList{
+			{
+				Header: floatHeader,
+				Points: dataset.Points{
+					{Epoch: epoch.Epoch(1), Values: []any{"1"}},
+					{Epoch: epoch.Epoch(2), Values: []any{"2"}},
+				},
+			},
+			{
+				Header: histogramHeader,
+				Points: dataset.Points{
+					{Epoch: epoch.Epoch(2), Values: []any{`{"count":"1","sum":"2"}`}},
+					{Epoch: epoch.Epoch(3), Values: []any{`{"count":"1","sum":"3"}`}},
+				},
+			},
+		}}},
+	}
+
+	ds.FinalizeValueMerge(int(merge.StrategySum))
+
+	require.Len(t, ds.Results[0].SeriesList, 2)
+	require.Equal(t, epoch.Epoch(1), ds.Results[0].SeriesList[0].Points[0].Epoch)
+	require.Equal(t, epoch.Epoch(3), ds.Results[0].SeriesList[1].Points[0].Epoch)
+	require.Equal(t, []string{mixedFloatHistogramWarning}, ds.Warnings)
+
+	ds.FinalizeValueMerge(int(merge.StrategySum))
+	require.Equal(t, []string{mixedFloatHistogramWarning}, ds.Warnings)
+}

--- a/pkg/backends/prometheus/model/timeseries.go
+++ b/pkg/backends/prometheus/model/timeseries.go
@@ -117,12 +117,13 @@ func UnmarshalTimeseriesReader(reader io.Reader, trq *timeseries.TimeRangeQuery)
 		wfd.Envelope = &Envelope{}
 	}
 	ds := &dataset.DataSet{
-		Status:         wfd.Status,
-		Error:          wfd.Error,
-		ErrorType:      wfd.ErrorType,
-		Warnings:       wfd.Warnings,
-		TimeRangeQuery: trq,
-		ExtentList:     timeseries.ExtentList{trq.Extent},
+		Status:          wfd.Status,
+		Error:           wfd.Error,
+		ErrorType:       wfd.ErrorType,
+		Warnings:        wfd.Warnings,
+		TimeRangeQuery:  trq,
+		ExtentList:      timeseries.ExtentList{trq.Extent},
+		ValueOperations: prometheusValueOperations,
 	}
 
 	switch wfd.Data.ResultType {

--- a/pkg/backends/prometheus/promql/expression_shape.go
+++ b/pkg/backends/prometheus/promql/expression_shape.go
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package promql
+
+import "strings"
+
+// NonShardLocalFunction returns a PromQL function whose result may depend on
+// seeing a globally complete vector rather than one fanout member's shard.
+func NonShardLocalFunction(query string) (string, bool) {
+	q := strings.ToLower(query)
+	var quote byte
+	var escaped bool
+	for i := 0; i < len(q); {
+		c := q[i]
+		if quote != 0 {
+			i++
+			if escaped {
+				escaped = false
+				continue
+			}
+			if c == '\\' && quote != '`' {
+				escaped = true
+				continue
+			}
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		if c == '"' || c == '\'' || c == '`' {
+			quote = c
+			i++
+			continue
+		}
+		if !isPromQLIdentifierStart(c) {
+			i++
+			continue
+		}
+		start := i
+		for i < len(q) && isPromQLIdentifierPart(q[i]) {
+			i++
+		}
+		name := q[start:i]
+		switch name {
+		case "absent", "absent_over_time", "histogram_fraction", "histogram_quantile",
+			"info", "scalar", "sort", "sort_desc", "sort_by_label", "sort_by_label_desc":
+		default:
+			continue
+		}
+		for i < len(q) && isPromQLSpace(q[i]) {
+			i++
+		}
+		if i < len(q) && q[i] == '(' {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+// ContainsBinaryExpression reports whether query contains a PromQL binary
+// expression outside label matchers, range selectors, and quoted strings.
+// TSM uses this as a conservative boundary for potentially cross-shard joins.
+func ContainsBinaryExpression(query string) bool {
+	q := strings.ToLower(query)
+	var quote byte
+	var escaped bool
+	var braces, brackets int
+	for i := 0; i < len(q); {
+		c := q[i]
+		if quote != 0 {
+			i++
+			if escaped {
+				escaped = false
+				continue
+			}
+			if c == '\\' && quote != '`' {
+				escaped = true
+				continue
+			}
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		if c == '"' || c == '\'' || c == '`' {
+			quote = c
+			i++
+			continue
+		}
+		switch c {
+		case '{':
+			braces++
+			i++
+			continue
+		case '}':
+			if braces > 0 {
+				braces--
+			}
+			i++
+			continue
+		case '[':
+			brackets++
+			i++
+			continue
+		case ']':
+			if brackets > 0 {
+				brackets--
+			}
+			i++
+			continue
+		}
+		if braces > 0 || brackets > 0 {
+			i++
+			continue
+		}
+		if isPromQLDigit(c) || c == '.' && i+1 < len(q) && isPromQLDigit(q[i+1]) {
+			i = skipPromQLNumber(q, i)
+			continue
+		}
+		if isPromQLIdentifierStart(c) {
+			start := i
+			for i < len(q) && isPromQLIdentifierPart(q[i]) {
+				i++
+			}
+			switch q[start:i] {
+			case "and", "or", "unless", "atan2":
+				return true
+			}
+			continue
+		}
+		switch c {
+		case '*', '/', '%', '^', '>', '<', '=':
+			return true
+		case '!':
+			if i+1 < len(q) && q[i+1] == '=' {
+				return true
+			}
+		case '+', '-':
+			if isBinaryAddSub(q, i) {
+				return true
+			}
+		}
+		i++
+	}
+	return false
+}
+
+func isBinaryAddSub(query string, index int) bool {
+	j := index - 1
+	for j >= 0 && isPromQLSpace(query[j]) {
+		j--
+	}
+	if j < 0 {
+		return false
+	}
+	switch query[j] {
+	case '(', ',', '+', '-', '*', '/', '%', '^', '<', '>', '=', '!', ':', '@':
+		return false
+	}
+	end := j + 1
+	for j >= 0 && isPromQLIdentifierPart(query[j]) {
+		j--
+	}
+	return query[j+1:end] != "offset"
+}
+
+func skipPromQLNumber(query string, index int) int {
+	i := index
+	if i+1 < len(query) && query[i] == '0' && query[i+1] == 'x' {
+		i += 2
+		for i < len(query) && (isPromQLHexDigit(query[i]) || query[i] == '.') {
+			i++
+		}
+		if i < len(query) && query[i] == 'p' {
+			i = skipPromQLExponent(query, i+1)
+		}
+		return i
+	}
+	for i < len(query) && (isPromQLDigit(query[i]) || query[i] == '.') {
+		i++
+	}
+	if i < len(query) && query[i] == 'e' {
+		i = skipPromQLExponent(query, i+1)
+	}
+	return i
+}
+
+func skipPromQLExponent(query string, index int) int {
+	i := index
+	if i < len(query) && (query[i] == '+' || query[i] == '-') {
+		i++
+	}
+	for i < len(query) && isPromQLDigit(query[i]) {
+		i++
+	}
+	return i
+}
+
+func isPromQLDigit(c byte) bool {
+	return c >= '0' && c <= '9'
+}
+
+func isPromQLHexDigit(c byte) bool {
+	return isPromQLDigit(c) || c >= 'a' && c <= 'f'
+}
+
+func isPromQLIdentifierStart(c byte) bool {
+	return c == '_' || c == ':' || c >= 'a' && c <= 'z'
+}
+
+func isPromQLIdentifierPart(c byte) bool {
+	return isPromQLIdentifierStart(c) || c >= '0' && c <= '9'
+}
+
+func isPromQLSpace(c byte) bool {
+	switch c {
+	case ' ', '\t', '\n', '\r':
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/backends/prometheus/promql/expression_shape_test.go
+++ b/pkg/backends/prometheus/promql/expression_shape_test.go
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package promql
+
+import "testing"
+
+func TestNonShardLocalFunction(t *testing.T) {
+	tests := []struct {
+		query string
+		want  string
+	}{
+		{"absent(up)", "absent"},
+		{"sum(absent_over_time(up[5m]))", "absent_over_time"},
+		{"histogram_quantile(0.9, buckets)", "histogram_quantile"},
+		{"scalar(up)", "scalar"},
+		{"sort_by_label(up, \"job\")", "sort_by_label"},
+		{"absent_total", ""},
+		{`label_replace(up, "note", "absent(up)", "src", ".*")`, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			got, found := NonShardLocalFunction(tt.query)
+			if got != tt.want || found != (tt.want != "") {
+				t.Fatalf("got (%q, %v) want (%q, %v)", got, found, tt.want, tt.want != "")
+			}
+		})
+	}
+}
+
+func TestContainsBinaryExpression(t *testing.T) {
+	tests := []struct {
+		query string
+		want  bool
+	}{
+		{"up + on (job) group_left down", true},
+		{"up-2", true},
+		{"metric1e-2", true},
+		{"rate(requests[5m]) / rate(errors[5m])", true},
+		{"up and on (job) ready", true},
+		{"up unless down", true},
+		{"up == bool down", true},
+		{"rate(up[5m])", false},
+		{"rate(up[5m] offset -1h)", false},
+		{"clamp_min(up, -1e-3)", false},
+		{"clamp_min(up, -0x1p-3)", false},
+		{"1e-3", false},
+		{`label_replace(up{method=~"GET|POST"}, "dst", "a+b", "src", ".*")`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			if got := ContainsBinaryExpression(tt.query); got != tt.want {
+				t.Fatalf("got %v want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/backends/prometheus/promql/limit_ratio.go
+++ b/pkg/backends/prometheus/promql/limit_ratio.go
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package promql
+
+import (
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/aggregation"
+)
+
+// LimitRatioAggregation describes a literal limit_ratio aggregation that TSM
+// can either leave on each shard or apply after globally merging its input.
+type LimitRatioAggregation struct {
+	Ratio            float64
+	InnerQuery       string
+	AggregationQuery string
+	Grouping         AggregationGrouping
+	SortSet          bool
+	SortDescending   bool
+}
+
+// ParseLimitRatioAggregation parses an outer literal limit_ratio aggregation,
+// optionally wrapped in sort or sort_desc. Scalar parameter expressions are
+// deliberately rejected because TSM cannot safely evaluate them per shard.
+func ParseLimitRatioAggregation(query string) (LimitRatioAggregation, bool) {
+	q := strings.TrimSpace(query)
+	if sortSpec, ok := ParseSortWrapper(q); ok {
+		spec, found := parseLimitRatioAggregation(sortSpec.InnerQuery)
+		if found {
+			spec.SortSet = true
+			spec.SortDescending = sortSpec.Descending
+		}
+		return spec, found
+	}
+	return parseLimitRatioAggregation(q)
+}
+
+func parseLimitRatioAggregation(query string) (LimitRatioAggregation, bool) {
+	const operator = aggregation.LimitRatio
+
+	q := strings.TrimSpace(query)
+	ql := strings.ToLower(q)
+	if !strings.HasPrefix(ql, operator) ||
+		(len(q) > len(operator) && !isPromQLBoundary(q[len(operator)])) {
+		return LimitRatioAggregation{}, false
+	}
+	aggregationQuery := q
+	q = strings.TrimSpace(q[len(operator):])
+
+	var grouping AggregationGrouping
+	var hasGrouping bool
+	if g, rest, ok := parseGrouping(q); ok {
+		grouping = g
+		hasGrouping = true
+		q = rest
+	}
+
+	if q == "" || q[0] != '(' {
+		return LimitRatioAggregation{}, false
+	}
+	closeIdx := findMatchingCloser(q, 0, '(', ')')
+	if closeIdx < 0 {
+		return LimitRatioAggregation{}, false
+	}
+	args := q[1:closeIdx]
+	trailer := strings.TrimSpace(q[closeIdx+1:])
+	if !hasGrouping && trailer != "" {
+		if g, rest, ok := parseGrouping(trailer); ok {
+			grouping = g
+			hasGrouping = true
+			trailer = rest
+		}
+	}
+	if trailer != "" {
+		return LimitRatioAggregation{}, false
+	}
+
+	comma := findTopLevelComma(args)
+	if comma < 0 {
+		return LimitRatioAggregation{}, false
+	}
+	ratio, ok := parseLimitRatio(args[:comma])
+	if !ok {
+		return LimitRatioAggregation{}, false
+	}
+	innerQuery := strings.TrimSpace(args[comma+1:])
+	if innerQuery == "" || findTopLevelComma(innerQuery) >= 0 {
+		return LimitRatioAggregation{}, false
+	}
+	if !hasGrouping {
+		grouping = AggregationGrouping{}
+	}
+
+	return LimitRatioAggregation{
+		Ratio:            ratio,
+		InnerQuery:       innerQuery,
+		AggregationQuery: aggregationQuery,
+		Grouping:         grouping,
+	}, true
+}
+
+func parseLimitRatio(input string) (float64, bool) {
+	ratio, err := strconv.ParseFloat(strings.TrimSpace(input), 64)
+	if err != nil || math.IsNaN(ratio) || math.IsInf(ratio, 0) || ratio < -1 || ratio > 1 {
+		return 0, false
+	}
+	return ratio, true
+}

--- a/pkg/backends/prometheus/promql/limit_ratio_test.go
+++ b/pkg/backends/prometheus/promql/limit_ratio_test.go
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package promql
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestParseLimitRatioAggregation(t *testing.T) {
+	tests := []struct {
+		name        string
+		query       string
+		wantFound   bool
+		wantRatio   float64
+		wantInner   string
+		wantQuery   string
+		wantLabels  []string
+		wantWithout bool
+		wantSortSet bool
+		wantSortDir bool
+	}{
+		{
+			name:      "direct",
+			query:     "limit_ratio(0.25, up)",
+			wantFound: true,
+			wantRatio: 0.25,
+			wantInner: "up",
+			wantQuery: "limit_ratio(0.25, up)",
+		},
+		{
+			name:       "negative exponent and prefix grouping",
+			query:      "limit_ratio by (region, job) (-2.5e-1, rate(requests[5m]))",
+			wantFound:  true,
+			wantRatio:  -0.25,
+			wantInner:  "rate(requests[5m])",
+			wantQuery:  "limit_ratio by (region, job) (-2.5e-1, rate(requests[5m]))",
+			wantLabels: []string{"job", "region"},
+		},
+		{
+			name:        "postfix without grouping",
+			query:       "limit_ratio(.5, up) without (pod, instance)",
+			wantFound:   true,
+			wantRatio:   0.5,
+			wantInner:   "up",
+			wantQuery:   "limit_ratio(.5, up) without (pod, instance)",
+			wantLabels:  []string{"instance", "pod"},
+			wantWithout: true,
+		},
+		{
+			name:        "sort desc wrapper",
+			query:       "sort_desc(limit_ratio(1, sum by (service) (requests)))",
+			wantFound:   true,
+			wantRatio:   1,
+			wantInner:   "sum by (service) (requests)",
+			wantQuery:   "limit_ratio(1, sum by (service) (requests))",
+			wantSortSet: true,
+			wantSortDir: true,
+		},
+		{
+			name:        "nested sort wrappers use outer direction",
+			query:       "sort(sort_desc(limit_ratio(-1, up)))",
+			wantFound:   true,
+			wantRatio:   -1,
+			wantInner:   "up",
+			wantQuery:   "limit_ratio(-1, up)",
+			wantSortSet: true,
+		},
+		{
+			name:      "inner expression contains commas",
+			query:     `limit_ratio(0.5, label_replace(up, "dst", "$1", "src", "(.*)"))`,
+			wantFound: true,
+			wantRatio: 0.5,
+			wantInner: `label_replace(up, "dst", "$1", "src", "(.*)")`,
+			wantQuery: `limit_ratio(0.5, label_replace(up, "dst", "$1", "src", "(.*)"))`,
+		},
+		{name: "lower boundary", query: "limit_ratio(-1, up)", wantFound: true, wantRatio: -1, wantInner: "up", wantQuery: "limit_ratio(-1, up)"},
+		{name: "zero", query: "limit_ratio(0, up)", wantFound: true, wantInner: "up", wantQuery: "limit_ratio(0, up)"},
+		{name: "upper boundary", query: "limit_ratio(1, up)", wantFound: true, wantRatio: 1, wantInner: "up", wantQuery: "limit_ratio(1, up)"},
+		{name: "scalar parameter expression", query: "limit_ratio(scalar(ratio), up)"},
+		{name: "positive out of range", query: "limit_ratio(1.01, up)"},
+		{name: "negative out of range", query: "limit_ratio(-1.01, up)"},
+		{name: "nan", query: "limit_ratio(NaN, up)"},
+		{name: "infinity", query: "limit_ratio(+Inf, up)"},
+		{name: "missing comma", query: "limit_ratio(0.5 up)"},
+		{name: "missing vector", query: "limit_ratio(0.5, )"},
+		{name: "extra argument", query: "limit_ratio(0.5, up, down)"},
+		{name: "unclosed", query: "limit_ratio(0.5, up"},
+		{name: "trailing expression", query: "limit_ratio(0.5, up) + down"},
+		{name: "nested below another operator", query: "sum(limit_ratio(0.5, up))"},
+		{name: "operator prefix collision", query: "limit_ratio_total(0.5, up)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, found := ParseLimitRatioAggregation(tt.query)
+			if found != tt.wantFound {
+				t.Fatalf("found got %v want %v", found, tt.wantFound)
+			}
+			if !found {
+				return
+			}
+			if got.Ratio != tt.wantRatio {
+				t.Errorf("ratio got %v want %v", got.Ratio, tt.wantRatio)
+			}
+			if got.InnerQuery != tt.wantInner {
+				t.Errorf("inner query got %q want %q", got.InnerQuery, tt.wantInner)
+			}
+			if got.AggregationQuery != tt.wantQuery {
+				t.Errorf("aggregation query got %q want %q", got.AggregationQuery, tt.wantQuery)
+			}
+			if !slices.Equal(got.Grouping.Labels, tt.wantLabels) {
+				t.Errorf("labels got %v want %v", got.Grouping.Labels, tt.wantLabels)
+			}
+			if got.Grouping.Without != tt.wantWithout {
+				t.Errorf("without got %v want %v", got.Grouping.Without, tt.wantWithout)
+			}
+			if got.SortSet != tt.wantSortSet {
+				t.Errorf("sort set got %v want %v", got.SortSet, tt.wantSortSet)
+			}
+			if got.SortDescending != tt.wantSortDir {
+				t.Errorf("sort direction got %v want %v", got.SortDescending, tt.wantSortDir)
+			}
+		})
+	}
+}

--- a/pkg/backends/prometheus/promql/outer_aggregator.go
+++ b/pkg/backends/prometheus/promql/outer_aggregator.go
@@ -18,6 +18,7 @@
 package promql
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/aggregation"
@@ -71,6 +72,119 @@ func OuterAggregator(query string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// CompleteOuterAggregator returns the outer aggregation only when it consumes
+// the complete query. This lets callers distinguish sum(up) from shapes such
+// as sum(up) + vector(1), which cannot use the same cross-shard merge plan.
+func CompleteOuterAggregator(query string) (string, bool) {
+	agg, _, found := CompleteOuterAggregation(query)
+	return agg, found
+}
+
+// CompleteOuterAggregation returns the outer aggregation and its vector input
+// only when the aggregation consumes the complete query.
+func CompleteOuterAggregation(query string) (string, string, bool) {
+	q := strings.TrimSpace(query)
+	agg, found := OuterAggregator(q)
+	if !found {
+		return "", "", false
+	}
+	rest := strings.TrimSpace(q[len(agg):])
+
+	var hasGrouping bool
+	if _, next, ok := parseGrouping(rest); ok {
+		hasGrouping = true
+		rest = next
+	}
+	if rest == "" || rest[0] != '(' {
+		return "", "", false
+	}
+	closeIdx := findMatchingCloser(rest, 0, '(', ')')
+	if closeIdx < 0 {
+		return "", "", false
+	}
+	args := strings.TrimSpace(rest[1:closeIdx])
+	trailer := strings.TrimSpace(rest[closeIdx+1:])
+	if !hasGrouping && trailer != "" {
+		if _, next, ok := parseGrouping(trailer); ok {
+			trailer = next
+		}
+	}
+	if trailer != "" || args == "" {
+		return "", "", false
+	}
+
+	input := args
+	switch agg {
+	case aggregation.CountValues, aggregation.TopK, aggregation.BottomK,
+		aggregation.Quantile, aggregation.LimitK, aggregation.LimitRatio:
+		comma := findTopLevelComma(args)
+		if comma < 0 || strings.TrimSpace(args[:comma]) == "" {
+			return "", "", false
+		}
+		input = strings.TrimSpace(args[comma+1:])
+	}
+	if input == "" || findTopLevelComma(input) >= 0 {
+		return "", "", false
+	}
+	return agg, input, true
+}
+
+// ContainsAggregator reports whether query contains an aggregation expression,
+// including one nested below a function or parenthesized expression.
+func ContainsAggregator(query string) bool {
+	q := strings.ToLower(query)
+	var quote byte
+	var escaped bool
+	for i := 0; i < len(q); {
+		c := q[i]
+		if quote != 0 {
+			i++
+			if escaped {
+				escaped = false
+				continue
+			}
+			if c == '\\' && quote != '`' {
+				escaped = true
+				continue
+			}
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		if c == '"' || c == '\'' || c == '`' {
+			quote = c
+			i++
+			continue
+		}
+		if !isPromQLIdentifierStart(c) {
+			i++
+			continue
+		}
+		start := i
+		for i < len(q) && isPromQLIdentifierPart(q[i]) {
+			i++
+		}
+		operator := q[start:i]
+		if !slices.Contains(AllAggregators, operator) {
+			continue
+		}
+		for i < len(q) && isPromQLSpace(q[i]) {
+			i++
+		}
+		if i < len(q) && q[i] == '(' {
+			return true
+		}
+		for _, grouping := range []string{"by", "without"} {
+			if strings.HasPrefix(q[i:], grouping) &&
+				(i+len(grouping) == len(q) || !isPromQLIdentifierPart(q[i+len(grouping)])) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // ReplaceOuterAggregator substitutes the outermost aggregator keyword in

--- a/pkg/backends/prometheus/promql/outer_aggregator_test.go
+++ b/pkg/backends/prometheus/promql/outer_aggregator_test.go
@@ -75,6 +75,73 @@ func TestOuterAggregator(t *testing.T) {
 	}
 }
 
+func TestCompleteOuterAggregator(t *testing.T) {
+	tests := []struct {
+		query string
+		want  aggregation.Operator
+	}{
+		{"sum(up)", aggregation.Sum},
+		{"sum by (service) (rate(requests[5m]))", aggregation.Sum},
+		{"avg(requests) without (instance)", aggregation.Average},
+		{`count_values("code", requests)`, aggregation.CountValues},
+		{"sum(up) + vector(1)", ""},
+		{"sum by service (up)", ""},
+		{"sum()", ""},
+		{"rate(sum(up)[5m:])", ""},
+		{"up", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			got, found := CompleteOuterAggregator(tt.query)
+			if got != tt.want || found != (tt.want != "") {
+				t.Fatalf("got (%q, %v) want (%q, %v)", got, found, tt.want, tt.want != "")
+			}
+		})
+	}
+}
+
+func TestCompleteOuterAggregationInput(t *testing.T) {
+	tests := []struct {
+		query string
+		agg   aggregation.Operator
+		input string
+	}{
+		{"sum by (job) (rate(up[5m]))", aggregation.Sum, "rate(up[5m])"},
+		{`count_values("code", requests)`, aggregation.CountValues, "requests"},
+		{"topk(5, up + down)", aggregation.TopK, "up + down"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			gotAgg, gotInput, found := CompleteOuterAggregation(tt.query)
+			if !found || gotAgg != tt.agg || gotInput != tt.input {
+				t.Fatalf("got (%q, %q, %v) want (%q, %q, true)",
+					gotAgg, gotInput, found, tt.agg, tt.input)
+			}
+		})
+	}
+}
+
+func TestContainsAggregator(t *testing.T) {
+	tests := []struct {
+		query string
+		want  bool
+	}{
+		{"sum(up)", true},
+		{"rate(sum by (service) (requests)[5m:])", true},
+		{"(topk(2, up))", true},
+		{"rate(up[5m])", false},
+		{`label_replace(up, "note", "sum(up)", "src", ".*")`, false},
+		{`sum_total{operation="sum"}`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			if got := ContainsAggregator(tt.query); got != tt.want {
+				t.Fatalf("got %v want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestReplaceOuterAggregator(t *testing.T) {
 	tests := []struct {
 		query       string

--- a/pkg/backends/prometheus/tsm_limit_ratio_finalize.go
+++ b/pkg/backends/prometheus/tsm_limit_ratio_finalize.go
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus
+
+import (
+	"math"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/trickstercache/trickster/v2/pkg/backends/prometheus/promql"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
+)
+
+func finalizeLimitRatio(ds *dataset.DataSet, spec promql.LimitRatioAggregation) {
+	isRangeQuery := ds.Step() > 0
+
+	ds.UpdateLock.Lock()
+	defer ds.UpdateLock.Unlock()
+
+	if isRangeQuery && spec.SortSet {
+		appendWarningOnce(ds, sortInRangeQueryWarning)
+	}
+	for _, result := range ds.Results {
+		if result == nil || len(result.SeriesList) == 0 {
+			continue
+		}
+		selected := result.SeriesList[:0]
+		// Prometheus hashes each complete label set; by/without only partitions
+		// candidates and does not change this per-series threshold decision.
+		for _, series := range result.SeriesList {
+			if series == nil || len(series.Points) == 0 ||
+				!limitRatioSelectHash(spec.Ratio, prometheusLabelsHash(series.Header.Tags)) {
+				continue
+			}
+			selected = append(selected, series)
+		}
+		result.SeriesList = selected
+		if spec.SortSet {
+			result.SeriesList = filterHistogramSeries(result.SeriesList)
+			if !isRangeQuery {
+				sortInstantSeries(result.SeriesList, spec.SortDescending)
+			}
+		}
+	}
+}
+
+// The default Prometheus stringlabels implementation hashes sorted,
+// length-prefixed label names and values as one xxhash byte stream.
+func prometheusLabelsHash(tags dataset.Tags) uint64 {
+	keys := tags.Keys()
+	size := 0
+	for _, key := range keys {
+		size += prometheusEncodedStringSize(len(key)) +
+			prometheusEncodedStringSize(len(tags[key]))
+	}
+	buf := make([]byte, 0, size)
+	for _, key := range keys {
+		buf = appendPrometheusStringSize(buf, len(key))
+		buf = append(buf, key...)
+		buf = appendPrometheusStringSize(buf, len(tags[key]))
+		buf = append(buf, tags[key]...)
+	}
+	return xxhash.Sum64(buf)
+}
+
+func prometheusEncodedStringSize(size int) int {
+	if size < 255 {
+		return size + 1
+	}
+	return size + 4
+}
+
+func appendPrometheusStringSize(buf []byte, size int) []byte {
+	if size < 255 {
+		return append(buf, byte(size)) // #nosec G115 -- size is bounded above by 254
+	}
+	return append(buf, 255,
+		byte(size), byte(size>>8), byte(size>>16), // #nosec G115 -- each encoded byte is intentional
+	)
+}
+
+func limitRatioSelectHash(ratio float64, hash uint64) bool {
+	offset := float64(hash) / float64(math.MaxUint64)
+	if ratio >= 0 {
+		return offset < ratio
+	}
+	return offset >= 1+ratio
+}

--- a/pkg/backends/prometheus/tsm_limit_ratio_finalize_test.go
+++ b/pkg/backends/prometheus/tsm_limit_ratio_finalize_test.go
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus
+
+import (
+	"math"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
+)
+
+func TestPrometheusLabelsHashCompatibility(t *testing.T) {
+	// Reference values come from labels.FromMap(...).Hash() in Prometheus
+	// commit 2cf323988931bd586a2ab25160e46bcace9398ae.
+	tests := []struct {
+		name string
+		tags dataset.Tags
+		want uint64
+	}{
+		{"empty", dataset.Tags{}, 17241709254077376921},
+		{"up a", dataset.Tags{"__name__": "up", "instance": "a"}, 10139292233165076983},
+		{"up b", dataset.Tags{"__name__": "up", "instance": "b"}, 1606270689090314871},
+		{"service c", dataset.Tags{"service": "c"}, 9299309263614530225},
+		{"service d", dataset.Tags{"service": "d"}, 375245342754498227},
+		{"two labels sort by name", dataset.Tags{"foo": "bar", "baz": "qux"}, 9578719315788400658},
+		{"254 byte value", dataset.Tags{"long": strings.Repeat("x", 254)}, 447315130497038107},
+		{"255 byte value", dataset.Tags{"long": strings.Repeat("x", 255)}, 9328540357359131664},
+		{"256 byte value", dataset.Tags{"long": strings.Repeat("x", 256)}, 837123608085968220},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := prometheusLabelsHash(tt.tags); got != tt.want {
+				t.Fatalf("hash got %d want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLimitRatioSelectHashBoundaries(t *testing.T) {
+	for _, hash := range []uint64{0, 1 << 62, 1 << 63, 3 << 62, math.MaxUint64} {
+		if limitRatioSelectHash(0, hash) {
+			t.Errorf("ratio 0 selected hash %d", hash)
+		}
+		if !limitRatioSelectHash(-1, hash) {
+			t.Errorf("ratio -1 omitted hash %d", hash)
+		}
+	}
+	if !limitRatioSelectHash(1, 0) {
+		t.Fatal("ratio 1 omitted the zero offset")
+	}
+	if limitRatioSelectHash(1, math.MaxUint64) {
+		t.Fatal("ratio 1 selected the documented max-hash boundary")
+	}
+
+	for _, hash := range []uint64{0, 1 << 62, 1 << 63, 3 << 62, math.MaxUint64} {
+		positive := limitRatioSelectHash(0.25, hash)
+		negativeComplement := limitRatioSelectHash(-0.75, hash)
+		if positive == negativeComplement {
+			t.Errorf("hash %d is not in exactly one complementary set", hash)
+		}
+	}
+}
+
+func TestFinalizeTSMMergeLimitRatio(t *testing.T) {
+	t.Run("positive and negative ratios are complements", func(t *testing.T) {
+		positive := rankDataSet(
+			rankSeries("a", "1", 100),
+			rankSeries("b", "2", 100),
+		)
+		negative := rankDataSet(
+			rankSeries("a", "1", 100),
+			rankSeries("b", "2", 100),
+		)
+
+		client := &Client{}
+		client.FinalizeTSMMerge("limit_ratio(0.5, up)", positive)
+		client.FinalizeTSMMerge("limit_ratio(-0.5, up)", negative)
+
+		if got, want := seriesNames(positive), []string{"b"}; !slices.Equal(got, want) {
+			t.Fatalf("positive series got %v want %v", got, want)
+		}
+		if got, want := seriesNames(negative), []string{"a"}; !slices.Equal(got, want) {
+			t.Fatalf("negative series got %v want %v", got, want)
+		}
+	})
+
+	t.Run("grouping forms retain complete-label selection", func(t *testing.T) {
+		for _, query := range []string{
+			"limit_ratio by (job) (0.5, up)",
+			"limit_ratio(0.5, up) without (pod)",
+		} {
+			ds := rankDataSet(
+				rankSeries("a", "1", 100),
+				rankSeries("b", "2", 100),
+			)
+			(&Client{}).FinalizeTSMMerge(query, ds)
+			if got, want := seriesNames(ds), []string{"b"}; !slices.Equal(got, want) {
+				t.Fatalf("%s series got %v want %v", query, got, want)
+			}
+		}
+	})
+
+	t.Run("range selection keeps every sparse point", func(t *testing.T) {
+		ds := rankDataSet(
+			rankSeries("a", "1", 100, "3", 300),
+			rankSeries("b", "2", 100, "4", 400),
+		)
+		ds.TimeRangeQuery = &timeseries.TimeRangeQuery{Step: time.Minute}
+
+		(&Client{}).FinalizeTSMMerge("limit_ratio(0.5, up)", ds)
+
+		if got, want := seriesNames(ds), []string{"b"}; !slices.Equal(got, want) {
+			t.Fatalf("series got %v want %v", got, want)
+		}
+		if got, want := seriesPointValues(ds)["b"], []string{"2", "4"}; !slices.Equal(got, want) {
+			t.Fatalf("points got %v want %v", got, want)
+		}
+	})
+
+	t.Run("unwrapped ratio preserves floats and native histograms", func(t *testing.T) {
+		tags := dataset.Tags{"__name__": "up", "instance": "b"}
+		floatSeries := rankSeriesWithTags("float", tags.Clone(), "2", 100)
+		histogram := rankSeriesWithTags("histogram", tags.Clone(),
+			`{"count":"2","sum":"2.5"}`, 100)
+		histogram.Header.ValueFieldsList = timeseries.FieldDefinitions{{Name: histogramFieldName}}
+		ds := rankDataSet(floatSeries, histogram)
+
+		(&Client{}).FinalizeTSMMerge("limit_ratio(0.5, up)", ds)
+
+		if got, want := seriesNames(ds), []string{"float", "histogram"}; !slices.Equal(got, want) {
+			t.Fatalf("series got %v want %v", got, want)
+		}
+	})
+
+	t.Run("edge ratios", func(t *testing.T) {
+		for _, tt := range []struct {
+			query string
+			want  []string
+		}{
+			{"limit_ratio(0, up)", nil},
+			{"limit_ratio(-1, up)", []string{"a", "b"}},
+			{"limit_ratio(1, up)", []string{"a", "b"}},
+		} {
+			ds := rankDataSet(rankSeries("a", "1", 100), rankSeries("b", "2", 100))
+			(&Client{}).FinalizeTSMMerge(tt.query, ds)
+			if got := seriesNames(ds); !slices.Equal(got, tt.want) {
+				t.Fatalf("%s series got %v want %v", tt.query, got, tt.want)
+			}
+		}
+	})
+
+	t.Run("sort wrapper orders floats and omits histograms", func(t *testing.T) {
+		histogram := rankSeries("histogram", `{"count":"2","sum":"2.5"}`, 100)
+		histogram.Header.ValueFieldsList = timeseries.FieldDefinitions{{Name: histogramFieldName}}
+		ds := rankDataSet(
+			rankSeries("a", "3", 100),
+			histogram,
+			rankSeries("b", "1", 100),
+		)
+
+		(&Client{}).FinalizeTSMMerge("sort(limit_ratio(-1, up))", ds)
+
+		if got, want := seriesNames(ds), []string{"b", "a"}; !slices.Equal(got, want) {
+			t.Fatalf("series got %v want %v", got, want)
+		}
+	})
+
+	t.Run("range sort wrapper preserves order and warns once", func(t *testing.T) {
+		histogram := rankSeries("histogram", `{"count":"2","sum":"2.5"}`, 100)
+		histogram.Header.ValueFieldsList = timeseries.FieldDefinitions{{Name: histogramFieldName}}
+		ds := rankDataSet(
+			rankSeries("a", "3", 100),
+			histogram,
+			rankSeries("b", "1", 100),
+		)
+		ds.TimeRangeQuery = &timeseries.TimeRangeQuery{Step: time.Minute}
+
+		client := &Client{}
+		client.FinalizeTSMMerge("sort_desc(limit_ratio(-1, up))", ds)
+		client.FinalizeTSMMerge("sort_desc(limit_ratio(-1, up))", ds)
+
+		if got, want := seriesNames(ds), []string{"a", "b"}; !slices.Equal(got, want) {
+			t.Fatalf("series got %v want %v", got, want)
+		}
+		if got, want := ds.Warnings, []string{sortInRangeQueryWarning}; !slices.Equal(got, want) {
+			t.Fatalf("warnings got %v want %v", got, want)
+		}
+	})
+}
+
+func TestLimitRatioSelectionDistributesAcrossUnequalShards(t *testing.T) {
+	combined := rankDataSet(
+		rankSeries("a", "1", 100),
+		rankSeries("b", "2", 100),
+		rankSeries("c", "3", 100),
+		rankSeries("d", "4", 100),
+	)
+	shardA := rankDataSet(rankSeries("a", "1", 100))
+	shardB := rankDataSet(
+		rankSeries("b", "2", 100),
+		rankSeries("c", "3", 100),
+		rankSeries("d", "4", 100),
+	)
+
+	client := &Client{}
+	for _, ds := range []*dataset.DataSet{combined, shardA, shardB} {
+		client.FinalizeTSMMerge("limit_ratio(0.5, up)", ds)
+	}
+	want := seriesNames(combined)
+	got := append(seriesNames(shardB), seriesNames(shardA)...)
+	slices.Sort(want)
+	slices.Sort(got)
+	if !slices.Equal(got, want) {
+		t.Fatalf("shard union got %v want global selection %v", got, want)
+	}
+}

--- a/pkg/backends/prometheus/tsm_provider.go
+++ b/pkg/backends/prometheus/tsm_provider.go
@@ -42,6 +42,9 @@ func (c *Client) PlanTSMMerge(r *http.Request, query string) (*merge.TSMMergePla
 	if r == nil {
 		return nil, errors.New("cannot plan a nil request")
 	}
+	if spec, found := promql.ParseLimitRatioAggregation(query); found {
+		return c.planLimitRatio(r, query, spec)
+	}
 	fanoutQuery, rewritten := tsmInnerQuery(query)
 	finalizer := tsmFinalizer(query)
 
@@ -59,7 +62,7 @@ func (c *Client) PlanTSMMerge(r *http.Request, query string) (*merge.TSMMergePla
 		case aggregation.Sum, aggregation.Count, aggregation.CountValues:
 			strategy = int(merge.StrategySum)
 		case aggregation.Average:
-			return weightedAveragePlan(r, query, fanoutQuery, finalizer)
+			return weightedAveragePlan(r, query, fanoutQuery, finalizer, false)
 		case aggregation.Minimum:
 			strategy = int(merge.StrategyMin)
 		case aggregation.Maximum:
@@ -101,8 +104,112 @@ func (c *Client) PlanTSMMerge(r *http.Request, query string) (*merge.TSMMergePla
 	return plan, nil
 }
 
+func (c *Client) planLimitRatio(r *http.Request, query string,
+	spec promql.LimitRatioAggregation,
+) (*merge.TSMMergePlan, error) {
+	fanoutQuery := spec.AggregationQuery
+	rewritten := spec.SortSet
+	strategy := int(merge.StrategyDedup)
+	unsupportedWarning := ""
+	finalizer := merge.TSMFinalizerSpec{}
+	if spec.SortSet {
+		finalizer = merge.TSMFinalizerSpec{Enabled: true, Query: query}
+	}
+
+	if agg, aggregationInput, found := promql.CompleteOuterAggregation(spec.InnerQuery); found {
+		candidateStrategy := int(merge.StrategyDedup)
+		requiresHistogramAwareReduction := false
+		switch agg {
+		case aggregation.Count, aggregation.CountValues:
+			candidateStrategy = int(merge.StrategySum)
+		case aggregation.Sum, aggregation.Average:
+			requiresHistogramAwareReduction = true
+		case aggregation.Minimum:
+			candidateStrategy = int(merge.StrategyMin)
+		case aggregation.Maximum:
+			candidateStrategy = int(merge.StrategyMax)
+		case aggregation.Group:
+			// Deduplication unions the per-shard groups, whose values are all one.
+		default:
+			unsupportedWarning = `trickster: limit_ratio inner aggregator "` + agg +
+				`" cannot be correctly merged across fanout backends; results may be inaccurate`
+		}
+		if unsupportedWarning == "" {
+			globalFunction, hasGlobalFunction := promql.NonShardLocalFunction(aggregationInput)
+			switch {
+			case promql.ContainsAggregator(aggregationInput):
+				unsupportedWarning = "trickster: limit_ratio contains a nested aggregation that " +
+					"cannot be correctly merged across fanout backends; results may be inaccurate"
+			case promql.ContainsBinaryExpression(aggregationInput):
+				unsupportedWarning = "trickster: limit_ratio contains a binary expression that " +
+					"may require cross-shard matching; results may be inaccurate"
+			case hasGlobalFunction:
+				unsupportedWarning = `trickster: limit_ratio contains function "` + globalFunction +
+					`" that may require globally complete input; results may be inaccurate`
+			case requiresHistogramAwareReduction:
+				unsupportedWarning = `trickster: limit_ratio inner aggregator "` + agg +
+					`" cannot be correctly merged across fanout backends until ` +
+					`native-histogram-aware reduction is supported; ` +
+					`results may be inaccurate`
+			default:
+				strategy = candidateStrategy
+				fanoutQuery = spec.InnerQuery
+				rewritten = true
+				finalizer = merge.TSMFinalizerSpec{Enabled: true, Query: query}
+			}
+		}
+	} else if promql.ContainsAggregator(spec.InnerQuery) {
+		unsupportedWarning = "trickster: limit_ratio contains a nested aggregation that " +
+			"cannot be correctly merged across fanout backends; results may be inaccurate"
+	} else if promql.ContainsBinaryExpression(spec.InnerQuery) {
+		unsupportedWarning = "trickster: limit_ratio contains a binary expression that " +
+			"may require cross-shard matching; results may be inaccurate"
+	} else if globalFunction, found := promql.NonShardLocalFunction(spec.InnerQuery); found {
+		unsupportedWarning = `trickster: limit_ratio contains function "` + globalFunction +
+			`" that may require globally complete input; results may be inaccurate`
+	}
+	if spec.SortSet {
+		// Global ordering already requires a finalizer. Always merge the
+		// unsampled inner vectors so finalization applies the ratio exactly once,
+		// including when the inner expression retains an inaccuracy warning.
+		fanoutQuery = spec.InnerQuery
+	}
+
+	variantRequest := r
+	var err error
+	if rewritten {
+		variantRequest, err = rewritePromQueryParam(r, fanoutQuery)
+		if err != nil {
+			return nil, fmt.Errorf("prepare tsm primary variant: %w", err)
+		}
+	}
+
+	plan := &merge.TSMMergePlan{
+		OriginalQuery: query,
+		Variants: []merge.TSMQueryVariant{{
+			Name:              merge.TSMVariantPrimary,
+			Request:           variantRequest,
+			MergeStrategy:     strategy,
+			ResponseAuthority: true,
+		}},
+		Reduction: merge.TSMReductionSpec{
+			Kind:          merge.TSMReductionStandard,
+			InputVariants: merge.TSMReductionPrimaryVariant(),
+		},
+		Finalizer:           finalizer,
+		Completeness:        merge.TSMCompletenessResponseAuthority,
+		UnsupportedWarning:  unsupportedWarning,
+		StripInjectedLabels: true,
+	}
+	plan.AllowSingleMemberBypass = !rewritten && !finalizer.Enabled && unsupportedWarning == ""
+	if err := plan.Validate(); err != nil {
+		return nil, err
+	}
+	return plan, nil
+}
+
 func weightedAveragePlan(r *http.Request, originalQuery, fanoutQuery string,
-	finalizer merge.TSMFinalizerSpec,
+	finalizer merge.TSMFinalizerSpec, stripInjectedLabels bool,
 ) (*merge.TSMMergePlan, error) {
 	sumQuery := promql.ReplaceOuterAggregator(fanoutQuery, aggregation.Average, aggregation.Sum)
 	countQuery := promql.ReplaceOuterAggregator(fanoutQuery, aggregation.Average, aggregation.Count)
@@ -136,8 +243,9 @@ func weightedAveragePlan(r *http.Request, originalQuery, fanoutQuery string,
 			Kind:          merge.TSMReductionWeightedAverage,
 			InputVariants: merge.TSMReductionWeightedAverageVariants(),
 		},
-		Finalizer:    finalizer,
-		Completeness: merge.TSMCompletenessAllVariants,
+		Finalizer:           finalizer,
+		Completeness:        merge.TSMCompletenessAllVariants,
+		StripInjectedLabels: stripInjectedLabels,
 	}
 	if err := plan.Validate(); err != nil {
 		return nil, err

--- a/pkg/backends/prometheus/tsm_provider.go
+++ b/pkg/backends/prometheus/tsm_provider.go
@@ -118,12 +118,12 @@ func (c *Client) planLimitRatio(r *http.Request, query string,
 
 	if agg, aggregationInput, found := promql.CompleteOuterAggregation(spec.InnerQuery); found {
 		candidateStrategy := int(merge.StrategyDedup)
-		requiresHistogramAwareReduction := false
+		weightedAverage := false
 		switch agg {
-		case aggregation.Count, aggregation.CountValues:
+		case aggregation.Sum, aggregation.Count, aggregation.CountValues:
 			candidateStrategy = int(merge.StrategySum)
-		case aggregation.Sum, aggregation.Average:
-			requiresHistogramAwareReduction = true
+		case aggregation.Average:
+			weightedAverage = true
 		case aggregation.Minimum:
 			candidateStrategy = int(merge.StrategyMin)
 		case aggregation.Maximum:
@@ -146,11 +146,9 @@ func (c *Client) planLimitRatio(r *http.Request, query string,
 			case hasGlobalFunction:
 				unsupportedWarning = `trickster: limit_ratio contains function "` + globalFunction +
 					`" that may require globally complete input; results may be inaccurate`
-			case requiresHistogramAwareReduction:
-				unsupportedWarning = `trickster: limit_ratio inner aggregator "` + agg +
-					`" cannot be correctly merged across fanout backends until ` +
-					`native-histogram-aware reduction is supported; ` +
-					`results may be inaccurate`
+			case weightedAverage:
+				return weightedAveragePlan(r, query, spec.InnerQuery,
+					merge.TSMFinalizerSpec{Enabled: true, Query: query}, true)
 			default:
 				strategy = candidateStrategy
 				fanoutQuery = spec.InnerQuery

--- a/pkg/backends/prometheus/tsm_provider_test.go
+++ b/pkg/backends/prometheus/tsm_provider_test.go
@@ -73,9 +73,9 @@ func TestPlanTSMMergeStrategies(t *testing.T) {
 		{"limit_ratio(0.5, min(requests))", int(merge.StrategyMin), standard, ""},
 		{"limit_ratio(0.5, max(requests))", int(merge.StrategyMax), standard, ""},
 		{"limit_ratio(0.5, group by (service) (requests))", int(merge.StrategyDedup), standard, ""},
-		{"limit_ratio(0.5, sum by (service) (requests))", int(merge.StrategyDedup), standard, "native-histogram-aware"},
-		{"limit_ratio(0.5, avg by (service) (requests))", int(merge.StrategyDedup), standard, "native-histogram-aware"},
-		{"sort_desc(limit_ratio(0.5, sum(requests)))", int(merge.StrategyDedup), standard, "native-histogram-aware"},
+		{"limit_ratio(0.5, sum by (service) (requests))", int(merge.StrategySum), standard, ""},
+		{"limit_ratio(0.5, avg by (service) (requests))", int(merge.StrategySum), weighted, ""},
+		{"sort_desc(limit_ratio(0.5, sum(requests)))", int(merge.StrategySum), standard, ""},
 		// Sort wrappers preserve the inner aggregation strategy.
 		{"sort(sum(up))", int(merge.StrategySum), standard, ""},
 		{"sort_desc(count by (service) (up))", int(merge.StrategySum), standard, ""},
@@ -306,19 +306,28 @@ func TestPlanTSMMergeLimitRatioContents(t *testing.T) {
 		}
 	})
 
-	t.Run("histogram-capable inner aggregations retain fallback", func(t *testing.T) {
-		for _, operator := range []string{aggregation.Sum, aggregation.Average} {
-			query := "limit_ratio(-0.5, " + operator + " by (service) (requests))"
+	t.Run("histogram-capable inner aggregations use exact plans", func(t *testing.T) {
+		tests := []struct {
+			operator  string
+			reduction merge.TSMReductionKind
+			variants  int
+		}{
+			{aggregation.Sum, merge.TSMReductionStandard, 1},
+			{aggregation.Average, merge.TSMReductionWeightedAverage, 2},
+		}
+		for _, test := range tests {
+			query := "limit_ratio(-0.5, " + test.operator + " by (service) (requests))"
 			r, _ := http.NewRequest(http.MethodGet,
 				"http://example.com/api/v1/query?query="+url.QueryEscape(query), nil)
 			plan := mustTSMMergePlan(t, r, query)
 
-			if plan.Variants[0].Request != r || plan.Variants[0].MergeStrategy != int(merge.StrategyDedup) ||
-				plan.Reduction.Kind != merge.TSMReductionStandard || plan.Finalizer.Enabled {
-				t.Fatalf("%s fallback plan: %#v", operator, plan)
+			if len(plan.Variants) != test.variants ||
+				plan.Variants[0].MergeStrategy != int(merge.StrategySum) ||
+				plan.Reduction.Kind != test.reduction || !plan.Finalizer.Enabled {
+				t.Fatalf("%s exact plan: %#v", test.operator, plan)
 			}
-			if !strings.Contains(plan.UnsupportedWarning, "native-histogram-aware") {
-				t.Fatalf("%s warning: %q", operator, plan.UnsupportedWarning)
+			if plan.UnsupportedWarning != "" {
+				t.Fatalf("%s warning: %q", test.operator, plan.UnsupportedWarning)
 			}
 		}
 	})

--- a/pkg/backends/prometheus/tsm_provider_test.go
+++ b/pkg/backends/prometheus/tsm_provider_test.go
@@ -65,6 +65,17 @@ func TestPlanTSMMergeStrategies(t *testing.T) {
 		{"sort_desc(topk(5, max(up)))", int(merge.StrategyMax), standard, ""},
 		{"bottomk(5, up)", int(merge.StrategyDedup), standard, ""},
 		{"sort_desc(topk(5, up))", int(merge.StrategyDedup), standard, ""},
+		// Literal limit_ratio uses a shard-local fast path or globally merges a
+		// compatible inner aggregation before applying the ratio.
+		{"limit_ratio(0.5, up)", int(merge.StrategyDedup), standard, ""},
+		{"limit_ratio by (job) (-0.5, rate(requests[5m]))", int(merge.StrategyDedup), standard, ""},
+		{"limit_ratio(0.5, count by (service) (requests))", int(merge.StrategySum), standard, ""},
+		{"limit_ratio(0.5, min(requests))", int(merge.StrategyMin), standard, ""},
+		{"limit_ratio(0.5, max(requests))", int(merge.StrategyMax), standard, ""},
+		{"limit_ratio(0.5, group by (service) (requests))", int(merge.StrategyDedup), standard, ""},
+		{"limit_ratio(0.5, sum by (service) (requests))", int(merge.StrategyDedup), standard, "native-histogram-aware"},
+		{"limit_ratio(0.5, avg by (service) (requests))", int(merge.StrategyDedup), standard, "native-histogram-aware"},
+		{"sort_desc(limit_ratio(0.5, sum(requests)))", int(merge.StrategyDedup), standard, "native-histogram-aware"},
 		// Sort wrappers preserve the inner aggregation strategy.
 		{"sort(sum(up))", int(merge.StrategySum), standard, ""},
 		{"sort_desc(count by (service) (up))", int(merge.StrategySum), standard, ""},
@@ -80,7 +91,15 @@ func TestPlanTSMMergeStrategies(t *testing.T) {
 		{"sort_desc(stddev(up))", int(merge.StrategyDedup), standard, aggregation.StdDev},
 		{"topk(k, up)", int(merge.StrategyDedup), standard, aggregation.TopK},
 		{"limitk(5, up)", int(merge.StrategyDedup), standard, aggregation.LimitK},
-		{"limit_ratio(0.5, up)", int(merge.StrategyDedup), standard, aggregation.LimitRatio},
+		{"limit_ratio(0.5, stddev(up))", int(merge.StrategyDedup), standard, aggregation.StdDev},
+		{"sort_desc(limit_ratio(0.5, stddev(up)))", int(merge.StrategyDedup), standard, aggregation.StdDev},
+		{"limit_ratio(0.5, rate(sum(up)[5m:]))", int(merge.StrategyDedup), standard, "nested"},
+		{"limit_ratio(0.5, sum(sum(up)))", int(merge.StrategyDedup), standard, "nested"},
+		{"limit_ratio(0.5, sum(up + down))", int(merge.StrategyDedup), standard, "binary"},
+		{"limit_ratio(0.5, up + on (job) group_left down)", int(merge.StrategyDedup), standard, "binary"},
+		{"limit_ratio(0.5, absent(up))", int(merge.StrategyDedup), standard, "absent"},
+		{"limit_ratio(0.5, sum(absent(up)))", int(merge.StrategyDedup), standard, "absent"},
+		{"limit_ratio(scalar(ratio), up)", int(merge.StrategyDedup), standard, aggregation.LimitRatio},
 		{"group(up)", int(merge.StrategyDedup), standard, ""},
 	}
 
@@ -222,6 +241,184 @@ func TestPlanTSMMergeContents(t *testing.T) {
 			t.Fatal("unsupported fallback allowed a single-member bypass")
 		}
 	})
+}
+
+func TestPlanTSMMergeLimitRatioContents(t *testing.T) {
+	t.Run("shard-local fast path", func(t *testing.T) {
+		const query = "limit_ratio(0.5, rate(requests[5m]))"
+		r, _ := http.NewRequest(http.MethodGet,
+			"http://example.com/api/v1/query?query="+url.QueryEscape(query), nil)
+		plan := mustTSMMergePlan(t, r, query)
+
+		if plan.Variants[0].Request != r {
+			t.Fatal("fast path cloned the original request")
+		}
+		if plan.Finalizer.Enabled {
+			t.Fatalf("fast path enabled finalizer: %#v", plan.Finalizer)
+		}
+		if !plan.StripInjectedLabels {
+			t.Fatal("fast path did not request injected-label stripping")
+		}
+		if !plan.AllowSingleMemberBypass {
+			t.Fatal("fast path did not allow a safe single-member bypass")
+		}
+	})
+
+	t.Run("globally merged inner count", func(t *testing.T) {
+		const (
+			query = "limit_ratio(0.5, count by (service) (requests))"
+			inner = "count by (service) (requests)"
+		)
+		r, _ := http.NewRequest(http.MethodGet,
+			"http://example.com/api/v1/query?query="+url.QueryEscape(query), nil)
+		plan := mustTSMMergePlan(t, r, query)
+		values, _, _ := params.GetRequestValues(plan.Variants[0].Request)
+
+		if got := values.Get(promQueryParam); got != inner {
+			t.Fatalf("fanout query got %q want %q", got, inner)
+		}
+		if plan.Variants[0].MergeStrategy != int(merge.StrategySum) {
+			t.Fatalf("strategy got %d want sum", plan.Variants[0].MergeStrategy)
+		}
+		if !plan.Finalizer.Enabled || plan.Finalizer.Query != query {
+			t.Fatalf("finalizer: %#v", plan.Finalizer)
+		}
+		if !plan.StripInjectedLabels {
+			t.Fatal("global plan did not request injected-label stripping")
+		}
+	})
+
+	t.Run("sort wrapper moves sampling and ordering global", func(t *testing.T) {
+		const (
+			query = "sort_desc(limit_ratio(0.5, up))"
+			inner = "up"
+		)
+		r, _ := http.NewRequest(http.MethodGet,
+			"http://example.com/api/v1/query?query="+url.QueryEscape(query), nil)
+		plan := mustTSMMergePlan(t, r, query)
+		values, _, _ := params.GetRequestValues(plan.Variants[0].Request)
+
+		if got := values.Get(promQueryParam); got != inner {
+			t.Fatalf("fanout query got %q want %q", got, inner)
+		}
+		if !plan.Finalizer.Enabled || plan.Finalizer.Query != query {
+			t.Fatalf("finalizer: %#v", plan.Finalizer)
+		}
+	})
+
+	t.Run("histogram-capable inner aggregations retain fallback", func(t *testing.T) {
+		for _, operator := range []string{aggregation.Sum, aggregation.Average} {
+			query := "limit_ratio(-0.5, " + operator + " by (service) (requests))"
+			r, _ := http.NewRequest(http.MethodGet,
+				"http://example.com/api/v1/query?query="+url.QueryEscape(query), nil)
+			plan := mustTSMMergePlan(t, r, query)
+
+			if plan.Variants[0].Request != r || plan.Variants[0].MergeStrategy != int(merge.StrategyDedup) ||
+				plan.Reduction.Kind != merge.TSMReductionStandard || plan.Finalizer.Enabled {
+				t.Fatalf("%s fallback plan: %#v", operator, plan)
+			}
+			if !strings.Contains(plan.UnsupportedWarning, "native-histogram-aware") {
+				t.Fatalf("%s warning: %q", operator, plan.UnsupportedWarning)
+			}
+		}
+	})
+
+	t.Run("nested unsupported aggregation falls back with warning", func(t *testing.T) {
+		const query = "limit_ratio(0.5, rate(sum(up)[5m:]))"
+		r, _ := http.NewRequest(http.MethodGet,
+			"http://example.com/api/v1/query?query="+url.QueryEscape(query), nil)
+		plan := mustTSMMergePlan(t, r, query)
+
+		if plan.Variants[0].Request != r {
+			t.Fatal("unsupported fallback rewrote the request")
+		}
+		if !strings.Contains(plan.UnsupportedWarning, "nested") {
+			t.Fatalf("warning got %q", plan.UnsupportedWarning)
+		}
+		if plan.Finalizer.Enabled {
+			t.Fatalf("unsupported fallback enabled finalizer: %#v", plan.Finalizer)
+		}
+	})
+
+	t.Run("cross-shard binary expression falls back with warning", func(t *testing.T) {
+		const query = "limit_ratio(0.5, up + on (job) group_left down)"
+		r, _ := http.NewRequest(http.MethodGet,
+			"http://example.com/api/v1/query?query="+url.QueryEscape(query), nil)
+		plan := mustTSMMergePlan(t, r, query)
+
+		if plan.Variants[0].Request != r {
+			t.Fatal("binary fallback rewrote the request")
+		}
+		if !strings.Contains(plan.UnsupportedWarning, "cross-shard") {
+			t.Fatalf("warning got %q", plan.UnsupportedWarning)
+		}
+		if plan.Finalizer.Enabled {
+			t.Fatalf("binary fallback enabled finalizer: %#v", plan.Finalizer)
+		}
+	})
+
+	t.Run("sort wrapper samples unsupported inner expression once", func(t *testing.T) {
+		const (
+			query = "sort_desc(limit_ratio(0.5, stddev(up)))"
+			inner = "stddev(up)"
+		)
+		r, _ := http.NewRequest(http.MethodGet,
+			"http://example.com/api/v1/query?query="+url.QueryEscape(query), nil)
+		plan := mustTSMMergePlan(t, r, query)
+		values, _, _ := params.GetRequestValues(plan.Variants[0].Request)
+
+		if got := values.Get(promQueryParam); got != inner {
+			t.Fatalf("fanout query got %q want %q", got, inner)
+		}
+		if !plan.Finalizer.Enabled || plan.Finalizer.Query != query {
+			t.Fatalf("finalizer: %#v", plan.Finalizer)
+		}
+		if !strings.Contains(plan.UnsupportedWarning, aggregation.StdDev) {
+			t.Fatalf("warning got %q", plan.UnsupportedWarning)
+		}
+	})
+}
+
+func TestPlanTSMMergeLimitRatioPOST(t *testing.T) {
+	const (
+		query    = "limit_ratio(0.5, count by (service) (requests))"
+		wantQ    = "count by (service) (requests)"
+		origBody = "query=limit_ratio%280.5%2C+count+by+%28service%29+%28requests%29%29&start=1000&end=2000&step=15"
+	)
+	r, _ := http.NewRequest(http.MethodPost,
+		"http://example.com/api/v1/query_range",
+		io.NopCloser(bytes.NewBufferString(origBody)))
+	r.Header.Set(headers.NameContentType, headers.ValueXFormURLEncoded)
+	r = request.SetResources(r, &request.Resources{RequestBody: []byte(origBody)})
+
+	plan := mustTSMMergePlan(t, r, query)
+	rewritten := plan.Variants[0].Request
+	values, _, _ := params.GetRequestValues(rewritten)
+	if got := values.Get(promQueryParam); got != wantQ {
+		t.Fatalf("rewritten query got %q want %q", got, wantQ)
+	}
+	body, err := io.ReadAll(rewritten.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	bodyValues, err := url.ParseQuery(string(body))
+	if err != nil {
+		t.Fatalf("parse body: %v", err)
+	}
+	if got := bodyValues.Get(promQueryParam); got != wantQ {
+		t.Fatalf("body query got %q want %q", got, wantQ)
+	}
+	rsc := request.GetResources(rewritten)
+	if rsc == nil {
+		t.Fatal("rewritten request has no resources")
+	}
+	cachedValues, err := url.ParseQuery(string(rsc.RequestBody))
+	if err != nil {
+		t.Fatalf("parse cached body: %v", err)
+	}
+	if got := cachedValues.Get(promQueryParam); got != wantQ {
+		t.Fatalf("cached body query got %q want %q", got, wantQ)
+	}
 }
 
 type failingTSMRequestBody struct{}

--- a/pkg/backends/prometheus/tsm_rank_finalize.go
+++ b/pkg/backends/prometheus/tsm_rank_finalize.go
@@ -122,12 +122,16 @@ func (h *rankCandidateHeap) tags(candidate rankCandidate) string {
 	return tags
 }
 
-// FinalizeTSMMerge applies Prometheus-only rank and sort finalization after TSM
-// fanout has accumulated the rewritten inner-query responses. These operations
-// belong here so they use globally merged values rather than per-backend data.
+// FinalizeTSMMerge applies Prometheus-only aggregation and sort finalization
+// after TSM fanout has accumulated the rewritten inner-query responses. These
+// operations belong here so they use globally merged values.
 func (c *Client) FinalizeTSMMerge(query string, ts timeseries.Timeseries) {
 	ds, ok := ts.(*dataset.DataSet)
 	if !ok || ds == nil {
+		return
+	}
+	if spec, found := promql.ParseLimitRatioAggregation(query); found {
+		finalizeLimitRatio(ds, spec)
 		return
 	}
 	if spec, found := promql.ParseRankAggregation(query); found {

--- a/pkg/timeseries/dataset/dataset.go
+++ b/pkg/timeseries/dataset/dataset.go
@@ -70,6 +70,8 @@ type DataSet struct {
 	SizeCropper func(int, time.Time, timeseries.Extent) `msg:"-"`
 	// RangeCropper is the DataSet's CropToRange function, which defaults to DefaultRangeCropper
 	RangeCropper func(timeseries.Extent) `msg:"-"`
+	// ValueOperations provides wire-format-specific value reduction when present.
+	ValueOperations ValueMergeOperations `msg:"-"`
 }
 
 type DataSets []*DataSet
@@ -96,12 +98,13 @@ func (ds *DataSet) CroppedClone(e timeseries.Extent) timeseries.Timeseries {
 	}
 
 	clone := &DataSet{
-		Error:        ds.Error,
-		Sorter:       ds.Sorter,
-		Merger:       ds.Merger,
-		SizeCropper:  ds.SizeCropper,
-		RangeCropper: ds.RangeCropper,
-		Results:      make([]*Result, len(ds.Results)),
+		Error:           ds.Error,
+		Sorter:          ds.Sorter,
+		Merger:          ds.Merger,
+		SizeCropper:     ds.SizeCropper,
+		RangeCropper:    ds.RangeCropper,
+		ValueOperations: ds.ValueOperations,
+		Results:         make([]*Result, len(ds.Results)),
 	}
 	ds.UpdateLock.Lock()
 	defer ds.UpdateLock.Unlock()
@@ -186,12 +189,13 @@ func (ds *DataSet) Clone() timeseries.Timeseries {
 	ds.UpdateLock.Lock()
 	defer ds.UpdateLock.Unlock()
 	clone := &DataSet{
-		Error:        ds.Error,
-		Sorter:       ds.Sorter,
-		Merger:       ds.Merger,
-		SizeCropper:  ds.SizeCropper,
-		RangeCropper: ds.RangeCropper,
-		Results:      make([]*Result, len(ds.Results)),
+		Error:           ds.Error,
+		Sorter:          ds.Sorter,
+		Merger:          ds.Merger,
+		SizeCropper:     ds.SizeCropper,
+		RangeCropper:    ds.RangeCropper,
+		ValueOperations: ds.ValueOperations,
+		Results:         make([]*Result, len(ds.Results)),
 	}
 	if ds.TimeRangeQuery != nil {
 		clone.TimeRangeQuery = ds.TimeRangeQuery.Clone()
@@ -232,6 +236,7 @@ func (ds *DataSet) Merge(sortPoints bool, collection ...timeseries.Timeseries) {
 func (ds *DataSet) DefaultMerger(sortPoints bool, collection ...timeseries.Timeseries) {
 	ds.UpdateLock.Lock()
 	defer ds.UpdateLock.Unlock()
+	ds.inheritValueOperations(collection)
 	ds.mergeDataSets(collection, MergeOpts{SortPoints: sortPoints}, true)
 }
 
@@ -266,7 +271,47 @@ func (ds *DataSet) MergeWithOpts(opts MergeOpts, collection ...timeseries.Timese
 	}
 	ds.UpdateLock.Lock()
 	defer ds.UpdateLock.Unlock()
+	ds.inheritValueOperations(collection)
+	if opts.ValueOperations == nil {
+		opts.ValueOperations = ds.ValueOperations
+	}
 	ds.mergeDataSets(collection, opts, false)
+}
+
+func (ds *DataSet) inheritValueOperations(collection []timeseries.Timeseries) {
+	if ds.ValueOperations != nil {
+		return
+	}
+	for _, ts := range collection {
+		if candidate, ok := ts.(*DataSet); ok && candidate != nil &&
+			candidate.ValueOperations != nil {
+			ds.ValueOperations = candidate.ValueOperations
+			return
+		}
+	}
+}
+
+// FinalizeValueMerge applies provider-specific cross-series merge semantics
+// after all members for a strategy have been accumulated.
+func (ds *DataSet) FinalizeValueMerge(strategy int) {
+	if ds == nil || ds.ValueOperations == nil {
+		return
+	}
+	ds.UpdateLock.Lock()
+	defer ds.UpdateLock.Unlock()
+	ds.ValueOperations.FinalizeMerge(ds, merge.Strategy(strategy))
+}
+
+// PairingHash returns the provider-aware identity used to align related
+// reduction variants, falling back to the historical series-header hash.
+func (ds *DataSet) PairingHash(header *SeriesHeader, queryStatement string) Hash {
+	if ds != nil && ds.ValueOperations != nil {
+		return ds.ValueOperations.PairingHash(header, queryStatement)
+	}
+	if queryStatement == "" {
+		return header.CalculateHash()
+	}
+	return header.CalculateHashWithQueryStatement(queryStatement)
 }
 
 type resultMergeGroup struct {
@@ -365,10 +410,7 @@ func (ds *DataSet) FinalizeWeightedAvg(countDS *DataSet, pairingQueryStatement s
 		return
 	}
 	pairingHash := func(sh *SeriesHeader) Hash {
-		if pairingQueryStatement == "" {
-			return sh.CalculateHash()
-		}
-		return sh.CalculateHashWithQueryStatement(pairingQueryStatement)
+		return ds.PairingHash(sh, pairingQueryStatement)
 	}
 	// Build lookup: statementID → seriesHash → epoch → count value
 	type epochCounts = map[epoch.Epoch]float64
@@ -424,11 +466,21 @@ func (ds *DataSet) FinalizeWeightedAvg(countDS *DataSet, pairingQueryStatement s
 					dropped++
 					continue
 				}
+				if ds.ValueOperations != nil {
+					if value, handled := ds.ValueOperations.DivideValue(
+						s.Points[i].Values[0], cnt,
+					); handled {
+						setPointValue(&s.Points[i], 0, value)
+						kept = append(kept, s.Points[i])
+						continue
+					}
+				}
 				sum := parseFloat(s.Points[i].Values[0])
 				s.Points[i].Values[0] = strconv.FormatFloat(sum/cnt, 'f', -1, 64)
 				kept = append(kept, s.Points[i])
 			}
 			s.Points = kept
+			s.PointSize = kept.Size()
 			if dropped > 0 {
 				ds.Warnings = append(ds.Warnings,
 					"trickster: weighted-avg series "+s.Header.Name+

--- a/pkg/timeseries/dataset/merge.go
+++ b/pkg/timeseries/dataset/merge.go
@@ -18,6 +18,15 @@ package dataset
 
 import "github.com/trickstercache/trickster/v2/pkg/timeseries/merge"
 
+// ValueMergeOperations lets a wire-format provider extend numeric dataset
+// reduction for provider-specific values such as native histograms.
+type ValueMergeOperations interface {
+	MergeValues(dst, src any, strategy merge.Strategy) (any, bool)
+	DivideValue(value any, divisor float64) (any, bool)
+	PairingHash(header *SeriesHeader, queryStatement string) Hash
+	FinalizeMerge(ds *DataSet, strategy merge.Strategy)
+}
+
 // MergeOpts controls a single merge invocation across the dataset package.
 // All fields have zero-value defaults that preserve historical behavior:
 // SortPoints=false leaves the output unsorted, Strategy=StrategyDedup
@@ -27,7 +36,8 @@ import "github.com/trickstercache/trickster/v2/pkg/timeseries/merge"
 // Strategy is StrategyDedup, adjacent (sorted) points whose epoch
 // difference is <= ToleranceNanos collapse to a single survivor.
 type MergeOpts struct {
-	SortPoints     bool
-	Strategy       merge.Strategy
-	ToleranceNanos int64
+	SortPoints      bool
+	Strategy        merge.Strategy
+	ToleranceNanos  int64
+	ValueOperations ValueMergeOperations
 }

--- a/pkg/timeseries/dataset/point_aggregate.go
+++ b/pkg/timeseries/dataset/point_aggregate.go
@@ -28,7 +28,9 @@ import (
 // for the dedup strategy; non-dedup strategies ignore tolerance since
 // aggregating across a multi-step window would change semantics that callers
 // don't expect (sum-of-cluster, not sum-at-epoch).
-func sortAndAggregateTolerant(p Points, strategy merge.Strategy, toleranceNanos int64) Points {
+func sortAndAggregateTolerant(p Points, strategy merge.Strategy, toleranceNanos int64,
+	valueOperations ValueMergeOperations,
+) Points {
 	if strategy == merge.StrategyDedup {
 		return sortAndDedupeTolerant(p, toleranceNanos)
 	}
@@ -53,13 +55,13 @@ func sortAndAggregateTolerant(p Points, strategy merge.Strategy, toleranceNanos 
 		}
 		if p[k].Epoch == p[i].Epoch {
 			// same epoch: aggregate values
-			aggregateValues(&p[k], &p[i], strategy)
+			aggregateValuesWithOperations(&p[k], &p[i], strategy, valueOperations)
 			count++
 			// for avg, we finalize after the run ends (see below)
 		} else {
 			// new epoch: finalize avg for previous run if needed
 			if strategy == merge.StrategyAvg && count > 1 {
-				finalizeAvg(&p[k], count)
+				finalizeAvgWithOperations(&p[k], count, valueOperations)
 			}
 			count = 1
 			k++
@@ -70,7 +72,7 @@ func sortAndAggregateTolerant(p Points, strategy merge.Strategy, toleranceNanos 
 	}
 	// finalize avg for the last run
 	if strategy == merge.StrategyAvg && count > 1 {
-		finalizeAvg(&p[k], count)
+		finalizeAvgWithOperations(&p[k], count, valueOperations)
 	}
 	return p[:k+1]
 }
@@ -78,6 +80,12 @@ func sortAndAggregateTolerant(p Points, strategy merge.Strategy, toleranceNanos 
 // aggregateValues combines the value from src into dst using the given strategy.
 // Both points are expected to have at least one value in Values[0] as a string-encoded float.
 func aggregateValues(dst, src *Point, strategy merge.Strategy) {
+	aggregateValuesWithOperations(dst, src, strategy, nil)
+}
+
+func aggregateValuesWithOperations(dst, src *Point, strategy merge.Strategy,
+	valueOperations ValueMergeOperations,
+) {
 	if len(dst.Values) == 0 || len(src.Values) == 0 {
 		return
 	}
@@ -86,6 +94,13 @@ func aggregateValues(dst, src *Point, strategy merge.Strategy) {
 	dNaN := math.IsNaN(dv)
 	sNaN := math.IsNaN(sv)
 	if dNaN && sNaN {
+		if valueOperations != nil {
+			if value, handled := valueOperations.MergeValues(
+				dst.Values[0], src.Values[0], strategy,
+			); handled {
+				setPointValue(dst, 0, value)
+			}
+		}
 		return // both non-numeric (e.g. histograms): keep dst as-is
 	}
 	if dNaN {
@@ -111,15 +126,39 @@ func aggregateValues(dst, src *Point, strategy merge.Strategy) {
 
 // finalizeAvg divides the accumulated sum in p by count.
 func finalizeAvg(p *Point, count int) {
+	finalizeAvgWithOperations(p, count, nil)
+}
+
+func finalizeAvgWithOperations(p *Point, count int,
+	valueOperations ValueMergeOperations,
+) {
 	if len(p.Values) == 0 || count <= 1 {
 		return
 	}
 	v := parseFloat(p.Values[0])
 	if math.IsNaN(v) {
+		if valueOperations != nil {
+			if value, handled := valueOperations.DivideValue(
+				p.Values[0], float64(count),
+			); handled {
+				setPointValue(p, 0, value)
+			}
+		}
 		return
 	}
 	v /= float64(count)
 	p.Values[0] = strconv.FormatFloat(v, 'f', -1, 64)
+}
+
+func setPointValue(point *Point, index int, value any) {
+	if point.Size > 0 {
+		oldString, oldOK := point.Values[index].(string)
+		newString, newOK := value.(string)
+		if oldOK && newOK {
+			point.Size += len(newString) - len(oldString)
+		}
+	}
+	point.Values[index] = value
 }
 
 // parseFloat extracts a float64 from a point value. Returns NaN if unparsable.
@@ -184,7 +223,8 @@ func MergePointsWithOpts(p, p2 Points, opts MergeOpts) Points {
 	}
 	finalize := func(out Points) Points {
 		if opts.SortPoints && len(out) > 1 {
-			out = sortAndAggregateTolerant(out, opts.Strategy, opts.ToleranceNanos)
+			out = sortAndAggregateTolerant(out, opts.Strategy, opts.ToleranceNanos,
+				opts.ValueOperations)
 		}
 		return out
 	}

--- a/pkg/timeseries/merge/merge.go
+++ b/pkg/timeseries/merge/merge.go
@@ -90,12 +90,15 @@ type TSMQueryVariant struct {
 
 // TSMMergePlan is the complete execution plan for one TSM request.
 type TSMMergePlan struct {
-	OriginalQuery           string
-	Variants                []TSMQueryVariant
-	Reduction               TSMReductionSpec
-	Finalizer               TSMFinalizerSpec
-	Completeness            TSMCompletenessPolicy
-	UnsupportedWarning      string
+	OriginalQuery      string
+	Variants           []TSMQueryVariant
+	Reduction          TSMReductionSpec
+	Finalizer          TSMFinalizerSpec
+	Completeness       TSMCompletenessPolicy
+	UnsupportedWarning string
+	// StripInjectedLabels removes provider-configured routing labels before
+	// merge and finalization, even when the merge strategy is deduplication.
+	StripInjectedLabels     bool
 	AllowSingleMemberBypass bool
 }
 


### PR DESCRIPTION
## Description

Closes #1069.

Adds literal `limit_ratio` planning and finalization for ALB TSM. Shard-local expressions keep the deterministic per-member fast path, while compatible inner aggregations are merged globally before applying the ratio once. Inner `sum` and `avg` retain an explicit fallback warning until TSM can reduce native histograms without losing shard contributions. The finalizer follows Prometheus label hashing and threshold behavior, strips configured routing labels before selection, preserves histogram/range semantics, and keeps explicit warnings for query shapes that cannot be merged safely.

Coverage includes parser and hash boundaries, positive/negative complements, GET and POST rewrites, supported nested aggregation plans, multi-shard native-histogram fallbacks for `sum` and `avg`, HA duplicates, pool ordering, partial fanout, and capture limits.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Optimization
- [x] Test coverage
- [ ] Documentation
- [ ] Infrastructure

## AI Disclosure

- [ ] This contribution DOES NOT include AI-generated changes
- [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
