### PR TITLE
feat(alb,proxy): enforce max_query_range limit on ALB TSM scatter/gather entry point

### DIFF
--- a/deploy/kube/configmap.yaml
+++ b/deploy/kube/configmap.yaml
@@ -274,6 +274,11 @@ data:
         # it is false, by default; but if you only have a single backend configured, is_default will be true unless explicitly set to false
         is_default: true
 
+        # max_query_range specifies the maximum allowed query range duration for this backend (e.g. 1h, 1d, 14d).
+        # Setting this value restricts clients from making oversized queries.
+        # default is empty (disabled)
+        # max_query_range: 14d
+
     #     # hosts indicates which FQDNs requested by the client should route to this Origin (in addition to path-based routing)
     #     # if you are using TLS, all FQDNs should be included in the certfiicate common names to avoid insecure warnings to clients
     #     # default setting is empty list. List format is: hosts: [ 1.example.com, 2.example.com ]

--- a/docs/alb.md
+++ b/docs/alb.md
@@ -118,6 +118,10 @@ When a non-dedup strategy is in effect and backends have [injected labels](./pro
 
 Native histogram samples are preserved through the merge rather than being numerically aggregated. When a timestamp has a histogram on one backend and a float sample on another (or histograms on both), the histogram value is kept as-is — numeric aggregators like `sum` only apply across float samples. This prevents mixed-type series from being corrupted into garbage values when backends return a mix of float and histogram samples at the same timestamp.
 
+#### Max Query Range Limitation
+
+Trickster ALB supports enforcing a `max_query_range` duration on ALB backends. When configured (e.g. `max_query_range: 14d`), queries spanning a duration longer than allowed are rejected at the ALB entry point prior to fanout, returning an HTTP `400 Bad Request` status and incrementing the `query_range_rejections_total` metric.
+
 #### Providers Supporting Time Series Merge
 
 Trickster currently supports Time Series Merging for the following TSDB Providers:
@@ -147,9 +151,11 @@ backends:
       labels:
         region: us-east-1
 
-  # prom-alb-01 scatter/gathers to prom01a and prom01b and merges responses for the caller
+  # prom-alb-01 scatter/gathers to prom01a and prom01b and merges responses for the caller.
+  # Enforces a max 14-day time range limit on all incoming merge requests.
   prom-alb-01:
     provider: alb
+    max_query_range: 14d
     alb:
       mechanism: tsm # time series merge
       pool: 

--- a/docs/alb.md
+++ b/docs/alb.md
@@ -120,7 +120,7 @@ Native histogram samples are preserved through the merge rather than being numer
 
 #### Max Query Range Limitation
 
-Trickster ALB supports enforcing a `max_query_range` duration on ALB backends. When configured (e.g. `max_query_range: 14d`), queries spanning a duration longer than allowed are rejected at the ALB entry point prior to fanout, returning an HTTP `400 Bad Request` status and incrementing the `query_range_rejections_total` metric.
+Trickster ALB supports enforcing a `max_query_range` duration on ALB backends. For details on how to configure and use query range limits, see the [Query Range Limits](./query-range-limits.md) documentation.
 
 #### Providers Supporting Time Series Merge
 

--- a/docs/clickhouse.md
+++ b/docs/clickhouse.md
@@ -64,6 +64,8 @@ Trickster exposes a `/ping` endpoint that returns a health check response, match
 
 ### Normalization and "Fast Forwarding"
 
-Trickster will always normalize the calculated time range to fit the step size, so small variations in the time range will still result in actual queries for
-the entire time "bucket".  In addition, Trickster will not cache the results for the portion of the query that is still active -- i.e., within the current bucket
-or within the configured backfill tolerance setting (whichever is greater) 
+Trickster will always normalize the calculated time range to fit the step size, so small variations in the time range will still result in actual queries for the entire time "bucket". In addition, Trickster will not cache the results for the portion of the query that is still active -- i.e., within the current bucket or within the configured backfill tolerance setting (whichever is greater).
+
+## Max Query Range Limitation
+
+Trickster supports enforcing a `max_query_range` limit on ClickHouse backends. For details on how to configure and use query range limits, see the [Query Range Limits](./query-range-limits.md) documentation.

--- a/docs/influxdb.md
+++ b/docs/influxdb.md
@@ -15,3 +15,7 @@ Trickster supports integrations with InfluxDB 1.x and 2.0.
 Trickster supports the Flux Query Language for general/basic usage. Trickster does not support advanced union-style queries (e.g., with multiple `from` clauses). In this rare use case, these responses will currently provide invalid data, however, a subsequent beta will proxy unsupported requests.
 
 Trickster currently does not properly handle schema changes within a response CSV body (e.g., multiple CSVs in the same document with their own #annotation and header rows). We will fully support this use case in a future beta.
+
+## Max Query Range Limitation
+
+Trickster supports enforcing a `max_query_range` limit on InfluxDB backends. For details on how to configure and use query range limits, see the [Query Range Limits](./query-range-limits.md) documentation.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -77,6 +77,10 @@ The following metrics are available for polling with any Trickster configuration
 
 * `trickster_proxy_failed_connections_total` (Counter) - Trickster total number of failed client connections.
 
+* `trickster_proxy_query_range_rejected_total` (Counter) - Trickster total number of queries rejected due to exceeding the `max_query_range` limit.
+  * labels:
+    * `backend` - the name of the configured backend rejecting the query
+
 * `trickster_cache_operation_objects_total` (Counter) - The total number of objects upon which the Trickster cache has operated.
   * labels:
     * `cache_name` - the name of the configured cache performing the operation$

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -73,3 +73,7 @@ backends:
 ### Interaction with ALB Merge Strategy
 
 When using label injection with an ALB configured for [Time Series Merge](./alb.md#time-series-merge), injected labels are automatically stripped from responses before merging. This ensures that series from different backends are aggregated correctly, and the injected labels do not appear in the final response to the caller. See the [ALB Merge Strategy documentation](./alb.md#merge-strategy) for details.
+
+## Max Query Range Limitation
+
+Trickster supports enforcing a `max_query_range` limit on Prometheus backends. For details on how to configure and use query range limits, see the [Query Range Limits](./query-range-limits.md) documentation.

--- a/docs/query-range-limits.md
+++ b/docs/query-range-limits.md
@@ -1,0 +1,64 @@
+# Query Range Limits
+
+Trickster supports enforcing limits on the maximum time range (duration) of incoming queries. This feature protects both the Trickster cache and the downstream origin TSDBs from resource-intensive, oversized queries.
+
+## Overview
+
+When a client sends a query spanning a duration larger than the configured limit, Trickster intercepts the request early in the pipeline. It rejects the query, returns an HTTP `400 Bad Request` status, and increments a metric counter. This helps prevent large queries (e.g., querying 1 year of data at 15s resolution) from causing out-of-memory (OOM) issues or heavy processing spikes.
+
+## Configuration
+
+You can configure the query range limit on any backend by setting the `max_query_range` option. The value is a duration string (e.g., `1h`, `1d`, `14d`).
+
+Here is a configuration example:
+
+```yaml
+backends:
+  prometheus_dev:
+    provider: prometheus
+    origin_url: http://prometheus-origin:9090
+    max_query_range: 14d
+```
+
+Setting `max_query_range: 0` or omitting the field disables the range limit enforcement.
+
+## Supported and Unsupported Backends
+
+Query range limit enforcement is active on backends that implement the `backends.TimeseriesBackend` interface, which includes:
+
+- **Supported Backends:**
+  - Prometheus
+  - InfluxDB
+  - ClickHouse
+  - Application Load Balancers (ALBs) using Time Series Merge (TSM)
+- **Unsupported Backends:**
+  - Standard HTTP Reverse Proxy backends (e.g., `reverseproxycache`) that do not parse the query timespan.
+
+## Rejection Behavior
+
+When an incoming query's duration exceeds the allowed `max_query_range`:
+1. **HTTP Status:** Trickster responds immediately with HTTP `400 Bad Request`.
+2. **Error Message:** The response body contains an error message, e.g., `query time range exceeds the allowed limit of 336h0m0s`.
+3. **Short-circuiting:** Downstream origin TSDB instances are never contacted, conserving database resources.
+
+## Metrics and Logging
+
+Trickster exposes metrics and logs to track rejected queries:
+
+### Metrics
+- **Metric Name:** `trickster_proxy_query_range_rejected_total`
+- **Labels:** `backend` (name of the backend rejecting the query)
+- **Type:** Counter
+- **Description:** Tracks the total number of queries rejected due to exceeding the `max_query_range` limit.
+
+### Logs
+Upon query rejection, Trickster emits a structured warning log including information about the offending query:
+```text
+[WARN] query rejected due to max_query_range limit (backendName=prometheus_dev, limit=336h0m0s, duration=360h0m0s, clientIP=127.0.0.1, path=/api/v1/query_range, statement=up)
+```
+
+## Use with ALBs
+
+Application Load Balancer (ALB) backends configured with the Time Series Merge (TSM) mechanism can enforce query range limits at the ALB entry point. This ensures that Trickster rejects oversized queries *before* scattering them across downstream pool member backends.
+
+For details on using `max_query_range` with TSM ALBs, refer to the [ALB Documentation](./alb.md).

--- a/examples/conf/example.full.yaml
+++ b/examples/conf/example.full.yaml
@@ -270,6 +270,11 @@ backends:
     # it is false, by default; but if you only have a single backend configured, is_default will be true unless explicitly set to false
     is_default: true
 
+    # max_query_range specifies the maximum allowed query range duration for this backend (e.g. 1h, 1d, 14d).
+    # Setting this value restricts clients from making oversized queries.
+    # default is empty (disabled)
+    # max_query_range: 14d
+
 #     # hosts indicates which FQDNs requested by the client should route to this Origin (in addition to path-based routing)
 #     # if you are using TLS, all FQDNs should be included in the certfiicate common names to avoid insecure warnings to clients
 #     # default setting is empty list. List format is: hosts: [ 1.example.com, 2.example.com ]

--- a/pkg/backends/alb/mech/tsm/time_series_merge.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends"
 	"github.com/trickstercache/trickster/v2/pkg/backends/alb/errors"
@@ -262,7 +263,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// limit query time range if configured on the ALB backend
-	if rsc.BackendOptions != nil && rsc.BackendOptions.MaxQueryRangeDuration > 0 {
+	if rsc.BackendOptions != nil && rsc.BackendOptions.MaxQueryRange > 0 {
 		var trq *timeseries.TimeRangeQuery
 		if rsc.TimeRangeQuery != nil {
 			trq = rsc.TimeRangeQuery
@@ -279,7 +280,8 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		if trq != nil {
 			duration := trq.Extent.End.Sub(trq.Extent.Start)
-			if duration > rsc.BackendOptions.MaxQueryRangeDuration {
+			limit := time.Duration(rsc.BackendOptions.MaxQueryRange)
+			if duration > limit {
 				metrics.ProxyQueryRangeRejections.WithLabelValues(rsc.BackendOptions.Name).Inc()
 				clientIP := r.Header.Get("X-Forwarded-For")
 				if clientIP == "" {
@@ -294,9 +296,9 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						"start":       trq.Extent.Start.String(),
 						"end":         trq.Extent.End.String(),
 						"duration":    duration.String(),
-						"limit":       rsc.BackendOptions.MaxQueryRange,
+						"limit":       limit.String(),
 					})
-				http.Error(w, "query time range exceeds the allowed limit of "+rsc.BackendOptions.MaxQueryRange, http.StatusBadRequest)
+				http.Error(w, "query time range exceeds the allowed limit of "+limit.String(), http.StatusBadRequest)
 				return
 			}
 		}

--- a/pkg/backends/alb/mech/tsm/time_series_merge.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge.go
@@ -271,6 +271,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				if tsb, ok := b.(backends.TimeseriesBackend); ok {
 					if parsedTrq, _, _, err := tsb.ParseTimeRangeQuery(r); err == nil && parsedTrq != nil {
 						trq = parsedTrq
+						rsc.TimeRangeQuery = parsedTrq
 					}
 				}
 			}

--- a/pkg/backends/alb/mech/tsm/time_series_merge.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge.go
@@ -261,6 +261,46 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// limit query time range if configured on the ALB backend
+	if rsc.BackendOptions != nil && rsc.BackendOptions.MaxQueryRangeDuration > 0 {
+		var trq *timeseries.TimeRangeQuery
+		if rsc.TimeRangeQuery != nil {
+			trq = rsc.TimeRangeQuery
+		} else if hl[0] != nil {
+			if b := hl[0].Backend(); b != nil {
+				if tsb, ok := b.(backends.TimeseriesBackend); ok {
+					if parsedTrq, _, _, err := tsb.ParseTimeRangeQuery(r); err == nil && parsedTrq != nil {
+						trq = parsedTrq
+					}
+				}
+			}
+		}
+
+		if trq != nil {
+			duration := trq.Extent.End.Sub(trq.Extent.Start)
+			if duration > rsc.BackendOptions.MaxQueryRangeDuration {
+				metrics.ProxyQueryRangeRejections.WithLabelValues(rsc.BackendOptions.Name).Inc()
+				clientIP := r.Header.Get("X-Forwarded-For")
+				if clientIP == "" {
+					clientIP = r.RemoteAddr
+				}
+				logger.Warn("query rejected due to max_query_range limit",
+					logging.Pairs{
+						"backendName": rsc.BackendOptions.Name,
+						"clientIP":    clientIP,
+						"path":        r.URL.Path,
+						"statement":   trq.Statement,
+						"start":       trq.Extent.Start.String(),
+						"end":         trq.Extent.End.String(),
+						"duration":    duration.String(),
+						"limit":       rsc.BackendOptions.MaxQueryRange,
+					})
+				http.Error(w, "query time range exceeds the allowed limit of "+rsc.BackendOptions.MaxQueryRange, http.StatusBadRequest)
+				return
+			}
+		}
+	}
+
 	// Determine the correct merge strategy for this query. We ask the first
 	// healthy pool backend to parse the request via its ParseTimeRangeQuery
 	// method. If rsc already carries a parsed TimeRangeQuery (set by upstream

--- a/pkg/backends/alb/mech/tsm/time_series_merge.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge.go
@@ -62,6 +62,7 @@ type handler struct {
 	tsmOptions            options.TimeSeriesMergeOptions
 	maxCaptureBytes       int
 	maxFanoutCaptureBytes int
+	queryParser           backends.TimeseriesBackend
 
 	// poolVersion increments on every SetPool so cached pool-derived data
 	// (stripKeys) can be invalidated without locking.
@@ -120,6 +121,12 @@ func New(o *options.Options, factories rt.Lookup) (types.Mechanism, error) {
 		return nil, err
 	}
 	// convert the new time series handler to a mergeable timeseries handler to get the merge paths
+	tsb, ok := mc1.(backends.TimeseriesBackend)
+	if !ok {
+		return nil, errors.ErrInvalidTimeSeriesMergeProvider
+	}
+	out.queryParser = tsb
+
 	mc2, ok := mc1.(backends.MergeableTimeseriesBackend)
 	if !ok {
 		return nil, errors.ErrInvalidTimeSeriesMergeProvider
@@ -267,14 +274,11 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var trq *timeseries.TimeRangeQuery
 		if rsc.TimeRangeQuery != nil {
 			trq = rsc.TimeRangeQuery
-		} else if hl[0] != nil {
-			if b := hl[0].Backend(); b != nil {
-				if tsb, ok := b.(backends.TimeseriesBackend); ok {
-					if parsedTrq, _, _, err := tsb.ParseTimeRangeQuery(r); err == nil && parsedTrq != nil {
-						trq = parsedTrq
-						rsc.TimeRangeQuery = parsedTrq
-					}
-				}
+		} else if h.queryParser != nil {
+			parsedTrq, _, _, err := h.queryParser.ParseTimeRangeQuery(r)
+			if err == nil && parsedTrq != nil {
+				trq = parsedTrq
+				rsc.TimeRangeQuery = parsedTrq
 			}
 		}
 

--- a/pkg/backends/alb/mech/tsm/time_series_merge_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_test.go
@@ -205,6 +205,7 @@ func TestLimitQueryRangeALB(t *testing.T) {
 	target := pool.NewTarget(http.HandlerFunc(tu.BasicHTTPHandler), status, mockMemberBackend)
 	p := pool.New([]*pool.Target{target}, 1)
 	defer p.Stop()
+	albpool.WaitHealthy(t, p, 1)
 
 	h := &handler{mergePaths: []string{"/"}}
 	h.SetPool(p)

--- a/pkg/backends/alb/mech/tsm/time_series_merge_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_test.go
@@ -20,12 +20,20 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/trickstercache/trickster/v2/pkg/backends"
+	"github.com/trickstercache/trickster/v2/pkg/backends/alb/pool"
+	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
+	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
+	"github.com/trickstercache/trickster/v2/pkg/observability/metrics"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 	tu "github.com/trickstercache/trickster/v2/pkg/testutil"
 	"github.com/trickstercache/trickster/v2/pkg/testutil/albpool"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 )
 
 var testLogger = logging.NoopLogger()
@@ -155,4 +163,94 @@ func TestTSMPanicAllMembersDoesNotCrashRequest(t *testing.T) {
 	if w.Code < 500 {
 		t.Errorf("expected 5xx, got %d", w.Code)
 	}
+}
+
+type mockTimeseriesBackend struct {
+	backends.TimeseriesBackend
+	parseTRQFunc func(*http.Request) (*timeseries.TimeRangeQuery, *timeseries.RequestOptions, bool, error)
+}
+
+func (m *mockTimeseriesBackend) ParseTimeRangeQuery(r *http.Request) (*timeseries.TimeRangeQuery, *timeseries.RequestOptions, bool, error) {
+	if m.parseTRQFunc != nil {
+		return m.parseTRQFunc(r)
+	}
+	return nil, nil, false, nil
+}
+
+func TestLimitQueryRangeALB(t *testing.T) {
+	logger.SetLogger(testLogger)
+
+	// Create mock timeseries backend for member 0
+	now := time.Now()
+	mockMemberBackend := &mockTimeseriesBackend{
+		parseTRQFunc: func(r *http.Request) (*timeseries.TimeRangeQuery, *timeseries.RequestOptions, bool, error) {
+			// default range is 10 days
+			days := 10
+			if r.Header.Get("X-Test-Range") == "exceed" {
+				days = 15
+			}
+			return &timeseries.TimeRangeQuery{
+				Statement: "up",
+				Extent: timeseries.Extent{
+					Start: now.Add(-time.Duration(days) * 24 * time.Hour),
+					End:   now,
+				},
+			}, nil, false, nil
+		},
+	}
+
+	// Manually construct target and pool to inject the mock backend client
+	status := &healthcheck.Status{}
+	status.Set(healthcheck.StatusPassing)
+	target := pool.NewTarget(http.HandlerFunc(tu.BasicHTTPHandler), status, mockMemberBackend)
+	p := pool.New([]*pool.Target{target}, 1)
+	defer p.Stop()
+
+	h := &handler{mergePaths: []string{"/"}}
+	h.SetPool(p)
+
+	t.Run("within limit", func(t *testing.T) {
+		r := albpool.NewParentGET(t)
+		rsc := request.NewResources(&bo.Options{
+			MaxQueryRange:         "14d",
+			MaxQueryRangeDuration: 14 * 24 * time.Hour,
+		}, nil, nil, nil, nil, nil)
+		rsc.IsMergeMember = true
+		r = request.SetResources(r, rsc)
+
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("exceeds limit", func(t *testing.T) {
+		metrics.ProxyQueryRangeRejections.Reset()
+		r := albpool.NewParentGET(t)
+		r.Header.Set("X-Test-Range", "exceed")
+		rsc := request.NewResources(&bo.Options{
+			Name:                  "alb-test",
+			MaxQueryRange:         "14d",
+			MaxQueryRangeDuration: 14 * 24 * time.Hour,
+		}, nil, nil, nil, nil, nil)
+		rsc.IsMergeMember = true
+		r = request.SetResources(r, rsc)
+
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", w.Code)
+		}
+		assertMsg := "query time range exceeds the allowed limit of 14d"
+		if w.Body.String() != assertMsg+"\n" && w.Body.String() != assertMsg {
+			t.Errorf("expected error message to contain %q, got %q", assertMsg, w.Body.String())
+		}
+
+		// Verify metric is incremented
+		val := testutil.ToFloat64(metrics.ProxyQueryRangeRejections.WithLabelValues("alb-test"))
+		if val != 1.0 {
+			t.Errorf("expected metric value to be 1.0, got %f", val)
+		}
+	})
 }

--- a/pkg/backends/alb/mech/tsm/time_series_merge_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_test.go
@@ -34,6 +34,7 @@ import (
 	tu "github.com/trickstercache/trickster/v2/pkg/testutil"
 	"github.com/trickstercache/trickster/v2/pkg/testutil/albpool"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
+	"github.com/trickstercache/trickster/v2/pkg/util/timeconv"
 )
 
 var testLogger = logging.NoopLogger()
@@ -213,8 +214,7 @@ func TestLimitQueryRangeALB(t *testing.T) {
 	t.Run("within limit", func(t *testing.T) {
 		r := albpool.NewParentGET(t)
 		rsc := request.NewResources(&bo.Options{
-			MaxQueryRange:         "14d",
-			MaxQueryRangeDuration: 14 * 24 * time.Hour,
+			MaxQueryRange: timeconv.Duration(14 * 24 * time.Hour),
 		}, nil, nil, nil, nil, nil)
 		rsc.IsMergeMember = true
 		r = request.SetResources(r, rsc)
@@ -231,9 +231,8 @@ func TestLimitQueryRangeALB(t *testing.T) {
 		r := albpool.NewParentGET(t)
 		r.Header.Set("X-Test-Range", "exceed")
 		rsc := request.NewResources(&bo.Options{
-			Name:                  "alb-test",
-			MaxQueryRange:         "14d",
-			MaxQueryRangeDuration: 14 * 24 * time.Hour,
+			Name:          "alb-test",
+			MaxQueryRange: timeconv.Duration(14 * 24 * time.Hour),
 		}, nil, nil, nil, nil, nil)
 		rsc.IsMergeMember = true
 		r = request.SetResources(r, rsc)
@@ -243,7 +242,7 @@ func TestLimitQueryRangeALB(t *testing.T) {
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("expected 400, got %d", w.Code)
 		}
-		assertMsg := "query time range exceeds the allowed limit of 14d"
+		assertMsg := "query time range exceeds the allowed limit of 336h0m0s"
 		if w.Body.String() != assertMsg+"\n" && w.Body.String() != assertMsg {
 			t.Errorf("expected error message to contain %q, got %q", assertMsg, w.Body.String())
 		}

--- a/pkg/backends/alb/mech/tsm/time_series_merge_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_test.go
@@ -209,6 +209,7 @@ func TestLimitQueryRangeALB(t *testing.T) {
 	albpool.WaitHealthy(t, p, 1)
 
 	h := &handler{mergePaths: []string{"/"}}
+	h.queryParser = mockMemberBackend
 	h.SetPool(p)
 
 	t.Run("within limit", func(t *testing.T) {


### PR DESCRIPTION
## Description

This PR introduces time range limit enforcement for Application Load Balancer (ALB) Time Series Merge (TSM) backends, preventing oversized queries from executing scatter/gather fanouts across downstream TSDB instances.

### Changes & Feature Highlights
1. **ALB TSM Enforcement (time_series_merge.go)**:
   - Before executing scatter/gather fanouts across pool members, TSM inspects the parsed `TimeRangeQuery` duration against the backend's configured `max_query_range` limit.
   - If the duration exceeds the limit, the request is rejected immediately with an HTTP `400 Bad Request` status, avoiding unnecessary fanout load on downstream TSDBs.
2. **Observability**:
   - Emits structured warning audit logs (`query rejected due to max_query_range limit`) containing `backendName`, `clientIP`, `path`, `statement`, `duration`, and `limit`.
   - Increments the `query_range_rejections_total` Prometheus metric counter.
3. **Documentation (docs/alb.md)**:
   - Added documentation and configuration examples for `max_query_range` under the Application Load Balancer guide.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Optimization
- [x] Test coverage
- [x] Documentation
- [ ] Infrastructure

## AI Disclosure

- [ ] This contribution DOES NOT include AI-generated changes
- [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.