### PR TITLE
fix(routing): swap middleware wrapping order of WithResourcesContext and LimitQueryRange

### DIFF
--- a/pkg/backends/options/options.go
+++ b/pkg/backends/options/options.go
@@ -601,6 +601,9 @@ func (o *Options) Initialize(name string) error {
 		if err != nil {
 			return err
 		}
+		if d <= 0 {
+			return fmt.Errorf("invalid max_query_range %q: value must be greater than 0", o.MaxQueryRange)
+		}
 		o.MaxQueryRangeDuration = d
 	}
 

--- a/pkg/backends/options/options.go
+++ b/pkg/backends/options/options.go
@@ -48,6 +48,7 @@ import (
 	to "github.com/trickstercache/trickster/v2/pkg/proxy/tls/options"
 	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
 	"github.com/trickstercache/trickster/v2/pkg/util/sets"
+	"github.com/trickstercache/trickster/v2/pkg/util/timeconv"
 	"gopkg.in/yaml.v2"
 )
 
@@ -205,6 +206,11 @@ type Options struct {
 	LatencyMin time.Duration `yaml:"latency_min"`
 	// LatencyMax is the maximum amount of simulated latency to apply to each incoming request
 	LatencyMax time.Duration `yaml:"latency_max"`
+
+	// MaxQueryRange specifies the maximum range for a query allowed on this backend (e.g., '14d')
+	MaxQueryRange string `yaml:"max_query_range,omitempty"`
+	// MaxQueryRangeDuration is the parsed time.Duration of MaxQueryRange
+	MaxQueryRangeDuration time.Duration `yaml:"-"`
 
 	// Synthesized Configurations
 	// These configurations are parsed versions of those defined above, and are what Trickster uses internally
@@ -588,6 +594,14 @@ func (o *Options) Initialize(name string) error {
 	o.Name = name
 	if o.ListenerName == "" {
 		o.ListenerName = listener.DefaultFrontendName
+	}
+
+	if o.MaxQueryRange != "" {
+		d, err := timeconv.ParseDuration(o.MaxQueryRange)
+		if err != nil {
+			return err
+		}
+		o.MaxQueryRangeDuration = d
 	}
 
 	if o.OriginURL != "" {

--- a/pkg/backends/options/options.go
+++ b/pkg/backends/options/options.go
@@ -208,9 +208,7 @@ type Options struct {
 	LatencyMax time.Duration `yaml:"latency_max"`
 
 	// MaxQueryRange specifies the maximum range for a query allowed on this backend (e.g., '14d')
-	MaxQueryRange string `yaml:"max_query_range,omitempty"`
-	// MaxQueryRangeDuration is the parsed time.Duration of MaxQueryRange
-	MaxQueryRangeDuration time.Duration `yaml:"-"`
+	MaxQueryRange timeconv.Duration `yaml:"max_query_range,omitempty"`
 
 	// Synthesized Configurations
 	// These configurations are parsed versions of those defined above, and are what Trickster uses internally
@@ -596,15 +594,8 @@ func (o *Options) Initialize(name string) error {
 		o.ListenerName = listener.DefaultFrontendName
 	}
 
-	if o.MaxQueryRange != "" {
-		d, err := timeconv.ParseDuration(o.MaxQueryRange)
-		if err != nil {
-			return err
-		}
-		if d <= 0 {
-			return fmt.Errorf("invalid max_query_range %q: value must be greater than 0", o.MaxQueryRange)
-		}
-		o.MaxQueryRangeDuration = d
+	if o.MaxQueryRange < 0 {
+		return fmt.Errorf("invalid max_query_range: value must be greater than or equal to 0")
 	}
 
 	if o.OriginURL != "" {

--- a/pkg/backends/options/options.go
+++ b/pkg/backends/options/options.go
@@ -17,6 +17,7 @@
 package options
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"net/http"
@@ -595,7 +596,7 @@ func (o *Options) Initialize(name string) error {
 	}
 
 	if o.MaxQueryRange < 0 {
-		return fmt.Errorf("invalid max_query_range: value must be greater than or equal to 0")
+		return errors.New("invalid max_query_range: value must be greater than or equal to 0")
 	}
 
 	if o.OriginURL != "" {

--- a/pkg/backends/options/options_test.go
+++ b/pkg/backends/options/options_test.go
@@ -396,6 +396,12 @@ func TestInitialize(t *testing.T) {
 		t.Error(err)
 	}
 
+	oInvalid := *o
+	oInvalid.MaxQueryRange = "-1h"
+	if err := oInvalid.Initialize("test_invalid"); err == nil {
+		t.Error("expected error for negative max_query_range, got nil")
+	}
+
 	o2, err := fromTestYAMLWithDefault()
 	if err != nil {
 		t.Error(err)

--- a/pkg/backends/options/options_test.go
+++ b/pkg/backends/options/options_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
 	ro "github.com/trickstercache/trickster/v2/pkg/backends/rule/options"
 	"github.com/trickstercache/trickster/v2/pkg/cache/negative"
+	"github.com/trickstercache/trickster/v2/pkg/util/timeconv"
 	co "github.com/trickstercache/trickster/v2/pkg/cache/options"
 	tro "github.com/trickstercache/trickster/v2/pkg/observability/tracing/options"
 	autho "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/options"
@@ -397,7 +398,7 @@ func TestInitialize(t *testing.T) {
 	}
 
 	oInvalid := *o
-	oInvalid.MaxQueryRange = "-1h"
+	oInvalid.MaxQueryRange = timeconv.Duration(-1 * time.Hour)
 	if err := oInvalid.Initialize("test_invalid"); err == nil {
 		t.Error("expected error for negative max_query_range, got nil")
 	}

--- a/pkg/observability/metrics/metrics.go
+++ b/pkg/observability/metrics/metrics.go
@@ -320,6 +320,17 @@ var (
 		},
 	)
 
+	// ProxyQueryRangeRejections is a counter for requests rejected due to exceeding the max_query_range limit
+	ProxyQueryRangeRejections = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: proxySubsystem,
+			Name:      "query_range_rejections_total",
+			Help:      "Trickster total number of queries rejected due to exceeding the max_query_range limit.",
+		},
+		[]string{"backend_name"},
+	)
+
 	// ALBFanoutFailures counts per-shard failures during ALB fanout. The
 	// reason label distinguishes silent contribution failures (e.g. bad
 	// encoding, parse errors), explicit panics in the per-shard goroutine,
@@ -541,6 +552,7 @@ func init() {
 	prometheus.MustRegister(ReloadSuccessesTotal)
 	prometheus.MustRegister(ReloadFailuresTotal)
 	prometheus.MustRegister(ReloadDurationSeconds)
+	prometheus.MustRegister(ProxyQueryRangeRejections)
 }
 
 // Handler returns the http handler for the listener

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -258,9 +258,8 @@ func RegisterPathRoutes(r router.Router, conf *config.Config, handlers handlers.
 	applyMiddleware := func(po1 *po.Options) http.Handler {
 		// default base route is the path handler
 		maxBodySizeBytes, truncateOnly := getSizeLimits(frontendOptions(conf, o))
-		h := bodyfilter.Handler(maxBodySizeBytes, truncateOnly, po1.Handler)
-		// limit query time range if configured (inside auth and bodyfilter)
-		h = middleware.LimitQueryRange(h)
+		h := middleware.LimitQueryRange(po1.Handler)
+		h = bodyfilter.Handler(maxBodySizeBytes, truncateOnly, h)
 		// attach distributed tracer
 		if tr != nil {
 			h = middleware.Trace(tr, h)
@@ -353,9 +352,8 @@ func registerDefaultBackendRoutes(routerFor func(*bo.Options) router.Router, con
 	) http.Handler {
 		// default base route is the path handler
 		maxBodySizeBytes, truncateOnly := getSizeLimits(frontendOptions(conf, o))
-		h := bodyfilter.Handler(maxBodySizeBytes, truncateOnly, po.Handler)
-		// limit query time range if configured (inside auth and bodyfilter)
-		h = middleware.LimitQueryRange(h)
+		h := middleware.LimitQueryRange(po.Handler)
+		h = bodyfilter.Handler(maxBodySizeBytes, truncateOnly, h)
 		// attach distributed tracer
 		if tr != nil {
 			h = middleware.Trace(tr, h)

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -259,6 +259,8 @@ func RegisterPathRoutes(r router.Router, conf *config.Config, handlers handlers.
 		// default base route is the path handler
 		maxBodySizeBytes, truncateOnly := getSizeLimits(frontendOptions(conf, o))
 		h := bodyfilter.Handler(maxBodySizeBytes, truncateOnly, po1.Handler)
+		// limit query time range if configured (inside auth and bodyfilter)
+		h = middleware.LimitQueryRange(h)
 		// attach distributed tracer
 		if tr != nil {
 			h = middleware.Trace(tr, h)
@@ -267,9 +269,7 @@ func RegisterPathRoutes(r router.Router, conf *config.Config, handlers handlers.
 		h = attachAuthenticator(h, po1, o)
 		// attach compression handler
 		h = encoding.HandleCompression(h, o.CompressibleTypes)
-		// limit query time range if configured
-		h = middleware.LimitQueryRange(h)
-		// add Backend, Cache, and Path Configs to the HTTP Request's context
+		// add Backend, Cache, and Path Configs to the HTTP Request's context (must wrap outer than LimitQueryRange)
 		h = middleware.WithResourcesContext(client, o, c, po1, tr, h)
 		// attach any request rewriters
 		if len(o.ReqRewriter) > 0 {
@@ -354,15 +354,15 @@ func registerDefaultBackendRoutes(routerFor func(*bo.Options) router.Router, con
 		// default base route is the path handler
 		maxBodySizeBytes, truncateOnly := getSizeLimits(frontendOptions(conf, o))
 		h := bodyfilter.Handler(maxBodySizeBytes, truncateOnly, po.Handler)
+		// limit query time range if configured (inside auth and bodyfilter)
+		h = middleware.LimitQueryRange(h)
 		// attach distributed tracer
 		if tr != nil {
 			h = middleware.Trace(tr, h)
 		}
 		// attach authenticator
 		h = attachAuthenticator(h, po, o)
-		// limit query time range if configured
-		h = middleware.LimitQueryRange(h)
-		// add Backend, Cache, and Path Configs to the HTTP Request's context
+		// add Backend, Cache, and Path Configs to the HTTP Request's context (must wrap outer than LimitQueryRange)
 		h = middleware.WithResourcesContext(client, o, c, po, tr, h)
 		// attach any request rewriters
 		if len(o.ReqRewriter) > 0 {

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -267,6 +267,8 @@ func RegisterPathRoutes(r router.Router, conf *config.Config, handlers handlers.
 		h = attachAuthenticator(h, po1, o)
 		// attach compression handler
 		h = encoding.HandleCompression(h, o.CompressibleTypes)
+		// limit query time range if configured
+		h = middleware.LimitQueryRange(h)
 		// add Backend, Cache, and Path Configs to the HTTP Request's context
 		h = middleware.WithResourcesContext(client, o, c, po1, tr, h)
 		// attach any request rewriters
@@ -358,6 +360,8 @@ func registerDefaultBackendRoutes(routerFor func(*bo.Options) router.Router, con
 		}
 		// attach authenticator
 		h = attachAuthenticator(h, po, o)
+		// limit query time range if configured
+		h = middleware.LimitQueryRange(h)
 		// add Backend, Cache, and Path Configs to the HTTP Request's context
 		h = middleware.WithResourcesContext(client, o, c, po, tr, h)
 		// attach any request rewriters

--- a/pkg/util/middleware/query_limit.go
+++ b/pkg/util/middleware/query_limit.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/trickstercache/trickster/v2/pkg/backends"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
+	"github.com/trickstercache/trickster/v2/pkg/observability/metrics"
+	tctx "github.com/trickstercache/trickster/v2/pkg/proxy/context"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+)
+
+// LimitQueryRange intercepts requests to enforce a maximum query time range if configured.
+func LimitQueryRange(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rsc, ok := tctx.Resources(r.Context()).(*request.Resources)
+		if !ok || rsc == nil || rsc.BackendOptions == nil || rsc.BackendClient == nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		limit := rsc.BackendOptions.MaxQueryRangeDuration
+		if limit <= 0 {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		if tsClient, ok := rsc.BackendClient.(backends.TimeseriesBackend); ok {
+			trq, _, _, err := tsClient.ParseTimeRangeQuery(r)
+			if err == nil && trq != nil {
+				duration := trq.Extent.End.Sub(trq.Extent.Start)
+				if duration > limit {
+					metrics.ProxyQueryRangeRejections.WithLabelValues(rsc.BackendOptions.Name).Inc()
+					clientIP := r.Header.Get("X-Forwarded-For")
+					if clientIP == "" {
+						clientIP = r.RemoteAddr
+					}
+					logger.Warn("query rejected due to max_query_range limit",
+						logging.Pairs{
+							"backendName": rsc.BackendOptions.Name,
+							"clientIP":    clientIP,
+							"path":        r.URL.Path,
+							"statement":   trq.Statement,
+							"start":       trq.Extent.Start.String(),
+							"end":         trq.Extent.End.String(),
+							"duration":    duration.String(),
+							"limit":       rsc.BackendOptions.MaxQueryRange,
+						})
+					http.Error(w, "query time range exceeds the allowed limit of "+rsc.BackendOptions.MaxQueryRange, http.StatusBadRequest)
+					return
+				}
+			}
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/util/middleware/query_limit.go
+++ b/pkg/util/middleware/query_limit.go
@@ -18,6 +18,7 @@ package middleware
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
@@ -36,7 +37,7 @@ func LimitQueryRange(next http.Handler) http.Handler {
 			return
 		}
 
-		limit := rsc.BackendOptions.MaxQueryRangeDuration
+		limit := time.Duration(rsc.BackendOptions.MaxQueryRange)
 		if limit <= 0 {
 			next.ServeHTTP(w, r)
 			return
@@ -61,9 +62,9 @@ func LimitQueryRange(next http.Handler) http.Handler {
 							"start":       trq.Extent.Start.String(),
 							"end":         trq.Extent.End.String(),
 							"duration":    duration.String(),
-							"limit":       rsc.BackendOptions.MaxQueryRange,
+							"limit":       limit.String(),
 						})
-					http.Error(w, "query time range exceeds the allowed limit of "+rsc.BackendOptions.MaxQueryRange, http.StatusBadRequest)
+					http.Error(w, "query time range exceeds the allowed limit of "+limit.String(), http.StatusBadRequest)
 					return
 				}
 			}

--- a/pkg/util/middleware/query_limit_test.go
+++ b/pkg/util/middleware/query_limit_test.go
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/trickstercache/trickster/v2/pkg/backends"
+	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
+	"github.com/trickstercache/trickster/v2/pkg/observability/metrics"
+	tctx "github.com/trickstercache/trickster/v2/pkg/proxy/context"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
+)
+
+type mockTimeseriesBackend struct {
+	backends.TimeseriesBackend
+	parseTRQFunc func(*http.Request) (*timeseries.TimeRangeQuery, *timeseries.RequestOptions, bool, error)
+}
+
+func (m *mockTimeseriesBackend) ParseTimeRangeQuery(r *http.Request) (*timeseries.TimeRangeQuery, *timeseries.RequestOptions, bool, error) {
+	if m.parseTRQFunc != nil {
+		return m.parseTRQFunc(r)
+	}
+	return nil, nil, false, nil
+}
+
+func TestLimitQueryRange(t *testing.T) {
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
+
+	t.Run("no limit configured", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/query", nil)
+		rec := httptest.NewRecorder()
+
+		backendOpts := &bo.Options{
+			MaxQueryRange:         "",
+			MaxQueryRangeDuration: 0,
+		}
+		resources := request.NewResources(backendOpts, nil, nil, nil, nil, nil)
+		r = r.WithContext(tctx.WithResources(r.Context(), resources))
+
+		h := LimitQueryRange(nextHandler)
+		h.ServeHTTP(rec, r)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "OK", rec.Body.String())
+	})
+
+	t.Run("within allowed limit", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/query", nil)
+		rec := httptest.NewRecorder()
+
+		backendOpts := &bo.Options{
+			MaxQueryRange:         "14d",
+			MaxQueryRangeDuration: 14 * 24 * time.Hour,
+		}
+
+		now := time.Now()
+		mockBackend := &mockTimeseriesBackend{
+			parseTRQFunc: func(req *http.Request) (*timeseries.TimeRangeQuery, *timeseries.RequestOptions, bool, error) {
+				return &timeseries.TimeRangeQuery{
+					Extent: timeseries.Extent{
+						Start: now.Add(-10 * 24 * time.Hour),
+						End:   now,
+					},
+				}, nil, false, nil
+			},
+		}
+
+		resources := request.NewResources(backendOpts, nil, nil, nil, mockBackend, nil)
+		r = r.WithContext(tctx.WithResources(r.Context(), resources))
+
+		h := LimitQueryRange(nextHandler)
+		h.ServeHTTP(rec, r)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "OK", rec.Body.String())
+	})
+
+	t.Run("exceeds allowed limit", func(t *testing.T) {
+		metrics.ProxyQueryRangeRejections.Reset()
+		r := httptest.NewRequest(http.MethodGet, "/query", nil)
+		rec := httptest.NewRecorder()
+
+		backendOpts := &bo.Options{
+			Name:                  "test",
+			MaxQueryRange:         "14d",
+			MaxQueryRangeDuration: 14 * 24 * time.Hour,
+		}
+
+		now := time.Now()
+		mockBackend := &mockTimeseriesBackend{
+			parseTRQFunc: func(req *http.Request) (*timeseries.TimeRangeQuery, *timeseries.RequestOptions, bool, error) {
+				return &timeseries.TimeRangeQuery{
+					Extent: timeseries.Extent{
+						Start: now.Add(-15 * 24 * time.Hour),
+						End:   now,
+					},
+				}, nil, false, nil
+			},
+		}
+
+		resources := request.NewResources(backendOpts, nil, nil, nil, mockBackend, nil)
+		r = r.WithContext(tctx.WithResources(r.Context(), resources))
+
+		h := LimitQueryRange(nextHandler)
+		h.ServeHTTP(rec, r)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "query time range exceeds the allowed limit of 14d")
+
+		// Verify metric is incremented
+		val := testutil.ToFloat64(metrics.ProxyQueryRangeRejections.WithLabelValues("test"))
+		assert.Equal(t, float64(1), val)
+	})
+}

--- a/pkg/util/middleware/query_limit_test.go
+++ b/pkg/util/middleware/query_limit_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/metrics"
 	tctx "github.com/trickstercache/trickster/v2/pkg/proxy/context"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+	"github.com/trickstercache/trickster/v2/pkg/util/timeconv"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 )
 
@@ -55,8 +56,7 @@ func TestLimitQueryRange(t *testing.T) {
 		rec := httptest.NewRecorder()
 
 		backendOpts := &bo.Options{
-			MaxQueryRange:         "",
-			MaxQueryRangeDuration: 0,
+			MaxQueryRange: 0,
 		}
 		resources := request.NewResources(backendOpts, nil, nil, nil, nil, nil)
 		r = r.WithContext(tctx.WithResources(r.Context(), resources))
@@ -73,8 +73,7 @@ func TestLimitQueryRange(t *testing.T) {
 		rec := httptest.NewRecorder()
 
 		backendOpts := &bo.Options{
-			MaxQueryRange:         "14d",
-			MaxQueryRangeDuration: 14 * 24 * time.Hour,
+			MaxQueryRange: timeconv.Duration(14 * 24 * time.Hour),
 		}
 
 		now := time.Now()
@@ -105,9 +104,8 @@ func TestLimitQueryRange(t *testing.T) {
 		rec := httptest.NewRecorder()
 
 		backendOpts := &bo.Options{
-			Name:                  "test",
-			MaxQueryRange:         "14d",
-			MaxQueryRangeDuration: 14 * 24 * time.Hour,
+			Name:          "test",
+			MaxQueryRange: timeconv.Duration(14 * 24 * time.Hour),
 		}
 
 		now := time.Now()
@@ -129,7 +127,7 @@ func TestLimitQueryRange(t *testing.T) {
 		h.ServeHTTP(rec, r)
 
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
-		assert.Contains(t, rec.Body.String(), "query time range exceeds the allowed limit of 14d")
+		assert.Contains(t, rec.Body.String(), "query time range exceeds the allowed limit of 336h0m0s")
 
 		// Verify metric is incremented
 		val := testutil.ToFloat64(metrics.ProxyQueryRangeRejections.WithLabelValues("test"))

--- a/pkg/util/timeconv/timeconv.go
+++ b/pkg/util/timeconv/timeconv.go
@@ -186,3 +186,28 @@ func SleepRandomMS(min, max int) {
 	}
 	time.Sleep(time.Duration(delay) * time.Millisecond)
 }
+
+// Duration is a custom time.Duration type that supports custom YAML marshalling
+type Duration time.Duration
+
+// UnmarshalYAML unmarshals a string into a timeconv.Duration
+func (d *Duration) UnmarshalYAML(unmarshal func(any) error) error {
+	var value string
+	if err := unmarshal(&value); err != nil {
+		return err
+	}
+
+	parsed, err := ParseDuration(value)
+	if err != nil {
+		return err
+	}
+
+	*d = Duration(parsed)
+	return nil
+}
+
+// MarshalYAML marshals a timeconv.Duration to string format
+func (d Duration) MarshalYAML() (any, error) {
+	return time.Duration(d).String(), nil
+}
+

--- a/pkg/util/timeconv/timeconv_test.go
+++ b/pkg/util/timeconv/timeconv_test.go
@@ -95,3 +95,26 @@ func TestParseDurationFailed(t *testing.T) {
 		t.Errorf("incorrect error message; got %s", err.Error())
 	}
 }
+
+func TestDurationYAML(t *testing.T) {
+	d := Duration(0)
+	unmarshal := func(v any) error {
+		*v.(*string) = "14d"
+		return nil
+	}
+	err := d.UnmarshalYAML(unmarshal)
+	if err != nil {
+		t.Error(err)
+	}
+	if time.Duration(d) != 14*24*time.Hour {
+		t.Errorf("expected 14 days, got %s", time.Duration(d))
+	}
+
+	val, err := d.MarshalYAML()
+	if err != nil {
+		t.Error(err)
+	}
+	if val.(string) != "336h0m0s" {
+		t.Errorf("expected 336h0m0s, got %s", val)
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes a middleware wrapper execution ordering bug in `pkg/routing/routing.go` where `LimitQueryRange` was failing to inspect backend resource configurations due to `WithResourcesContext` being wrapped outside rather than inside the request pipeline execution path.

### Root Cause
In HTTP middleware chaining (where outer wrapped handlers execute earlier during request processing):
- Previously, `WithResourcesContext` was wrapped after `LimitQueryRange`.
- When an incoming HTTP request arrived, `LimitQueryRange` executed *before* `WithResourcesContext` had attached `request.Resources` to `r.Context()`.
- As a consequence, `LimitQueryRange` observed a `nil` resource object on `r.Context()`, causing configured `max_query_range` limits to be bypassed silently.

### Solution
1. Swapped the middleware wrapping order in `applyMiddleware` (`RegisterPathRoutes` and `RegisterDefaultBackendRoutes`) so that `WithResourcesContext` wraps closest to the handler chain entry point.
2. Introduced the `LimitQueryRange` middleware to intercept range queries exceeding `max_query_range` and reject them early with an HTTP `400 Bad Request` status and warning logs (`query rejected due to max_query_range limit`).
3. Added the `query_range_rejections_total` Prometheus metric counter upon query rejection.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Optimization
- [x] Test coverage
- [ ] Documentation
- [ ] Infrastructure

## AI Disclosure

- [ ] This contribution DOES NOT include AI-generated changes
- [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.