### PR TITLE
feat: support pooled stddev and stdvar in ALB TSM

### DIFF
--- a/pkg/backends/alb/mech/tsm/merge_plan.go
+++ b/pkg/backends/alb/mech/tsm/merge_plan.go
@@ -195,9 +195,13 @@ func (h *handler) serveMultiVariantPlan(
 		}
 	}
 	applyPlanCompleteness(plan, executions, memberCount)
-	applyPlanPointCompleteness(plan, executions, memberCount)
+	pointCompleteness := applyPlanPointCompleteness(plan, executions, memberCount)
 	var warnings []string
-	var hasPlanFailure bool
+	if plan.Reduction.Kind == tsmerge.TSMReductionPooledVariance {
+		warnings = pooledVarianceCompletenessWarnings(
+			pointCompleteness, hl, configured)
+	}
+	hasPlanFailure := len(warnings) > 0
 	for variantIndex := range plan.Variants {
 		logical, groupWarnings, groupFailure := coalesceReplicaContributions(
 			parentCtx, hl, configured, executions[variantIndex].contributions,
@@ -205,7 +209,7 @@ func (h *handler) serveMultiVariantPlan(
 		executions[variantIndex].contributions = logical
 		warnings = append(warnings, groupWarnings...)
 		if variantIndex == authorityIndex {
-			hasPlanFailure = groupFailure
+			hasPlanFailure = hasPlanFailure || groupFailure
 		}
 	}
 	var responseAccumulator *merge.Accumulator

--- a/pkg/backends/alb/mech/tsm/merge_plan.go
+++ b/pkg/backends/alb/mech/tsm/merge_plan.go
@@ -198,7 +198,6 @@ func (h *handler) serveMultiVariantPlan(
 	applyPlanPointCompleteness(plan, executions, memberCount)
 	var warnings []string
 	var hasPlanFailure bool
-	accumulators := make([]*merge.Accumulator, len(plan.Variants))
 	for variantIndex := range plan.Variants {
 		logical, groupWarnings, groupFailure := coalesceReplicaContributions(
 			parentCtx, hl, configured, executions[variantIndex].contributions,
@@ -208,31 +207,47 @@ func (h *handler) serveMultiVariantPlan(
 		if variantIndex == authorityIndex {
 			hasPlanFailure = groupFailure
 		}
-		accumulators[variantIndex] = merge.NewAccumulator()
-		failedMembers := mergeGatherContributions(parentCtx, accumulators[variantIndex],
-			logical)
-		if len(failedMembers) > 0 {
-			for _, member := range failedMembers {
-				metrics.ALBFanoutFailures.WithLabelValues(
-					names.MechanismTSM, plan.Variants[variantIndex].Name, "merge",
-				).Inc()
-				logger.Warn("tsm plan contribution merge failure", logging.Pairs{
-					"variant": plan.Variants[variantIndex].Name,
-					"member":  member,
-				})
-			}
-			// Re-running a partially mutated generic accumulator is unsafe. Fail
-			// closed instead of reducing variants built from different members.
-			failures.HandleBadGateway(w, r)
-			return
+	}
+	var responseAccumulator *merge.Accumulator
+	var err error
+	if plan.Reduction.Kind == tsmerge.TSMReductionPooledVariance {
+		var reductionWarnings []string
+		responseAccumulator, reductionWarnings, err = reducePooledVariancePlan(parentCtx, plan, executions)
+		warnings = append(warnings, reductionWarnings...)
+		if len(reductionWarnings) > 0 {
+			hasPlanFailure = true
 		}
+	} else {
+		accumulators := make([]*merge.Accumulator, len(plan.Variants))
+		for variantIndex := range plan.Variants {
+			accumulators[variantIndex] = merge.NewAccumulator()
+			failedMembers := mergeGatherContributions(parentCtx, accumulators[variantIndex],
+				executions[variantIndex].contributions)
+			if len(failedMembers) > 0 {
+				for _, member := range failedMembers {
+					metrics.ALBFanoutFailures.WithLabelValues(
+						names.MechanismTSM, plan.Variants[variantIndex].Name, "merge",
+					).Inc()
+					logger.Warn("tsm plan contribution merge failure", logging.Pairs{
+						"variant": plan.Variants[variantIndex].Name,
+						"member":  member,
+					})
+				}
+				// Re-running a partially mutated generic accumulator is unsafe. Fail
+				// closed instead of reducing variants built from different members.
+				failures.HandleBadGateway(w, r)
+				return
+			}
+			if parentCtx.Err() != nil {
+				return
+			}
+		}
+		responseAccumulator, err = reducePlan(parentCtx, plan, accumulators)
+	}
+	if err != nil {
 		if parentCtx.Err() != nil {
 			return
 		}
-	}
-
-	responseAccumulator, err := reducePlan(parentCtx, plan, accumulators)
-	if err != nil {
 		logger.Warn("tsm plan reduction failure", logging.Pairs{"error": err})
 		failures.HandleBadGateway(w, r)
 		return

--- a/pkg/backends/alb/mech/tsm/pooled_variance.go
+++ b/pkg/backends/alb/mech/tsm/pooled_variance.go
@@ -1,0 +1,473 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tsm
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"slices"
+	"strconv"
+
+	responsemerge "github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/epoch"
+	tsmerge "github.com/trickstercache/trickster/v2/pkg/timeseries/merge"
+)
+
+type pooledVarianceResultKey struct {
+	statementID int
+	name        string
+}
+
+type pooledVarianceSeriesKey struct {
+	result pooledVarianceResultKey
+	hash   dataset.Hash
+}
+
+type pooledVariancePointKey struct {
+	series pooledVarianceSeriesKey
+	epoch  epoch.Epoch
+}
+
+type pooledVarianceValue struct {
+	value  float64
+	series *dataset.Series
+}
+
+type pooledVariancePointIndex struct {
+	values  map[pooledVariancePointKey]pooledVarianceValue
+	invalid map[pooledVariancePointKey]struct{}
+	order   []pooledVariancePointKey
+}
+
+type pooledVarianceMemberPoint struct {
+	key    pooledVariancePointKey
+	header dataset.SeriesHeader
+	state  dataset.PooledVarianceState
+}
+
+type pooledVarianceStateBits struct {
+	count uint64
+	mean  uint64
+	m2    uint64
+}
+
+type pooledVarianceSeenStates struct {
+	first  pooledVarianceStateBits
+	others map[pooledVarianceStateBits]struct{}
+}
+
+type pooledVariancePointRef struct {
+	series *dataset.Series
+	index  int
+}
+
+type pooledVarianceOutput struct {
+	dataset *dataset.DataSet
+	results map[pooledVarianceResultKey]*dataset.Result
+	series  map[pooledVarianceSeriesKey]*dataset.Series
+	points  map[pooledVariancePointKey]pooledVariancePointRef
+	query   string
+}
+
+func reducePooledVariancePlan(
+	ctx context.Context,
+	plan *tsmerge.TSMMergePlan,
+	executions []planVariantExecution,
+) (*responsemerge.Accumulator, []string, error) {
+	variantIndexes := make(map[string]int, len(plan.Variants))
+	for i, variant := range plan.Variants {
+		variantIndexes[variant.Name] = i
+	}
+	inputNames := plan.Reduction.InputVariants
+	orderedExecutions := make([]planVariantExecution, len(inputNames))
+	for i, name := range inputNames {
+		index, ok := variantIndexes[name]
+		if !ok {
+			return nil, nil, fmt.Errorf("pooled-variance input %q is not in the plan", name)
+		}
+		orderedExecutions[i] = executions[index]
+	}
+
+	memberCount := 0
+	if len(orderedExecutions) > 0 {
+		memberCount = len(orderedExecutions[0].contributions)
+	}
+	seenStates := make(map[pooledVariancePointKey]pooledVarianceSeenStates)
+	var output *pooledVarianceOutput
+	var warnings []string
+
+	for member := range memberCount {
+		if err := ctx.Err(); err != nil {
+			return nil, warnings, err
+		}
+		datasets := make([]*dataset.DataSet, len(orderedExecutions))
+		complete := true
+		for variantIndex := range orderedExecutions {
+			contribution := orderedExecutions[variantIndex].contributions[member]
+			if contribution == nil {
+				complete = false
+				break
+			}
+			ds, ok := contribution.data.(*dataset.DataSet)
+			if !ok || ds == nil {
+				return nil, warnings, fmt.Errorf(
+					"pooled-variance variant %q member %d requires a dataset, got %T",
+					inputNames[variantIndex], member, contribution.data,
+				)
+			}
+			datasets[variantIndex] = ds
+		}
+		if !complete {
+			continue
+		}
+		newOutput := output == nil
+		if newOutput {
+			output = newPooledVarianceOutput(datasets[0], plan.OriginalQuery)
+		}
+		if !newOutput {
+			// The response-authority variant owns the envelope. Preserve one copy
+			// per included member, matching standard TSM merge.
+			output.mergeAuthorityEnvelope(datasets[0])
+		}
+
+		memberPoints, dropped, err := pairPooledVarianceMember(
+			ctx, datasets[0], datasets[1], datasets[2], plan.OriginalQuery,
+		)
+		if err != nil {
+			return nil, warnings, err
+		}
+		if dropped > 0 {
+			warnings = append(warnings,
+				"trickster: tsm excluded "+strconv.Itoa(dropped)+
+					" incomplete pooled-variance point(s) from pool member "+strconv.Itoa(member))
+		}
+		for _, point := range memberPoints {
+			bits := pooledVarianceBits(point.state)
+			seen, found := seenStates[point.key]
+			if !found {
+				seenStates[point.key] = pooledVarianceSeenStates{first: bits}
+			} else {
+				if bits == seen.first {
+					continue
+				}
+				if seen.others == nil {
+					capacity := min(memberCount-1, 8)
+					seen.others = make(map[pooledVarianceStateBits]struct{}, capacity)
+					seenStates[point.key] = seen
+				}
+				if _, duplicate := seen.others[bits]; duplicate {
+					continue
+				}
+				seen.others[bits] = struct{}{}
+			}
+			output.mergePoint(point.key, point.header, point.state)
+		}
+	}
+
+	accumulator := responsemerge.NewAccumulator()
+	if output != nil {
+		output.finish()
+		accumulator.SetTSData(output.dataset)
+	}
+	return accumulator, warnings, nil
+}
+
+func indexPooledVariancePoints(
+	ctx context.Context, ds *dataset.DataSet, pairingQuery string,
+) (pooledVariancePointIndex, error) {
+	index := pooledVariancePointIndex{
+		values:  make(map[pooledVariancePointKey]pooledVarianceValue),
+		invalid: make(map[pooledVariancePointKey]struct{}),
+	}
+	if err := ctx.Err(); err != nil {
+		return index, err
+	}
+	if ds == nil {
+		return index, nil
+	}
+	for _, result := range ds.Results {
+		if err := ctx.Err(); err != nil {
+			return index, err
+		}
+		if result == nil {
+			continue
+		}
+		resultKey := pooledVarianceResultKey{statementID: result.StatementID, name: result.Name}
+		for _, series := range result.SeriesList {
+			if err := ctx.Err(); err != nil {
+				return index, err
+			}
+			if series == nil {
+				continue
+			}
+			if len(series.Header.ValueFieldsList) > 0 &&
+				series.Header.ValueFieldsList[0].Name == "histogram" {
+				continue
+			}
+			seriesKey := pooledVarianceSeriesKey{
+				result: resultKey,
+				hash:   series.Header.CalculateHashWithQueryStatement(pairingQuery),
+			}
+			for pointIndex, point := range series.Points {
+				if pointIndex&255 == 0 {
+					if err := ctx.Err(); err != nil {
+						return index, err
+					}
+				}
+				key := pooledVariancePointKey{series: seriesKey, epoch: point.Epoch}
+				if _, seen := index.values[key]; !seen {
+					if _, invalid := index.invalid[key]; !invalid {
+						index.order = append(index.order, key)
+					}
+				}
+				value, ok := pooledVarianceFloat(point)
+				if !ok {
+					delete(index.values, key)
+					index.invalid[key] = struct{}{}
+					continue
+				}
+				if prior, exists := index.values[key]; exists &&
+					math.Float64bits(prior.value) != math.Float64bits(value) {
+					delete(index.values, key)
+					index.invalid[key] = struct{}{}
+					continue
+				}
+				if _, invalid := index.invalid[key]; invalid {
+					continue
+				}
+				index.values[key] = pooledVarianceValue{value: value, series: series}
+			}
+		}
+	}
+	return index, nil
+}
+
+func pairPooledVarianceMember(
+	ctx context.Context,
+	countDS, meanDS, varianceDS *dataset.DataSet,
+	pairingQuery string,
+) (
+	[]pooledVarianceMemberPoint, int, error,
+) {
+	datasets := []*dataset.DataSet{countDS, meanDS, varianceDS}
+	indexes := make([]pooledVariancePointIndex, 0, len(datasets))
+	for _, ds := range datasets {
+		index, err := indexPooledVariancePoints(ctx, ds, pairingQuery)
+		if err != nil {
+			return nil, 0, err
+		}
+		indexes = append(indexes, index)
+	}
+	orderedKeys := make([]pooledVariancePointKey, 0)
+	seenKeys := make(map[pooledVariancePointKey]struct{})
+	for _, index := range indexes {
+		for _, key := range index.order {
+			if _, seen := seenKeys[key]; seen {
+				continue
+			}
+			seenKeys[key] = struct{}{}
+			orderedKeys = append(orderedKeys, key)
+		}
+		for key := range index.invalid {
+			if _, seen := seenKeys[key]; seen {
+				continue
+			}
+			seenKeys[key] = struct{}{}
+			orderedKeys = append(orderedKeys, key)
+		}
+	}
+
+	points := make([]pooledVarianceMemberPoint, 0, len(orderedKeys))
+	dropped := 0
+	for keyIndex, key := range orderedKeys {
+		if keyIndex&255 == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, dropped, err
+			}
+		}
+		values := [3]pooledVarianceValue{}
+		usable := true
+		for i, index := range indexes {
+			if _, invalid := index.invalid[key]; invalid {
+				usable = false
+				break
+			}
+			var found bool
+			values[i], found = index.values[key]
+			if !found {
+				usable = false
+				break
+			}
+		}
+		if !usable {
+			dropped++
+			continue
+		}
+		state, err := dataset.NewPooledVarianceState(
+			values[0].value, values[1].value, values[2].value,
+		)
+		if err != nil {
+			dropped++
+			continue
+		}
+		points = append(points, pooledVarianceMemberPoint{
+			key:    key,
+			header: values[0].series.Header.Clone(),
+			state:  state,
+		})
+	}
+	return points, dropped, nil
+}
+
+func pooledVarianceFloat(point dataset.Point) (float64, bool) {
+	if len(point.Values) == 0 {
+		return 0, false
+	}
+	switch value := point.Values[0].(type) {
+	case string:
+		parsed, err := strconv.ParseFloat(value, 64)
+		return parsed, err == nil
+	case float64:
+		return value, true
+	case float32:
+		return float64(value), true
+	case int:
+		return float64(value), true
+	case int64:
+		return float64(value), true
+	default:
+		return 0, false
+	}
+}
+
+func pooledVarianceBits(state dataset.PooledVarianceState) pooledVarianceStateBits {
+	return pooledVarianceStateBits{
+		count: math.Float64bits(state.Count),
+		mean:  math.Float64bits(state.Mean),
+		m2:    math.Float64bits(state.M2),
+	}
+}
+
+func newPooledVarianceOutput(ds *dataset.DataSet, query string) *pooledVarianceOutput {
+	ds.UpdateLock.Lock()
+	defer ds.UpdateLock.Unlock()
+	clone := &dataset.DataSet{
+		Status:       ds.Status,
+		Error:        ds.Error,
+		ErrorType:    ds.ErrorType,
+		Warnings:     append([]string(nil), ds.Warnings...),
+		Sorter:       ds.Sorter,
+		Merger:       ds.Merger,
+		SizeCropper:  ds.SizeCropper,
+		RangeCropper: ds.RangeCropper,
+		Results:      make(dataset.Results, 0, len(ds.Results)),
+	}
+	if ds.ExtentList != nil {
+		clone.ExtentList = ds.ExtentList.Clone()
+	}
+	if ds.VolatileExtentList != nil {
+		clone.VolatileExtentList = ds.VolatileExtentList.Clone()
+	}
+	if ds.TimeRangeQuery != nil {
+		clone.TimeRangeQuery = ds.TimeRangeQuery.Clone()
+		clone.TimeRangeQuery.Statement = query
+	}
+	output := &pooledVarianceOutput{
+		dataset: clone,
+		results: make(map[pooledVarianceResultKey]*dataset.Result),
+		series:  make(map[pooledVarianceSeriesKey]*dataset.Series),
+		points:  make(map[pooledVariancePointKey]pooledVariancePointRef),
+		query:   query,
+	}
+	for _, result := range ds.Results {
+		if result == nil {
+			continue
+		}
+		resultClone := &dataset.Result{
+			StatementID: result.StatementID,
+			Name:        result.Name,
+			Error:       result.Error,
+		}
+		clone.Results = append(clone.Results, resultClone)
+		key := pooledVarianceResultKey{statementID: result.StatementID, name: result.Name}
+		output.results[key] = resultClone
+	}
+	return output
+}
+
+func (o *pooledVarianceOutput) mergeAuthorityEnvelope(ds *dataset.DataSet) {
+	o.dataset.ExtentList = o.dataset.ExtentList.Merge(ds.ExtentList, o.dataset.Step())
+	o.dataset.Warnings = append(o.dataset.Warnings, ds.Warnings...)
+	if o.dataset.Status == "" || (o.dataset.Status != "success" && ds.Status == "success") {
+		o.dataset.Status = ds.Status
+	}
+}
+
+func (o *pooledVarianceOutput) mergePoint(
+	key pooledVariancePointKey,
+	header dataset.SeriesHeader,
+	state dataset.PooledVarianceState,
+) {
+	if ref, found := o.points[key]; found {
+		point := &ref.series.Points[ref.index]
+		current := point.Values[0].(dataset.PooledVarianceState)
+		point.Values[0] = current.Merge(state)
+		return
+	}
+	result := o.results[key.series.result]
+	if result == nil {
+		result = &dataset.Result{
+			StatementID: key.series.result.statementID,
+			Name:        key.series.result.name,
+		}
+		o.dataset.Results = append(o.dataset.Results, result)
+		o.results[key.series.result] = result
+	}
+	series := o.series[key.series]
+	if series == nil {
+		header.QueryStatement = o.query
+		header.CalculateHash(true)
+		header.CalculateSize()
+		series = &dataset.Series{Header: header}
+		result.SeriesList = append(result.SeriesList, series)
+		o.series[key.series] = series
+	}
+	series.Points = append(series.Points, dataset.Point{
+		Epoch:  key.epoch,
+		Size:   56,
+		Values: []any{state},
+	})
+	o.points[key] = pooledVariancePointRef{series: series, index: len(series.Points) - 1}
+}
+
+func (o *pooledVarianceOutput) finish() {
+	for _, series := range o.series {
+		slices.SortFunc(series.Points, func(a, b dataset.Point) int {
+			switch {
+			case a.Epoch < b.Epoch:
+				return -1
+			case a.Epoch > b.Epoch:
+				return 1
+			default:
+				return 0
+			}
+		})
+		series.PointSize = series.Points.Size()
+	}
+}

--- a/pkg/backends/alb/mech/tsm/pooled_variance.go
+++ b/pkg/backends/alb/mech/tsm/pooled_variance.go
@@ -22,7 +22,9 @@ import (
 	"math"
 	"slices"
 	"strconv"
+	"strings"
 
+	"github.com/trickstercache/trickster/v2/pkg/backends/alb/pool"
 	responsemerge "github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/epoch"
@@ -61,17 +63,6 @@ type pooledVarianceMemberPoint struct {
 	state  dataset.PooledVarianceState
 }
 
-type pooledVarianceStateBits struct {
-	count uint64
-	mean  uint64
-	m2    uint64
-}
-
-type pooledVarianceSeenStates struct {
-	first  pooledVarianceStateBits
-	others map[pooledVarianceStateBits]struct{}
-}
-
 type pooledVariancePointRef struct {
 	series *dataset.Series
 	index  int
@@ -108,7 +99,6 @@ func reducePooledVariancePlan(
 	if len(orderedExecutions) > 0 {
 		memberCount = len(orderedExecutions[0].contributions)
 	}
-	seenStates := make(map[pooledVariancePointKey]pooledVarianceSeenStates)
 	var output *pooledVarianceOutput
 	var warnings []string
 
@@ -158,24 +148,6 @@ func reducePooledVariancePlan(
 					" incomplete pooled-variance point(s) from pool member "+strconv.Itoa(member))
 		}
 		for _, point := range memberPoints {
-			bits := pooledVarianceBits(point.state)
-			seen, found := seenStates[point.key]
-			if !found {
-				seenStates[point.key] = pooledVarianceSeenStates{first: bits}
-			} else {
-				if bits == seen.first {
-					continue
-				}
-				if seen.others == nil {
-					capacity := min(memberCount-1, 8)
-					seen.others = make(map[pooledVarianceStateBits]struct{}, capacity)
-					seenStates[point.key] = seen
-				}
-				if _, duplicate := seen.others[bits]; duplicate {
-					continue
-				}
-				seen.others[bits] = struct{}{}
-			}
 			output.mergePoint(point.key, point.header, point.state)
 		}
 	}
@@ -186,6 +158,49 @@ func reducePooledVariancePlan(
 		accumulator.SetTSData(output.dataset)
 	}
 	return accumulator, warnings, nil
+}
+
+func pooledVarianceCompletenessWarnings(
+	members []planPointCompleteness,
+	live, configured pool.Targets,
+) []string {
+	var warnings []string
+	for _, group := range replicaTopology(live, configured) {
+		present := make(map[replicaPointKey]struct{})
+		complete := make(map[replicaPointKey]struct{})
+		for _, member := range group.live {
+			if member >= len(members) {
+				continue
+			}
+			for key := range members[member].present {
+				present[key] = struct{}{}
+			}
+			for key := range members[member].complete {
+				complete[key] = struct{}{}
+			}
+		}
+		dropped := 0
+		for key := range present {
+			if _, ok := complete[key]; !ok {
+				dropped++
+			}
+		}
+		if dropped > 0 {
+			warnings = append(warnings, pooledVarianceIncompleteWarning(group, dropped))
+		}
+	}
+	return warnings
+}
+
+func pooledVarianceIncompleteWarning(group replicaGroup, count int) string {
+	scope := "replica group " + group.id
+	if member, ok := strings.CutPrefix(group.id, "\x00member-"); ok {
+		if _, err := strconv.Atoi(member); err == nil {
+			scope = "pool member " + member
+		}
+	}
+	return "trickster: tsm excluded " + strconv.Itoa(count) +
+		" incomplete pooled-variance point(s) from " + scope
 }
 
 func indexPooledVariancePoints(
@@ -353,14 +368,6 @@ func pooledVarianceFloat(point dataset.Point) (float64, bool) {
 		return float64(value), true
 	default:
 		return 0, false
-	}
-}
-
-func pooledVarianceBits(state dataset.PooledVarianceState) pooledVarianceStateBits {
-	return pooledVarianceStateBits{
-		count: math.Float64bits(state.Count),
-		mean:  math.Float64bits(state.Mean),
-		m2:    math.Float64bits(state.M2),
 	}
 }
 

--- a/pkg/backends/alb/mech/tsm/pooled_variance_test.go
+++ b/pkg/backends/alb/mech/tsm/pooled_variance_test.go
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tsm
+
+import (
+	"context"
+	"math"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/epoch"
+	tsmerge "github.com/trickstercache/trickster/v2/pkg/timeseries/merge"
+)
+
+func pooledVarianceTestDataSet(query string, tags dataset.Tags, values ...any) *dataset.DataSet {
+	points := make(dataset.Points, 0, len(values)/2)
+	for i := 0; i+1 < len(values); i += 2 {
+		points = append(points, dataset.Point{
+			Epoch:  epoch.Epoch(values[i].(int64)),
+			Values: []any{values[i+1]},
+		})
+	}
+	return &dataset.DataSet{
+		Status:         "success",
+		Warnings:       []string{"origin warning"},
+		TimeRangeQuery: &timeseries.TimeRangeQuery{Statement: query},
+		Results: dataset.Results{{
+			StatementID: 4,
+			Name:        "result",
+			SeriesList: dataset.SeriesList{{
+				Header: dataset.SeriesHeader{
+					Name:                tags["__name__"],
+					Tags:                tags,
+					QueryStatement:      query,
+					ValueFieldsList:     timeseries.FieldDefinitions{{Name: "value", DataType: timeseries.String}},
+					TimestampField:      timeseries.FieldDefinition{Name: "time"},
+					UntrackedFieldsList: nil,
+				},
+				Points: points,
+			}},
+		}},
+	}
+}
+
+func pooledVarianceTestPlan() *tsmerge.TSMMergePlan {
+	names := tsmerge.TSMReductionPooledVarianceVariants()
+	return &tsmerge.TSMMergePlan{
+		OriginalQuery: "stdvar by (job) (up)",
+		Variants: []tsmerge.TSMQueryVariant{
+			{Name: names[0]},
+			{Name: names[1]},
+			{Name: names[2]},
+		},
+		Reduction: tsmerge.TSMReductionSpec{
+			Kind:          tsmerge.TSMReductionPooledVariance,
+			InputVariants: names,
+		},
+	}
+}
+
+func pooledVarianceTestExecutions(members [][3]any) []planVariantExecution {
+	executions := make([]planVariantExecution, 3)
+	for variant := range executions {
+		executions[variant].contributions = make([]*gatherContribution, len(members))
+		for member := range members {
+			if members[member][variant] == nil {
+				continue
+			}
+			executions[variant].contributions[member] = &gatherContribution{
+				data:   members[member][variant],
+				member: member,
+			}
+		}
+	}
+	return executions
+}
+
+func TestReducePooledVariancePlan(t *testing.T) {
+	tags := dataset.Tags{"job": "api"}
+	member := func(count, mean, variance string) [3]any {
+		return [3]any{
+			pooledVarianceTestDataSet("count by (job) (up)", tags.Clone(), int64(100), count),
+			pooledVarianceTestDataSet("avg by (job) (up)", tags.Clone(), int64(100), mean),
+			pooledVarianceTestDataSet("stdvar by (job) (up)", tags.Clone(), int64(100), variance),
+		}
+	}
+	members := [][3]any{
+		member("2", "2", "1"),
+		member("3", "7", "2.6666666666666665"),
+		member("2", "2", "1"), // exact HA replica of member 0
+	}
+	members[0][0].(*dataset.DataSet).ExtentList = timeseries.ExtentList{{
+		Start: time.Unix(0, 0), End: time.Unix(10, 0),
+	}}
+	members[1][0].(*dataset.DataSet).ExtentList = timeseries.ExtentList{{
+		Start: time.Unix(5, 0), End: time.Unix(20, 0),
+	}}
+
+	accumulator, warnings, err := reducePooledVariancePlan(
+		context.Background(), pooledVarianceTestPlan(), pooledVarianceTestExecutions(members),
+	)
+	if err != nil {
+		t.Fatalf("reduce: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings: %v", warnings)
+	}
+	ds, ok := accumulator.GetTSData().(*dataset.DataSet)
+	if !ok || len(ds.Results) != 1 || len(ds.Results[0].SeriesList) != 1 {
+		t.Fatalf("output: %#v", accumulator.GetTSData())
+	}
+	series := ds.Results[0].SeriesList[0]
+	state, ok := series.Points[0].Values[0].(dataset.PooledVarianceState)
+	if !ok {
+		t.Fatalf("point value type: %T", series.Points[0].Values[0])
+	}
+	if got, want := state.PopulationVariance(), 8.0; math.Abs(got-want) > 1e-12 {
+		t.Fatalf("variance got %.17g want %.17g", got, want)
+	}
+	if state.Count != 5 {
+		t.Fatalf("deduplicated count got %v want 5", state.Count)
+	}
+	if series.Header.QueryStatement != pooledVarianceTestPlan().OriginalQuery {
+		t.Fatalf("query statement: %q", series.Header.QueryStatement)
+	}
+	if ds.TimeRangeQuery == nil || ds.TimeRangeQuery.Statement != pooledVarianceTestPlan().OriginalQuery {
+		t.Fatalf("time range query: %#v", ds.TimeRangeQuery)
+	}
+	if len(ds.Warnings) != len(members) {
+		t.Fatalf("dataset warnings: %v", ds.Warnings)
+	}
+	if len(ds.ExtentList) != 1 || !ds.ExtentList[0].Start.Equal(time.Unix(0, 0)) ||
+		!ds.ExtentList[0].End.Equal(time.Unix(20, 0)) {
+		t.Fatalf("dataset extents: %v", ds.ExtentList)
+	}
+	for _, warning := range ds.Warnings {
+		if warning != "origin warning" {
+			t.Fatalf("dataset warnings: %v", ds.Warnings)
+		}
+	}
+}
+
+func TestReducePooledVariancePlanDropsUnpairedPoints(t *testing.T) {
+	tags := dataset.Tags{"job": "api"}
+	members := [][3]any{{
+		pooledVarianceTestDataSet("count", tags.Clone(),
+			int64(100), "2", int64(200), "2"),
+		pooledVarianceTestDataSet("avg", tags.Clone(), int64(100), "3"),
+		pooledVarianceTestDataSet("stdvar", tags.Clone(),
+			int64(100), "1", int64(200), "1", int64(300), "0"),
+	}}
+
+	accumulator, warnings, err := reducePooledVariancePlan(
+		context.Background(), pooledVarianceTestPlan(), pooledVarianceTestExecutions(members),
+	)
+	if err != nil {
+		t.Fatalf("reduce: %v", err)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "2 incomplete") {
+		t.Fatalf("warnings: %v", warnings)
+	}
+	ds := accumulator.GetTSData().(*dataset.DataSet)
+	points := ds.Results[0].SeriesList[0].Points
+	if len(points) != 1 || points[0].Epoch != 100 {
+		t.Fatalf("points: %#v", points)
+	}
+}
+
+func TestReducePooledVariancePlanDropsUnpairedSeries(t *testing.T) {
+	api := dataset.Tags{"job": "api"}
+	db := dataset.Tags{"job": "db"}
+	countDS := pooledVarianceTestDataSet("count", api.Clone(), int64(100), "2")
+	countDS.Results[0].SeriesList = append(countDS.Results[0].SeriesList,
+		pooledVarianceTestDataSet("count", db.Clone(), int64(100), "2").Results[0].SeriesList[0])
+	meanDS := pooledVarianceTestDataSet("avg", api.Clone(), int64(100), "3")
+	varianceDS := pooledVarianceTestDataSet("stdvar", api.Clone(), int64(100), "1")
+	varianceDS.Results[0].SeriesList = append(varianceDS.Results[0].SeriesList,
+		pooledVarianceTestDataSet("stdvar", db.Clone(), int64(100), "4").Results[0].SeriesList[0])
+	members := [][3]any{{countDS, meanDS, varianceDS}}
+
+	accumulator, warnings, err := reducePooledVariancePlan(
+		context.Background(), pooledVarianceTestPlan(), pooledVarianceTestExecutions(members),
+	)
+	if err != nil {
+		t.Fatalf("reduce: %v", err)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "1 incomplete") {
+		t.Fatalf("warnings: %v", warnings)
+	}
+	ds := accumulator.GetTSData().(*dataset.DataSet)
+	if got := ds.Results[0].SeriesList; len(got) != 1 || got[0].Header.Tags["job"] != "api" {
+		t.Fatalf("series: %#v", got)
+	}
+}
+
+func TestReducePooledVariancePlanRejectsUnexpectedData(t *testing.T) {
+	members := [][3]any{{[]byte("wire"), &dataset.DataSet{}, &dataset.DataSet{}}}
+	if _, _, err := reducePooledVariancePlan(
+		context.Background(), pooledVarianceTestPlan(), pooledVarianceTestExecutions(members),
+	); err == nil {
+		t.Fatal("unexpected data type was accepted")
+	}
+}
+
+func TestReducePooledVariancePlanDropsInvalidCount(t *testing.T) {
+	tags := dataset.Tags{"job": "api"}
+	members := [][3]any{{
+		pooledVarianceTestDataSet("count", tags.Clone(), int64(100), "1.5"),
+		pooledVarianceTestDataSet("avg", tags.Clone(), int64(100), "2"),
+		pooledVarianceTestDataSet("stdvar", tags.Clone(), int64(100), "0"),
+	}}
+	accumulator, warnings, err := reducePooledVariancePlan(
+		context.Background(), pooledVarianceTestPlan(), pooledVarianceTestExecutions(members),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "1 incomplete") {
+		t.Fatalf("warnings: %v", warnings)
+	}
+	ds := accumulator.GetTSData().(*dataset.DataSet)
+	if len(ds.Results[0].SeriesList) != 0 {
+		t.Fatalf("invalid count produced series: %#v", ds.Results[0].SeriesList)
+	}
+}
+
+func TestPairPooledVarianceMemberIgnoresHistogramSeries(t *testing.T) {
+	tags := dataset.Tags{"job": "api"}
+	countDS := pooledVarianceTestDataSet("count", tags.Clone(), int64(100), "2")
+	countDS.Results[0].SeriesList[0].Header.ValueFieldsList[0].Name = "histogram"
+	meanDS := pooledVarianceTestDataSet("avg", tags.Clone(), int64(100), "3")
+	varianceDS := pooledVarianceTestDataSet("stdvar", tags.Clone(), int64(100), "1")
+
+	points, dropped, err := pairPooledVarianceMember(
+		context.Background(), countDS, meanDS, varianceDS, pooledVarianceTestPlan().OriginalQuery,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(points) != 0 || dropped != 1 {
+		t.Fatalf("points=%#v dropped=%d", points, dropped)
+	}
+}
+
+func TestIndexPooledVariancePointsHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ds := pooledVarianceTestDataSet("count", dataset.Tags{"job": "api"}, int64(100), "2")
+	if _, err := indexPooledVariancePoints(ctx, ds, pooledVarianceTestPlan().OriginalQuery); err == nil {
+		t.Fatal("canceled indexing unexpectedly succeeded")
+	}
+}
+
+func BenchmarkReducePooledVariancePlan(b *testing.B) {
+	const (
+		shardCount = 16
+		groupCount = 64
+		stepCount  = 30
+	)
+	members := make([][3]any, shardCount)
+	queries := [3]string{"count", "avg", "stdvar"}
+	for shard := range shardCount {
+		for variant := range 3 {
+			ds := &dataset.DataSet{Results: dataset.Results{{}}}
+			for group := range groupCount {
+				points := make(dataset.Points, stepCount)
+				for step := range stepCount {
+					value := "100"
+					switch variant {
+					case 1:
+						value = strconv.Itoa(shard + group)
+					case 2:
+						value = "4"
+					}
+					points[step] = dataset.Point{
+						Epoch:  epoch.Epoch(step + 1),
+						Values: []any{value},
+					}
+				}
+				ds.Results[0].SeriesList = append(ds.Results[0].SeriesList, &dataset.Series{
+					Header: dataset.SeriesHeader{
+						Tags:           dataset.Tags{"group": strconv.Itoa(group)},
+						QueryStatement: queries[variant],
+					},
+					Points: points,
+				})
+			}
+			members[shard][variant] = ds
+		}
+	}
+	plan := pooledVarianceTestPlan()
+	executions := pooledVarianceTestExecutions(members)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		accumulator, _, err := reducePooledVariancePlan(context.Background(), plan, executions)
+		if err != nil {
+			b.Fatalf("reduce: %v", err)
+		}
+		if accumulator.GetTSData() == nil {
+			b.Fatal("reduce returned no data")
+		}
+	}
+}

--- a/pkg/backends/alb/mech/tsm/pooled_variance_test.go
+++ b/pkg/backends/alb/mech/tsm/pooled_variance_test.go
@@ -105,7 +105,7 @@ func TestReducePooledVariancePlan(t *testing.T) {
 	members := [][3]any{
 		member("2", "2", "1"),
 		member("3", "7", "2.6666666666666665"),
-		member("2", "2", "1"), // exact HA replica of member 0
+		member("2", "2", "1"), // independent shard with the same state as member 0
 	}
 	members[0][0].(*dataset.DataSet).ExtentList = timeseries.ExtentList{{
 		Start: time.Unix(0, 0), End: time.Unix(10, 0),
@@ -132,11 +132,11 @@ func TestReducePooledVariancePlan(t *testing.T) {
 	if !ok {
 		t.Fatalf("point value type: %T", series.Points[0].Values[0])
 	}
-	if got, want := state.PopulationVariance(), 8.0; math.Abs(got-want) > 1e-12 {
+	if got, want := state.PopulationVariance(), 384.0/49.0; math.Abs(got-want) > 1e-12 {
 		t.Fatalf("variance got %.17g want %.17g", got, want)
 	}
-	if state.Count != 5 {
-		t.Fatalf("deduplicated count got %v want 5", state.Count)
+	if state.Count != 7 {
+		t.Fatalf("pooled count got %v want 7", state.Count)
 	}
 	if series.Header.QueryStatement != pooledVarianceTestPlan().OriginalQuery {
 		t.Fatalf("query statement: %q", series.Header.QueryStatement)

--- a/pkg/backends/alb/mech/tsm/replica_groups.go
+++ b/pkg/backends/alb/mech/tsm/replica_groups.go
@@ -265,6 +265,11 @@ type replicaPointKey struct {
 	epoch     int64
 }
 
+type planPointCompleteness struct {
+	present  map[replicaPointKey]struct{}
+	complete map[replicaPointKey]struct{}
+}
+
 // applyPlanPointCompleteness intersects all variants for each physical member
 // before replica selection. This prevents a sum point from one replica from
 // being paired with a count point from another replica merely because both
@@ -272,10 +277,11 @@ type replicaPointKey struct {
 func applyPlanPointCompleteness(plan *tsmerge.TSMMergePlan,
 	executions []planVariantExecution,
 	memberCount int,
-) {
+) []planPointCompleteness {
+	memberSets := make([]planPointCompleteness, memberCount)
 	if plan == nil || plan.Completeness != tsmerge.TSMCompletenessAllVariants ||
 		len(executions) < 2 {
-		return
+		return memberSets
 	}
 	for member := range memberCount {
 		variantSets := make([]map[replicaPointKey]struct{}, len(executions))
@@ -305,6 +311,12 @@ func applyPlanPointCompleteness(plan *tsmerge.TSMMergePlan,
 			}
 			continue
 		}
+		present := make(map[replicaPointKey]struct{})
+		for _, variantSet := range variantSets {
+			for key := range variantSet {
+				present[key] = struct{}{}
+			}
+		}
 		complete := variantSets[0]
 		for key := range complete {
 			for variantIndex := 1; variantIndex < len(variantSets); variantIndex++ {
@@ -314,11 +326,15 @@ func applyPlanPointCompleteness(plan *tsmerge.TSMMergePlan,
 				}
 			}
 		}
+		memberSets[member] = planPointCompleteness{
+			present: present, complete: complete,
+		}
 		for variantIndex := range executions {
 			ds := executions[variantIndex].contributions[member].data.(*dataset.DataSet)
 			pruneDataSetPoints(ds, plan.OriginalQuery, complete)
 		}
 	}
+	return memberSets
 }
 
 func dataSetPointKeys(ds *dataset.DataSet, pairingQuery string) map[replicaPointKey]struct{} {

--- a/pkg/backends/alb/mech/tsm/time_series_merge_pooled_variance_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_pooled_variance_test.go
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tsm
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/backends/alb/names"
+	"github.com/trickstercache/trickster/v2/pkg/backends/alb/pool"
+	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
+	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
+	prometheusbackend "github.com/trickstercache/trickster/v2/pkg/backends/prometheus"
+	prop "github.com/trickstercache/trickster/v2/pkg/backends/prometheus/options"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/params"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+	responsemerge "github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
+	"github.com/trickstercache/trickster/v2/pkg/testutil/albpool"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
+	tsmerge "github.com/trickstercache/trickster/v2/pkg/timeseries/merge"
+)
+
+type pooledVarianceBackend struct {
+	stripKeysStubBackend
+	client prometheusbackend.Client
+}
+
+func (b *pooledVarianceBackend) PlanTSMMerge(r *http.Request, query string) (*tsmerge.TSMMergePlan, error) {
+	return b.client.PlanTSMMerge(r, query)
+}
+
+func (b *pooledVarianceBackend) FinalizeTSMMerge(query string, ts timeseries.Timeseries) {
+	b.client.FinalizeTSMMerge(query, ts)
+}
+
+type pooledVarianceMemberSpec struct {
+	count          string
+	mean           string
+	variance       string
+	tags           dataset.Tags
+	failVariant    string
+	missingMeanAt2 bool
+}
+
+func pooledVarianceMemberHandler(spec pooledVarianceMemberSpec) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		values, _, _ := params.GetRequestValues(r)
+		query := values.Get("query")
+		variant := tsmerge.TSMVariantPooledVarianceCount
+		value := spec.count
+		switch {
+		case strings.HasPrefix(query, "avg") || strings.Contains(query, "(avg "):
+			variant = tsmerge.TSMVariantPooledVarianceMean
+			value = spec.mean
+		case strings.HasPrefix(query, "stdvar") || strings.Contains(query, "(stdvar "):
+			variant = tsmerge.TSMVariantPooledVarianceValue
+			value = spec.variance
+		}
+		rsc := request.GetResources(r)
+		if rsc != nil {
+			rsc.MergeRespondFunc = weightedAvgRespondFunc
+		}
+		if variant == spec.failVariant {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		if rsc != nil {
+			pointValues := []any{int64(100), value}
+			if !spec.missingMeanAt2 || variant != tsmerge.TSMVariantPooledVarianceMean {
+				pointValues = append(pointValues, int64(200), value)
+			}
+			rsc.TS = pooledVarianceTestDataSet(query, spec.tags.Clone(), pointValues...)
+			rsc.MergeFunc = responsemerge.TimeseriesMergeFuncWithStrategy(nil, rsc.TSMergeStrategy)
+			rsc.BatchMergeFunc = responsemerge.TimeseriesBatchMergeFuncWithStrategy(rsc.TSMergeStrategy)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func newPooledVariancePool(specs []pooledVarianceMemberSpec, stripLabel string) pool.Pool {
+	targets := make(pool.Targets, len(specs))
+	for i, spec := range specs {
+		status := &healthcheck.Status{}
+		status.Set(healthcheck.StatusPassing)
+		labels := map[string]string(nil)
+		if stripLabel != "" {
+			labels = map[string]string{stripLabel: spec.tags[stripLabel]}
+		}
+		backend := &pooledVarianceBackend{
+			stripKeysStubBackend: stripKeysStubBackend{
+				cfg: &bo.Options{Prometheus: &prop.Options{Labels: labels}},
+			},
+		}
+		targets[i] = pool.NewTarget(pooledVarianceMemberHandler(spec), status, backend)
+	}
+	p := pool.New(targets, -1)
+	p.RefreshHealthy()
+	return p
+}
+
+func TestServePooledVariance(t *testing.T) {
+	logger.SetLogger(testLogger)
+
+	t.Run("unequal members and HA replica", func(t *testing.T) {
+		specs := []pooledVarianceMemberSpec{
+			{count: "2", mean: "2", variance: "1", tags: dataset.Tags{"job": "api", "replica": "a"}},
+			{count: "3", mean: "7", variance: "2.6666666666666665", tags: dataset.Tags{"job": "api", "replica": "b"}},
+			{count: "2", mean: "2", variance: "1", tags: dataset.Tags{"job": "api", "replica": "c"}},
+		}
+		p := newPooledVariancePool(specs, "replica")
+		defer p.Stop()
+		albpool.WaitHealthy(t, p, len(specs))
+		h := &handler{mergePaths: []string{"/"}}
+		h.SetPool(p)
+		w := httptest.NewRecorder()
+
+		albpool.RequireFanoutAttemptDelta(t, names.MechanismTSM,
+			tsmerge.TSMVariantPooledVarianceCount, 1, func() {
+				albpool.RequireFanoutAttemptDelta(t, names.MechanismTSM,
+					tsmerge.TSMVariantPooledVarianceMean, 1, func() {
+						albpool.RequireFanoutAttemptDelta(t, names.MechanismTSM,
+							tsmerge.TSMVariantPooledVarianceValue, 1, func() {
+								h.ServeHTTP(w, newWeightedAvgRequest(t, "stdvar by (job) (requests)"))
+							})
+					})
+			})
+
+		if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "100=8;") ||
+			!strings.Contains(w.Body.String(), "200=8;") {
+			t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("failed variant excludes the whole member", func(t *testing.T) {
+		specs := []pooledVarianceMemberSpec{
+			{count: "2", mean: "2", variance: "1", tags: dataset.Tags{"job": "api"},
+				failVariant: tsmerge.TSMVariantPooledVarianceValue},
+			{count: "2", mean: "10", variance: "4", tags: dataset.Tags{"job": "api"}},
+		}
+		p := newPooledVariancePool(specs, "")
+		defer p.Stop()
+		albpool.WaitHealthy(t, p, len(specs))
+		h := &handler{mergePaths: []string{"/"}}
+		h.SetPool(p)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newWeightedAvgRequest(t, "stdvar by (job) (requests)"))
+
+		body := w.Body.String()
+		if w.Code != http.StatusOK || !strings.Contains(body, "100=4;") ||
+			!strings.Contains(body, tsmerge.TSMVariantPooledVarianceValue) {
+			t.Fatalf("status=%d body=%q", w.Code, body)
+		}
+	})
+
+	t.Run("missing timestamp is visible", func(t *testing.T) {
+		specs := []pooledVarianceMemberSpec{{
+			count: "2", mean: "3", variance: "1", tags: dataset.Tags{"job": "api"},
+			missingMeanAt2: true,
+		}}
+		p := newPooledVariancePool(specs, "")
+		defer p.Stop()
+		albpool.WaitHealthy(t, p, 1)
+		h := &handler{mergePaths: []string{"/"}}
+		h.SetPool(p)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newWeightedAvgRequest(t, "stddev by (job) (requests)"))
+
+		body := w.Body.String()
+		if w.Code != http.StatusOK || !strings.Contains(body, "100=1;") ||
+			strings.Contains(body, "200=") || !strings.Contains(body, "1 incomplete") {
+			t.Fatalf("status=%d body=%q", w.Code, body)
+		}
+		if got := w.Header().Get(headers.NameTricksterResult); !strings.Contains(got, "status=phit") {
+			t.Fatalf("result header: %q", got)
+		}
+	})
+}
+
+func BenchmarkServePooledVariance(b *testing.B) {
+	specs := make([]pooledVarianceMemberSpec, 32)
+	for i := range specs {
+		specs[i] = pooledVarianceMemberSpec{
+			count: "100", mean: strconv.Itoa(i), variance: "4",
+			tags: dataset.Tags{"job": "api", "shard": strconv.Itoa(i)},
+		}
+	}
+	p := newPooledVariancePool(specs, "shard")
+	defer p.Stop()
+	albpool.WaitHealthy(b, p, len(specs))
+	h := &handler{mergePaths: []string{"/"}}
+	h.SetPool(p)
+
+	for b.Loop() {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newWeightedAvgRequest(b, "stdvar by (job) (requests)"))
+		if w.Code != http.StatusOK {
+			b.Fatalf("status=%d", w.Code)
+		}
+	}
+}

--- a/pkg/backends/alb/mech/tsm/time_series_merge_pooled_variance_test.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge_pooled_variance_test.go
@@ -58,6 +58,7 @@ type pooledVarianceMemberSpec struct {
 	mean           string
 	variance       string
 	tags           dataset.Tags
+	replicaGroup   string
 	failVariant    string
 	missingMeanAt2 bool
 }
@@ -108,7 +109,11 @@ func newPooledVariancePool(specs []pooledVarianceMemberSpec, stripLabel string) 
 		}
 		backend := &pooledVarianceBackend{
 			stripKeysStubBackend: stripKeysStubBackend{
-				cfg: &bo.Options{Prometheus: &prop.Options{Labels: labels}},
+				cfg: &bo.Options{
+					Name:         "member-" + strconv.Itoa(i),
+					ReplicaGroup: spec.replicaGroup,
+					Prometheus:   &prop.Options{Labels: labels},
+				},
 			},
 		}
 		targets[i] = pool.NewTarget(pooledVarianceMemberHandler(spec), status, backend)
@@ -123,9 +128,12 @@ func TestServePooledVariance(t *testing.T) {
 
 	t.Run("unequal members and HA replica", func(t *testing.T) {
 		specs := []pooledVarianceMemberSpec{
-			{count: "2", mean: "2", variance: "1", tags: dataset.Tags{"job": "api", "replica": "a"}},
-			{count: "3", mean: "7", variance: "2.6666666666666665", tags: dataset.Tags{"job": "api", "replica": "b"}},
-			{count: "2", mean: "2", variance: "1", tags: dataset.Tags{"job": "api", "replica": "c"}},
+			{count: "2", mean: "2", variance: "1", replicaGroup: "shard-a",
+				tags: dataset.Tags{"job": "api", "replica": "a"}},
+			{count: "3", mean: "7", variance: "2.6666666666666665", replicaGroup: "shard-b",
+				tags: dataset.Tags{"job": "api", "replica": "b"}},
+			{count: "2", mean: "2", variance: "1", replicaGroup: "shard-a",
+				tags: dataset.Tags{"job": "api", "replica": "c"}},
 		}
 		p := newPooledVariancePool(specs, "replica")
 		defer p.Stop()
@@ -148,6 +156,53 @@ func TestServePooledVariance(t *testing.T) {
 		if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "100=8;") ||
 			!strings.Contains(w.Body.String(), "200=8;") {
 			t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("identical disjoint shards remain independently weighted", func(t *testing.T) {
+		specs := []pooledVarianceMemberSpec{
+			{count: "2", mean: "2", variance: "1", tags: dataset.Tags{"job": "api"}},
+			{count: "3", mean: "7", variance: "2.6666666666666665",
+				tags: dataset.Tags{"job": "api"}},
+			{count: "2", mean: "2", variance: "1", tags: dataset.Tags{"job": "api"}},
+		}
+		p := newPooledVariancePool(specs, "")
+		defer p.Stop()
+		albpool.WaitHealthy(t, p, len(specs))
+		h := &handler{mergePaths: []string{"/"}}
+		h.SetPool(p)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newWeightedAvgRequest(t, "stdvar by (job) (requests)"))
+
+		if w.Code != http.StatusOK ||
+			!strings.Contains(w.Body.String(), "100=7.836734693877552;") ||
+			!strings.Contains(w.Body.String(), "200=7.836734693877552;") {
+			t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("complete replica fills an incomplete primary point", func(t *testing.T) {
+		specs := []pooledVarianceMemberSpec{
+			{count: "2", mean: "3", variance: "1", replicaGroup: "shard-a",
+				tags: dataset.Tags{"job": "api"}, missingMeanAt2: true},
+			{count: "2", mean: "3", variance: "1", replicaGroup: "shard-a",
+				tags: dataset.Tags{"job": "api"}},
+		}
+		p := newPooledVariancePool(specs, "")
+		defer p.Stop()
+		albpool.WaitHealthy(t, p, len(specs))
+		h := &handler{mergePaths: []string{"/"}}
+		h.SetPool(p)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newWeightedAvgRequest(t, "stdvar by (job) (requests)"))
+
+		body := w.Body.String()
+		if w.Code != http.StatusOK || !strings.Contains(body, "100=1;") ||
+			!strings.Contains(body, "200=1;") || strings.Contains(body, "incomplete") {
+			t.Fatalf("status=%d body=%q", w.Code, body)
+		}
+		if got := w.Header().Get(headers.NameTricksterResult); strings.Contains(got, "status=phit") {
+			t.Fatalf("result header: %q", got)
 		}
 	})
 

--- a/pkg/backends/prometheus/promql/variance_aggregation.go
+++ b/pkg/backends/prometheus/promql/variance_aggregation.go
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package promql
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/aggregation"
+)
+
+const (
+	promMetricNameLabel     = "__name__"
+	promMetricTypeLabel     = "__type__"
+	promMetricUnitLabel     = "__unit__"
+	varianceTemporaryMetric = "__trickster_tsm_variance__"
+)
+
+var varianceMetadataLabels = map[string]string{
+	promMetricNameLabel: "__trickster_tsm_name__",
+	promMetricTypeLabel: "__trickster_tsm_type__",
+	promMetricUnitLabel: "__trickster_tsm_unit__",
+}
+
+// VarianceAggregation describes an outer stddev or stdvar aggregation,
+// optionally wrapped in sort or sort_desc.
+type VarianceAggregation struct {
+	Operator         string
+	InnerQuery       string
+	AggregationQuery string
+	Grouping         AggregationGrouping
+	SortSet          bool
+	SortDescending   bool
+
+	inputPrefix string
+	inputSuffix string
+}
+
+// ParseVarianceAggregation parses a complete outer stddev or stdvar
+// aggregation, optionally wrapped in sort or sort_desc.
+func ParseVarianceAggregation(query string) (VarianceAggregation, bool) {
+	q := strings.TrimSpace(query)
+	if sortSpec, ok := ParseSortWrapper(q); ok {
+		spec, found := parseVarianceAggregation(sortSpec.InnerQuery)
+		if found {
+			spec.SortSet = true
+			spec.SortDescending = sortSpec.Descending
+		}
+		return spec, found
+	}
+	return parseVarianceAggregation(q)
+}
+
+func parseVarianceAggregation(query string) (VarianceAggregation, bool) {
+	q := strings.TrimSpace(query)
+	ql := strings.ToLower(q)
+	operator := ""
+	for _, candidate := range []string{aggregation.StdDev, aggregation.StdVar} {
+		if strings.HasPrefix(ql, candidate) &&
+			(len(q) == len(candidate) || isPromQLBoundary(q[len(candidate)])) {
+			operator = candidate
+			break
+		}
+	}
+	if operator == "" {
+		return VarianceAggregation{}, false
+	}
+
+	pos := skipPromQLSpaces(q, len(operator))
+	grouping, next, hasPrefixGrouping := parseGroupingAt(q, pos)
+	if hasPrefixGrouping {
+		pos = skipPromQLSpaces(q, next)
+	}
+	if pos >= len(q) || q[pos] != '(' {
+		return VarianceAggregation{}, false
+	}
+	closeIdx := findMatchingCloser(q, pos, '(', ')')
+	if closeIdx < 0 {
+		return VarianceAggregation{}, false
+	}
+	innerQuery := strings.TrimSpace(q[pos+1 : closeIdx])
+	if innerQuery == "" || findTopLevelComma(innerQuery) >= 0 {
+		return VarianceAggregation{}, false
+	}
+
+	trailer := skipPromQLSpaces(q, closeIdx+1)
+	if !hasPrefixGrouping && trailer < len(q) {
+		var ok bool
+		grouping, trailer, ok = parseGroupingAt(q, trailer)
+		if !ok {
+			return VarianceAggregation{}, false
+		}
+		trailer = skipPromQLSpaces(q, trailer)
+	}
+	if trailer != len(q) {
+		return VarianceAggregation{}, false
+	}
+
+	return VarianceAggregation{
+		Operator:         operator,
+		InnerQuery:       innerQuery,
+		AggregationQuery: q,
+		Grouping:         grouping,
+		inputPrefix:      q[:pos+1],
+		inputSuffix:      q[closeIdx:],
+	}, true
+}
+
+func skipPromQLSpaces(input string, pos int) int {
+	for pos < len(input) && isPromQLSpace(input[pos]) {
+		pos++
+	}
+	return pos
+}
+
+func parseGroupingAt(input string, pos int) (AggregationGrouping, int, bool) {
+	if pos >= len(input) {
+		return AggregationGrouping{}, pos, false
+	}
+	lower := strings.ToLower(input[pos:])
+	for _, keyword := range []string{"without", "by"} {
+		if !strings.HasPrefix(lower, keyword) {
+			continue
+		}
+		endKeyword := pos + len(keyword)
+		if endKeyword < len(input) && isPromQLIdentifierPart(input[endKeyword]) {
+			continue
+		}
+		openIdx := skipPromQLSpaces(input, endKeyword)
+		if openIdx >= len(input) || input[openIdx] != '(' {
+			return AggregationGrouping{}, pos, false
+		}
+		closeIdx := findMatchingCloser(input, openIdx, '(', ')')
+		if closeIdx < 0 {
+			return AggregationGrouping{}, pos, false
+		}
+		return AggregationGrouping{
+			Labels:  parseLabels(input[openIdx+1 : closeIdx]),
+			Without: keyword == "without",
+		}, closeIdx + 1, true
+	}
+	return AggregationGrouping{}, pos, false
+}
+
+// VarianceVariantQuery rewrites spec as one count, avg, or stdvar query. The
+// generated input is float-only because those three operators do not otherwise
+// share stddev/stdvar's native-histogram behavior.
+func VarianceVariantQuery(spec VarianceAggregation, operator string) string {
+	metadataLabels := varianceGroupingMetadataLabels(spec.Grouping)
+	if len(metadataLabels) == 0 {
+		prefix := operator + spec.inputPrefix[len(spec.Operator):]
+		return prefix + "clamp(" + spec.InnerQuery + ", -Inf, +Inf)" + spec.inputSuffix
+	}
+
+	input := spec.InnerQuery
+	internalGrouping := AggregationGrouping{Labels: append([]string(nil), spec.Grouping.Labels...)}
+	internalGrouping.Without = spec.Grouping.Without
+	finalGrouping := AggregationGrouping{
+		Labels:  append([]string(nil), spec.Grouping.Labels...),
+		Without: spec.Grouping.Without,
+	}
+	temporaryLabels := varianceTemporaryLabels(spec.Grouping, metadataLabels)
+	for _, label := range metadataLabels {
+		temporary := temporaryLabels[label]
+		input = `label_replace(` + input + `, "` + temporary + `", "$1", "` +
+			label + `", "(.*)")`
+		if spec.Grouping.Without {
+			finalGrouping.Labels = append(finalGrouping.Labels, temporary)
+		} else {
+			for i := range internalGrouping.Labels {
+				if internalGrouping.Labels[i] == label {
+					internalGrouping.Labels[i] = temporary
+				}
+			}
+		}
+	}
+	input = "clamp(" + input + ", -Inf, +Inf)"
+	result := formatAggregation(operator, internalGrouping, input)
+	for _, label := range metadataLabels {
+		temporary := temporaryLabels[label]
+		result = `label_replace(` + result + `, "` + label + `", "$1", "` +
+			temporary + `", "(.*)")`
+	}
+	if !slices.Contains(metadataLabels, promMetricNameLabel) {
+		// Restoring __name__ clears Prometheus' delayed metadata-drop marker.
+		// When only __type__/__unit__ are retained, use a temporary metric name
+		// and let the final aggregation remove it again.
+		result = `label_replace(` + result + `, "` + promMetricNameLabel + `", "` +
+			varianceTemporaryMetric + `", "` + promMetricNameLabel + `", ".*")`
+	}
+	return formatAggregation(aggregation.Sum, finalGrouping, result)
+}
+
+func varianceTemporaryLabels(grouping AggregationGrouping, metadataLabels []string) map[string]string {
+	used := make(map[string]struct{}, len(grouping.Labels)+len(metadataLabels))
+	for _, label := range grouping.Labels {
+		used[label] = struct{}{}
+	}
+	temporaryLabels := make(map[string]string, len(metadataLabels))
+	for _, label := range metadataLabels {
+		candidate := varianceMetadataLabels[label]
+		for {
+			if _, exists := used[candidate]; !exists {
+				break
+			}
+			candidate += "_"
+		}
+		temporaryLabels[label] = candidate
+		used[candidate] = struct{}{}
+	}
+	return temporaryLabels
+}
+
+func varianceGroupingMetadataLabels(grouping AggregationGrouping) []string {
+	if grouping.Without {
+		excluded := make(map[string]struct{}, len(grouping.Labels))
+		for _, label := range grouping.Labels {
+			excluded[label] = struct{}{}
+		}
+		labels := make([]string, 0, 2)
+		for _, label := range []string{promMetricTypeLabel, promMetricUnitLabel} {
+			if _, found := excluded[label]; !found {
+				labels = append(labels, label)
+			}
+		}
+		return labels
+	}
+	labels := make([]string, 0, len(varianceMetadataLabels))
+	for _, label := range grouping.Labels {
+		if _, ok := varianceMetadataLabels[label]; ok {
+			labels = append(labels, label)
+		}
+	}
+	return labels
+}
+
+func formatAggregation(operator string, grouping AggregationGrouping, input string) string {
+	if grouping.Without {
+		return operator + " without (" + strings.Join(grouping.Labels, ", ") + ") (" + input + ")"
+	}
+	if len(grouping.Labels) > 0 {
+		return operator + " by (" + strings.Join(grouping.Labels, ", ") + ") (" + input + ")"
+	}
+	return operator + "(" + input + ")"
+}

--- a/pkg/backends/prometheus/promql/variance_aggregation_test.go
+++ b/pkg/backends/prometheus/promql/variance_aggregation_test.go
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package promql
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/aggregation"
+)
+
+func TestParseVarianceAggregation(t *testing.T) {
+	tests := []struct {
+		query          string
+		operator       string
+		inner          string
+		grouping       AggregationGrouping
+		sortSet        bool
+		sortDescending bool
+	}{
+		{"stddev(up)", aggregation.StdDev, "up", AggregationGrouping{}, false, false},
+		{"STDVAR by (zone, job) (rate(x[5m]))", aggregation.StdVar, "rate(x[5m])",
+			AggregationGrouping{Labels: []string{"job", "zone"}}, false, false},
+		{"stddev(sum(x)) without (instance)", aggregation.StdDev, "sum(x)",
+			AggregationGrouping{Labels: []string{"instance"}, Without: true}, false, false},
+		{"sort(stdvar without () ({__name__=~\".+\"}))", aggregation.StdVar,
+			"{__name__=~\".+\"}", AggregationGrouping{Without: true}, true, false},
+		{"sort_desc(stddev by (__name__) (up))", aggregation.StdDev, "up",
+			AggregationGrouping{Labels: []string{"__name__"}}, true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			spec, found := ParseVarianceAggregation(tt.query)
+			if !found {
+				t.Fatal("expected variance aggregation")
+			}
+			if spec.Operator != tt.operator || spec.InnerQuery != tt.inner ||
+				spec.SortSet != tt.sortSet || spec.SortDescending != tt.sortDescending ||
+				!reflect.DeepEqual(spec.Grouping, tt.grouping) {
+				t.Fatalf("unexpected parse: %#v", spec)
+			}
+		})
+	}
+}
+
+func TestParseVarianceAggregationRejectsOtherShapes(t *testing.T) {
+	queries := []string{
+		"stddev_over_time(up[5m])",
+		"stddev(up) + vector(1)",
+		"stdvar()",
+		"stdvar(up, down)",
+		"stddev by job (up)",
+		"sort(sum(up))",
+		"sort_desc(stddev(up), down)",
+	}
+	for _, query := range queries {
+		t.Run(query, func(t *testing.T) {
+			if _, found := ParseVarianceAggregation(query); found {
+				t.Fatal("unexpected variance aggregation")
+			}
+		})
+	}
+}
+
+func TestVarianceVariantQuery(t *testing.T) {
+	tests := []struct {
+		query    string
+		operator string
+		want     string
+	}{
+		{
+			query:    "stddev(rate(requests_total[5m]))",
+			operator: aggregation.Count,
+			want:     "count(clamp(rate(requests_total[5m]), -Inf, +Inf))",
+		},
+		{
+			query:    "stdvar without (instance, pod) (up)",
+			operator: aggregation.Average,
+			want: "sum without (instance, pod, __trickster_tsm_type__, __trickster_tsm_unit__) " +
+				"(label_replace(label_replace(label_replace(avg without (instance, pod) " +
+				"(clamp(label_replace(label_replace(up, \"__trickster_tsm_type__\", \"$1\", " +
+				"\"__type__\", \"(.*)\"), \"__trickster_tsm_unit__\", \"$1\", \"__unit__\", " +
+				"\"(.*)\"), -Inf, +Inf)), \"__type__\", \"$1\", \"__trickster_tsm_type__\", " +
+				"\"(.*)\"), \"__unit__\", \"$1\", \"__trickster_tsm_unit__\", \"(.*)\"), " +
+				"\"__name__\", \"__trickster_tsm_variance__\", \"__name__\", \".*\"))",
+		},
+		{
+			query:    "stddev(up) by (zone)",
+			operator: aggregation.StdVar,
+			want:     "stdvar(clamp(up, -Inf, +Inf)) by (zone)",
+		},
+		{
+			query:    "stddev by (__name__, job) (rate(x[5m]))",
+			operator: aggregation.Count,
+			want: "sum by (__name__, job) (label_replace(count by (__trickster_tsm_name__, job) " +
+				"(clamp(label_replace(rate(x[5m]), \"__trickster_tsm_name__\", \"$1\", \"__name__\", \"(.*)\"), " +
+				"-Inf, +Inf)), \"__name__\", \"$1\", \"__trickster_tsm_name__\", \"(.*)\"))",
+		},
+		{
+			query:    "stdvar by (__type__, __unit__) (x)",
+			operator: aggregation.StdVar,
+			want: "sum by (__type__, __unit__) (label_replace(label_replace(label_replace(stdvar by " +
+				"(__trickster_tsm_type__, __trickster_tsm_unit__) (clamp(label_replace(label_replace(x, " +
+				"\"__trickster_tsm_type__\", \"$1\", \"__type__\", \"(.*)\"), \"__trickster_tsm_unit__\", " +
+				"\"$1\", \"__unit__\", \"(.*)\"), -Inf, +Inf)), \"__type__\", \"$1\", " +
+				"\"__trickster_tsm_type__\", \"(.*)\"), \"__unit__\", \"$1\", " +
+				"\"__trickster_tsm_unit__\", \"(.*)\"), \"__name__\", " +
+				"\"__trickster_tsm_variance__\", \"__name__\", \".*\"))",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.query+"/"+tt.operator, func(t *testing.T) {
+			spec, found := ParseVarianceAggregation(tt.query)
+			if !found {
+				t.Fatal("expected variance aggregation")
+			}
+			if got := VarianceVariantQuery(spec, tt.operator); got != tt.want {
+				t.Fatalf("unexpected query\n got: %s\nwant: %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVarianceVariantQueryAvoidsTemporaryLabelCollision(t *testing.T) {
+	const query = "stdvar by (__name__, __trickster_tsm_name__) (x)"
+	spec, found := ParseVarianceAggregation(query)
+	if !found {
+		t.Fatal("expected variance aggregation")
+	}
+	want := "sum by (__name__, __trickster_tsm_name__) (label_replace(count by " +
+		"(__trickster_tsm_name___, __trickster_tsm_name__) (clamp(label_replace(x, " +
+		"\"__trickster_tsm_name___\", \"$1\", \"__name__\", \"(.*)\"), -Inf, +Inf)), " +
+		"\"__name__\", \"$1\", \"__trickster_tsm_name___\", \"(.*)\"))"
+	if got := VarianceVariantQuery(spec, aggregation.Count); got != want {
+		t.Fatalf("unexpected query\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestVarianceVariantQueryWithoutPreservesNonExcludedMetadata(t *testing.T) {
+	tests := []struct {
+		query         string
+		wantTemporary string
+		reject        string
+	}{
+		{
+			query:         "stdvar without (__type__, instance) (x)",
+			wantTemporary: "__trickster_tsm_unit__",
+			reject:        "__trickster_tsm_type__",
+		},
+		{
+			query:         "stdvar without (__unit__, instance) (x)",
+			wantTemporary: "__trickster_tsm_type__",
+			reject:        "__trickster_tsm_unit__",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			spec, found := ParseVarianceAggregation(tt.query)
+			if !found {
+				t.Fatal("expected variance aggregation")
+			}
+			got := VarianceVariantQuery(spec, aggregation.Count)
+			if !strings.Contains(got, tt.wantTemporary) || strings.Contains(got, tt.reject) {
+				t.Fatalf("unexpected metadata rewrite: %s", got)
+			}
+		})
+	}
+}

--- a/pkg/backends/prometheus/tsm_provider.go
+++ b/pkg/backends/prometheus/tsm_provider.go
@@ -124,17 +124,13 @@ func (c *Client) planVariance(r *http.Request, query string,
 			return nil, false, nil
 		}
 
-		if innerAggregation == aggregation.Sum || innerAggregation == aggregation.Average {
-			// These aggregators may produce native histograms. The numeric TSM
-			// reducers cannot preserve their cross-shard semantics, even though
-			// the outer variance aggregation ultimately ignores histograms.
-			return nil, false, nil
-		}
-
 		strategy := int(merge.StrategyDedup)
 		switch innerAggregation {
-		case aggregation.Count, aggregation.CountValues:
+		case aggregation.Sum, aggregation.Count, aggregation.CountValues:
 			strategy = int(merge.StrategySum)
+		case aggregation.Average:
+			plan, err := weightedAveragePlan(r, query, spec.InnerQuery, finalizer, true)
+			return plan, true, err
 		case aggregation.Minimum:
 			strategy = int(merge.StrategyMin)
 		case aggregation.Maximum:

--- a/pkg/backends/prometheus/tsm_provider.go
+++ b/pkg/backends/prometheus/tsm_provider.go
@@ -45,6 +45,11 @@ func (c *Client) PlanTSMMerge(r *http.Request, query string) (*merge.TSMMergePla
 	if spec, found := promql.ParseLimitRatioAggregation(query); found {
 		return c.planLimitRatio(r, query, spec)
 	}
+	if spec, found := promql.ParseVarianceAggregation(query); found {
+		if plan, handled, err := c.planVariance(r, query, spec); handled || err != nil {
+			return plan, err
+		}
+	}
 	fanoutQuery, rewritten := tsmInnerQuery(query)
 	finalizer := tsmFinalizer(query)
 
@@ -100,6 +105,117 @@ func (c *Client) PlanTSMMerge(r *http.Request, query string) (*merge.TSMMergePla
 		UnsupportedWarning: unsupportedWarning,
 	}
 	plan.AllowSingleMemberBypass = !rewritten && !finalizer.Enabled && unsupportedWarning == ""
+	if err := plan.Validate(); err != nil {
+		return nil, err
+	}
+	return plan, nil
+}
+
+func (c *Client) planVariance(r *http.Request, query string,
+	spec promql.VarianceAggregation,
+) (*merge.TSMMergePlan, bool, error) {
+	finalizer := merge.TSMFinalizerSpec{Enabled: true, Query: query}
+	if innerAggregation, aggregationInput, found := promql.CompleteOuterAggregation(spec.InnerQuery); found {
+		if promql.ContainsAggregator(aggregationInput) ||
+			promql.ContainsBinaryExpression(aggregationInput) {
+			return nil, false, nil
+		}
+		if _, found := promql.NonShardLocalFunction(aggregationInput); found {
+			return nil, false, nil
+		}
+
+		if innerAggregation == aggregation.Sum || innerAggregation == aggregation.Average {
+			// These aggregators may produce native histograms. The numeric TSM
+			// reducers cannot preserve their cross-shard semantics, even though
+			// the outer variance aggregation ultimately ignores histograms.
+			return nil, false, nil
+		}
+
+		strategy := int(merge.StrategyDedup)
+		switch innerAggregation {
+		case aggregation.Count, aggregation.CountValues:
+			strategy = int(merge.StrategySum)
+		case aggregation.Minimum:
+			strategy = int(merge.StrategyMin)
+		case aggregation.Maximum:
+			strategy = int(merge.StrategyMax)
+		case aggregation.Group:
+		default:
+			return nil, false, nil
+		}
+
+		variantRequest, err := rewritePromQueryParam(r, spec.InnerQuery)
+		if err != nil {
+			return nil, true, fmt.Errorf("prepare tsm primary variant: %w", err)
+		}
+		plan := &merge.TSMMergePlan{
+			OriginalQuery: query,
+			Variants: []merge.TSMQueryVariant{{
+				Name:              merge.TSMVariantPrimary,
+				Request:           variantRequest,
+				MergeStrategy:     strategy,
+				ResponseAuthority: true,
+			}},
+			Reduction: merge.TSMReductionSpec{
+				Kind:          merge.TSMReductionStandard,
+				InputVariants: merge.TSMReductionPrimaryVariant(),
+			},
+			Finalizer:           finalizer,
+			Completeness:        merge.TSMCompletenessResponseAuthority,
+			StripInjectedLabels: true,
+		}
+		if err := plan.Validate(); err != nil {
+			return nil, true, err
+		}
+		return plan, true, nil
+	}
+
+	if promql.ContainsAggregator(spec.InnerQuery) ||
+		promql.ContainsBinaryExpression(spec.InnerQuery) {
+		return nil, false, nil
+	}
+	if _, found := promql.NonShardLocalFunction(spec.InnerQuery); found {
+		return nil, false, nil
+	}
+
+	plan, err := pooledVariancePlan(r, query, spec)
+	return plan, true, err
+}
+
+func pooledVariancePlan(r *http.Request, originalQuery string,
+	spec promql.VarianceAggregation,
+) (*merge.TSMMergePlan, error) {
+	variantNames := merge.TSMReductionPooledVarianceVariants()
+	operators := []string{aggregation.Count, aggregation.Average, aggregation.StdVar}
+	variants := make([]merge.TSMQueryVariant, len(variantNames))
+	for i, name := range variantNames {
+		variantQuery := promql.VarianceVariantQuery(spec, operators[i])
+		variantRequest, err := rewritePromQueryParam(r, variantQuery)
+		if err != nil {
+			return nil, fmt.Errorf("prepare tsm %s variant: %w", name, err)
+		}
+		variants[i] = merge.TSMQueryVariant{
+			Name:              name,
+			Request:           variantRequest,
+			MergeStrategy:     int(merge.StrategyDedup),
+			ResponseAuthority: i == 0,
+		}
+	}
+
+	plan := &merge.TSMMergePlan{
+		OriginalQuery: originalQuery,
+		Variants:      variants,
+		Reduction: merge.TSMReductionSpec{
+			Kind:          merge.TSMReductionPooledVariance,
+			InputVariants: variantNames,
+		},
+		Finalizer: merge.TSMFinalizerSpec{
+			Enabled: true,
+			Query:   originalQuery,
+		},
+		Completeness:        merge.TSMCompletenessAllVariants,
+		StripInjectedLabels: true,
+	}
 	if err := plan.Validate(); err != nil {
 		return nil, err
 	}

--- a/pkg/backends/prometheus/tsm_provider_test.go
+++ b/pkg/backends/prometheus/tsm_provider_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/trickstercache/trickster/v2/pkg/backends/prometheus/promql"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/params"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
@@ -38,6 +39,7 @@ func TestPlanTSMMergeStrategies(t *testing.T) {
 	const (
 		standard = merge.TSMReductionStandard
 		weighted = merge.TSMReductionWeightedAverage
+		pooled   = merge.TSMReductionPooledVariance
 	)
 	tests := []struct {
 		query          string
@@ -89,12 +91,24 @@ func TestPlanTSMMergeStrategies(t *testing.T) {
 		{"sort(min(up))", int(merge.StrategyMin), standard, ""},
 		{"sort_desc(max(up))", int(merge.StrategyMax), standard, ""},
 		{"sort(up)", int(merge.StrategyDedup), standard, ""},
+		// Float-only stddev/stdvar use paired count, mean, and variance inputs.
+		{"stddev(up)", int(merge.StrategyDedup), pooled, ""},
+		{"stdvar without (instance) (rate(requests[5m]))", int(merge.StrategyDedup), pooled, ""},
+		{"sort_desc(stddev by (job) (up))", int(merge.StrategyDedup), pooled, ""},
+		// Numeric-compatible inner aggregations are completed globally before
+		// the outer variance aggregation is finalized.
+		{"stddev(count by (service) (requests))", int(merge.StrategySum), standard, ""},
+		{"stddev(min(requests))", int(merge.StrategyMin), standard, ""},
+		{"stdvar(max(requests))", int(merge.StrategyMax), standard, ""},
+		{"stddev(group by (service) (requests))", int(merge.StrategyDedup), standard, ""},
 		// Unsupported aggregations fall back to deduplication with a warning.
-		{"stddev(up)", int(merge.StrategyDedup), standard, aggregation.StdDev},
-		{"stdvar(up)", int(merge.StrategyDedup), standard, aggregation.StdVar},
+		{"stddev(sum by (service) (requests))", int(merge.StrategyDedup), standard, aggregation.StdDev},
+		{"stdvar(avg by (service) (requests))", int(merge.StrategyDedup), standard, aggregation.StdVar},
+		{"stddev(up + down)", int(merge.StrategyDedup), standard, aggregation.StdDev},
+		{"stdvar(rate(sum(up)[5m:]))", int(merge.StrategyDedup), standard, aggregation.StdVar},
+		{"stddev(stdvar(up))", int(merge.StrategyDedup), standard, aggregation.StdDev},
 		{"quantile(0.9, up)", int(merge.StrategyDedup), standard, aggregation.Quantile},
 		{"topk(5, stddev(up))", int(merge.StrategyDedup), standard, aggregation.StdDev},
-		{"sort_desc(stddev(up))", int(merge.StrategyDedup), standard, aggregation.StdDev},
 		{"topk(k, up)", int(merge.StrategyDedup), standard, aggregation.TopK},
 		{"limitk(5, up)", int(merge.StrategyDedup), standard, aggregation.LimitK},
 		{"limit_ratio(0.5, stddev(up))", int(merge.StrategyDedup), standard, aggregation.StdDev},
@@ -122,8 +136,11 @@ func TestPlanTSMMergeStrategies(t *testing.T) {
 				t.Fatalf("Validate: %v", err)
 			}
 			wantVariants := 1
-			if test.wantReduction == weighted {
+			switch test.wantReduction {
+			case weighted:
 				wantVariants = 2
+			case pooled:
+				wantVariants = 3
 			}
 			if len(plan.Variants) != wantVariants {
 				t.Fatalf("variant count: got %d want %d", len(plan.Variants), wantVariants)
@@ -233,7 +250,7 @@ func TestPlanTSMMergeContents(t *testing.T) {
 	})
 
 	t.Run("unsupported fallback", func(t *testing.T) {
-		const query = "stddev(up)"
+		const query = "stddev(up + down)"
 		r, _ := http.NewRequest(http.MethodGet,
 			"http://example.com/api/v1/query?query="+url.QueryEscape(query), nil)
 		plan := mustTSMMergePlan(t, r, query)
@@ -247,6 +264,155 @@ func TestPlanTSMMergeContents(t *testing.T) {
 			t.Fatal("unsupported fallback allowed a single-member bypass")
 		}
 	})
+}
+
+func TestPlanTSMMergeVarianceContents(t *testing.T) {
+	t.Run("pooled float-only variants", func(t *testing.T) {
+		const query = "sort_desc(stddev without (instance) (rate(requests[5m])))"
+		r, _ := http.NewRequest(http.MethodGet,
+			"http://example.com/api/v1/query?query="+url.QueryEscape(query), nil)
+		plan := mustTSMMergePlan(t, r, query)
+
+		if plan.Reduction.Kind != merge.TSMReductionPooledVariance || len(plan.Variants) != 3 {
+			t.Fatalf("pooled plan: %#v", plan)
+		}
+		spec, found := promql.ParseVarianceAggregation(query)
+		if !found {
+			t.Fatal("expected variance aggregation")
+		}
+		wantNames := merge.TSMReductionPooledVarianceVariants()
+		wantQueries := []string{
+			promql.VarianceVariantQuery(spec, aggregation.Count),
+			promql.VarianceVariantQuery(spec, aggregation.Average),
+			promql.VarianceVariantQuery(spec, aggregation.StdVar),
+		}
+		for i, variant := range plan.Variants {
+			values, _, _ := params.GetRequestValues(variant.Request)
+			if variant.Name != wantNames[i] || values.Get(promQueryParam) != wantQueries[i] {
+				t.Fatalf("variant %d: name=%q query=%q", i, variant.Name,
+					values.Get(promQueryParam))
+			}
+			if variant.MergeStrategy != int(merge.StrategyDedup) {
+				t.Fatalf("variant %d strategy: %d", i, variant.MergeStrategy)
+			}
+			if variant.ResponseAuthority != (i == 0) {
+				t.Fatalf("variant %d authority: %v", i, variant.ResponseAuthority)
+			}
+		}
+		if !plan.Finalizer.Enabled || plan.Finalizer.Query != query ||
+			plan.Completeness != merge.TSMCompletenessAllVariants ||
+			!plan.StripInjectedLabels || plan.AllowSingleMemberBypass {
+			t.Fatalf("pooled metadata: %#v", plan)
+		}
+	})
+
+	t.Run("metric name grouping survives float filter", func(t *testing.T) {
+		const query = "stdvar by (__name__, job) (up)"
+		r, _ := http.NewRequest(http.MethodGet,
+			"http://example.com/api/v1/query?query="+url.QueryEscape(query), nil)
+		plan := mustTSMMergePlan(t, r, query)
+		values, _, _ := params.GetRequestValues(plan.Variants[0].Request)
+		got := values.Get(promQueryParam)
+		for _, required := range []string{
+			"clamp(", "__trickster_tsm_name__", "label_replace(", "sum by (__name__, job)",
+		} {
+			if !strings.Contains(got, required) {
+				t.Fatalf("query %q does not contain %q", got, required)
+			}
+		}
+	})
+
+	t.Run("globally merged inner count", func(t *testing.T) {
+		const (
+			query = "stddev by (region) (count by (service) (requests))"
+			inner = "count by (service) (requests)"
+		)
+		r, _ := http.NewRequest(http.MethodGet,
+			"http://example.com/api/v1/query?query="+url.QueryEscape(query), nil)
+		plan := mustTSMMergePlan(t, r, query)
+		values, _, _ := params.GetRequestValues(plan.Variants[0].Request)
+		if got := values.Get(promQueryParam); got != inner {
+			t.Fatalf("fanout query got %q want %q", got, inner)
+		}
+		if plan.Reduction.Kind != merge.TSMReductionStandard ||
+			plan.Variants[0].MergeStrategy != int(merge.StrategySum) ||
+			!plan.Finalizer.Enabled || !plan.StripInjectedLabels {
+			t.Fatalf("inner count plan: %#v", plan)
+		}
+	})
+
+	t.Run("histogram-capable inner aggregations keep fallback", func(t *testing.T) {
+		for _, query := range []string{
+			"stddev(sum by (service) (requests))",
+			"stdvar(avg by (service) (requests))",
+		} {
+			t.Run(query, func(t *testing.T) {
+				r, _ := http.NewRequest(http.MethodGet,
+					"http://example.com/api/v1/query?query="+url.QueryEscape(query), nil)
+				plan := mustTSMMergePlan(t, r, query)
+				values, _, _ := params.GetRequestValues(plan.Variants[0].Request)
+				if got := values.Get(promQueryParam); got != query {
+					t.Fatalf("fallback query got %q want %q", got, query)
+				}
+				if plan.Reduction.Kind != merge.TSMReductionStandard ||
+					len(plan.Variants) != 1 ||
+					!strings.Contains(plan.UnsupportedWarning, "cannot be correctly merged") {
+					t.Fatalf("fallback plan: %#v", plan)
+				}
+			})
+		}
+	})
+
+	t.Run("unsupported sorted binary expression keeps fallback", func(t *testing.T) {
+		const query = "sort(stddev(up + down))"
+		r, _ := http.NewRequest(http.MethodGet,
+			"http://example.com/api/v1/query?query="+url.QueryEscape(query), nil)
+		plan := mustTSMMergePlan(t, r, query)
+		values, _, _ := params.GetRequestValues(plan.Variants[0].Request)
+		if got := values.Get(promQueryParam); got != "stddev(up + down)" {
+			t.Fatalf("fallback query got %q", got)
+		}
+		if plan.Reduction.Kind != merge.TSMReductionStandard ||
+			!strings.Contains(plan.UnsupportedWarning, aggregation.StdDev) ||
+			!plan.Finalizer.Enabled {
+			t.Fatalf("fallback plan: %#v", plan)
+		}
+	})
+}
+
+func TestPlanTSMMergeVariancePOST(t *testing.T) {
+	const (
+		query    = "stddev by (job) (rate(requests[5m]))"
+		origBody = "query=stddev+by+%28job%29+%28rate%28requests%5B5m%5D%29%29&time=1000"
+	)
+	r, _ := http.NewRequest(http.MethodPost, "http://example.com/api/v1/query",
+		io.NopCloser(bytes.NewBufferString(origBody)))
+	r.Header.Set(headers.NameContentType, headers.ValueXFormURLEncoded)
+	r = request.SetResources(r, &request.Resources{RequestBody: []byte(origBody)})
+
+	plan := mustTSMMergePlan(t, r, query)
+	want := []string{
+		"count by (job) (clamp(rate(requests[5m]), -Inf, +Inf))",
+		"avg by (job) (clamp(rate(requests[5m]), -Inf, +Inf))",
+		"stdvar by (job) (clamp(rate(requests[5m]), -Inf, +Inf))",
+	}
+	for i, variant := range plan.Variants {
+		values, _, _ := params.GetRequestValues(variant.Request)
+		if got := values.Get(promQueryParam); got != want[i] {
+			t.Fatalf("variant %d values query got %q want %q", i, got, want[i])
+		}
+		body, err := io.ReadAll(variant.Request.Body)
+		if err != nil {
+			t.Fatalf("variant %d read body: %v", i, err)
+		}
+		bodyValues, err := url.ParseQuery(string(body))
+		if err != nil {
+			t.Fatalf("variant %d parse body: %v", i, err)
+		}
+		if got := bodyValues.Get(promQueryParam); got != want[i] {
+			t.Fatalf("variant %d body query got %q want %q", i, got, want[i])
+		}
+	}
 }
 
 func TestPlanTSMMergeLimitRatioContents(t *testing.T) {

--- a/pkg/backends/prometheus/tsm_provider_test.go
+++ b/pkg/backends/prometheus/tsm_provider_test.go
@@ -102,8 +102,8 @@ func TestPlanTSMMergeStrategies(t *testing.T) {
 		{"stdvar(max(requests))", int(merge.StrategyMax), standard, ""},
 		{"stddev(group by (service) (requests))", int(merge.StrategyDedup), standard, ""},
 		// Unsupported aggregations fall back to deduplication with a warning.
-		{"stddev(sum by (service) (requests))", int(merge.StrategyDedup), standard, aggregation.StdDev},
-		{"stdvar(avg by (service) (requests))", int(merge.StrategyDedup), standard, aggregation.StdVar},
+		{"stddev(sum by (service) (requests))", int(merge.StrategySum), standard, ""},
+		{"stdvar(avg by (service) (requests))", int(merge.StrategySum), weighted, ""},
 		{"stddev(up + down)", int(merge.StrategyDedup), standard, aggregation.StdDev},
 		{"stdvar(rate(sum(up)[5m:]))", int(merge.StrategyDedup), standard, aggregation.StdVar},
 		{"stddev(stdvar(up))", int(merge.StrategyDedup), standard, aggregation.StdDev},
@@ -341,23 +341,44 @@ func TestPlanTSMMergeVarianceContents(t *testing.T) {
 		}
 	})
 
-	t.Run("histogram-capable inner aggregations keep fallback", func(t *testing.T) {
-		for _, query := range []string{
-			"stddev(sum by (service) (requests))",
-			"stdvar(avg by (service) (requests))",
-		} {
-			t.Run(query, func(t *testing.T) {
+	t.Run("histogram-capable inner aggregations use exact plans", func(t *testing.T) {
+		tests := []struct {
+			query       string
+			variants    int
+			reduction   merge.TSMReductionKind
+			wantQueries []string
+		}{
+			{
+				query:       "stddev(sum by (service) (requests))",
+				variants:    1,
+				reduction:   merge.TSMReductionStandard,
+				wantQueries: []string{"sum by (service) (requests)"},
+			},
+			{
+				query:       "stdvar(avg by (service) (requests))",
+				variants:    2,
+				reduction:   merge.TSMReductionWeightedAverage,
+				wantQueries: []string{"sum by (service) (requests)", "count by (service) (requests)"},
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.query, func(t *testing.T) {
 				r, _ := http.NewRequest(http.MethodGet,
-					"http://example.com/api/v1/query?query="+url.QueryEscape(query), nil)
-				plan := mustTSMMergePlan(t, r, query)
-				values, _, _ := params.GetRequestValues(plan.Variants[0].Request)
-				if got := values.Get(promQueryParam); got != query {
-					t.Fatalf("fallback query got %q want %q", got, query)
+					"http://example.com/api/v1/query?query="+url.QueryEscape(test.query), nil)
+				plan := mustTSMMergePlan(t, r, test.query)
+				if len(plan.Variants) != test.variants ||
+					plan.Reduction.Kind != test.reduction ||
+					!plan.Finalizer.Enabled || plan.UnsupportedWarning != "" {
+					t.Fatalf("exact plan: %#v", plan)
 				}
-				if plan.Reduction.Kind != merge.TSMReductionStandard ||
-					len(plan.Variants) != 1 ||
-					!strings.Contains(plan.UnsupportedWarning, "cannot be correctly merged") {
-					t.Fatalf("fallback plan: %#v", plan)
+				for i, wantQuery := range test.wantQueries {
+					values, _, _ := params.GetRequestValues(plan.Variants[i].Request)
+					if got := values.Get(promQueryParam); got != wantQuery {
+						t.Fatalf("variant %d query got %q want %q", i, got, wantQuery)
+					}
+					if plan.Variants[i].MergeStrategy != int(merge.StrategySum) {
+						t.Fatalf("variant %d strategy: %d", i, plan.Variants[i].MergeStrategy)
+					}
 				}
 			})
 		}

--- a/pkg/backends/prometheus/tsm_rank_finalize.go
+++ b/pkg/backends/prometheus/tsm_rank_finalize.go
@@ -134,6 +134,10 @@ func (c *Client) FinalizeTSMMerge(query string, ts timeseries.Timeseries) {
 		finalizeLimitRatio(ds, spec)
 		return
 	}
+	if spec, found := promql.ParseVarianceAggregation(query); found {
+		finalizeVarianceAggregation(ds, spec)
+		return
+	}
 	if spec, found := promql.ParseRankAggregation(query); found {
 		finalizeRankAggregation(ds, spec)
 		return

--- a/pkg/backends/prometheus/tsm_variance_finalize.go
+++ b/pkg/backends/prometheus/tsm_variance_finalize.go
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus
+
+import (
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/trickstercache/trickster/v2/pkg/backends/prometheus/promql"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/aggregation"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/epoch"
+)
+
+const invalidPooledVarianceWarning = "trickster: pooled-variance finalization dropped an invalid intermediate point"
+
+type varianceFinalizeGroup struct {
+	header dataset.SeriesHeader
+	states map[epoch.Epoch]dataset.PooledVarianceState
+}
+
+func finalizeVarianceAggregation(ds *dataset.DataSet, spec promql.VarianceAggregation) {
+	isRangeQuery := ds.Step() > 0
+	ds.UpdateLock.Lock()
+	defer ds.UpdateLock.Unlock()
+
+	switch {
+	case hasPooledVarianceState(ds):
+		finalizePooledVarianceStates(ds, spec.Operator)
+	case isCentralVarianceInput(ds, spec):
+		finalizeCentralVariance(ds, spec)
+	default:
+		// Unsupported variance shapes retain the established per-shard fallback.
+		// A sort wrapper still needs its normal global output handling.
+	}
+
+	if !spec.SortSet {
+		return
+	}
+	if isRangeQuery {
+		appendWarningOnce(ds, sortInRangeQueryWarning)
+	}
+	for _, result := range ds.Results {
+		if result == nil {
+			continue
+		}
+		result.SeriesList = filterHistogramSeries(result.SeriesList)
+		if !isRangeQuery {
+			sortInstantSeries(result.SeriesList, spec.SortDescending)
+		}
+	}
+}
+
+func hasPooledVarianceState(ds *dataset.DataSet) bool {
+	for _, result := range ds.Results {
+		if result == nil {
+			continue
+		}
+		for _, series := range result.SeriesList {
+			if series == nil {
+				continue
+			}
+			for _, point := range series.Points {
+				if len(point.Values) == 0 {
+					continue
+				}
+				if _, ok := point.Values[0].(dataset.PooledVarianceState); ok {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func finalizePooledVarianceStates(ds *dataset.DataSet, operator string) {
+	for _, result := range ds.Results {
+		if result == nil {
+			continue
+		}
+		keptSeries := result.SeriesList[:0]
+		for _, series := range result.SeriesList {
+			if series == nil {
+				continue
+			}
+			keptPoints := series.Points[:0]
+			for _, point := range series.Points {
+				if len(point.Values) == 0 {
+					appendWarningOnce(ds, invalidPooledVarianceWarning)
+					continue
+				}
+				state, ok := point.Values[0].(dataset.PooledVarianceState)
+				if !ok || state.Count <= 0 || math.IsNaN(state.Count) || math.IsInf(state.Count, 0) {
+					appendWarningOnce(ds, invalidPooledVarianceWarning)
+					continue
+				}
+				value := varianceFinalValue(state, operator)
+				formatted := strconv.FormatFloat(value, 'f', -1, 64)
+				point.Values[0] = formatted
+				point.Size = len(formatted) + 32
+				keptPoints = append(keptPoints, point)
+			}
+			if len(keptPoints) == 0 {
+				continue
+			}
+			series.Points = keptPoints
+			series.PointSize = keptPoints.Size()
+			keptSeries = append(keptSeries, series)
+		}
+		result.SeriesList = keptSeries
+	}
+}
+
+func isCentralVarianceInput(ds *dataset.DataSet, spec promql.VarianceAggregation) bool {
+	// A supported nested plan fans out spec.InnerQuery. The legacy sorted
+	// fallback fans out the outer variance aggregation instead, so its statement
+	// must not be aggregated a second time.
+	candidates := map[string]struct{}{strings.TrimSpace(spec.InnerQuery): {}}
+	if ds.TimeRangeQuery != nil {
+		if _, found := candidates[strings.TrimSpace(ds.TimeRangeQuery.Statement)]; found {
+			return true
+		}
+	}
+	for _, result := range ds.Results {
+		if result == nil {
+			continue
+		}
+		for _, series := range result.SeriesList {
+			if series == nil {
+				continue
+			}
+			if _, found := candidates[strings.TrimSpace(series.Header.QueryStatement)]; found {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func finalizeCentralVariance(ds *dataset.DataSet, spec promql.VarianceAggregation) {
+	for _, result := range ds.Results {
+		if result == nil {
+			continue
+		}
+		groups := make(map[string]*varianceFinalizeGroup)
+		groupOrder := make([]string, 0)
+		for _, series := range result.SeriesList {
+			if series == nil || isHistogramSeries(series) {
+				continue
+			}
+			tags := varianceGroupingTags(series.Header.Tags, spec.Grouping)
+			key := tags.JSON()
+			group := groups[key]
+			if group == nil {
+				header := series.Header.Clone()
+				header.Tags = tags
+				header.Name = tags["__name__"]
+				header.TagFieldsList = nil
+				header.QueryStatement = spec.AggregationQuery
+				header.CalculateHash(true)
+				header.CalculateSize()
+				group = &varianceFinalizeGroup{
+					header: header,
+					states: make(map[epoch.Epoch]dataset.PooledVarianceState),
+				}
+				groups[key] = group
+				groupOrder = append(groupOrder, key)
+			}
+			for _, point := range series.Points {
+				value, ok := variancePointFloat(point)
+				if !ok {
+					continue
+				}
+				group.states[point.Epoch] = group.states[point.Epoch].Add(value)
+			}
+		}
+
+		output := make(dataset.SeriesList, 0, len(groupOrder))
+		for _, key := range groupOrder {
+			group := groups[key]
+			epochs := make([]epoch.Epoch, 0, len(group.states))
+			for pointEpoch := range group.states {
+				epochs = append(epochs, pointEpoch)
+			}
+			slices.Sort(epochs)
+			points := make(dataset.Points, 0, len(epochs))
+			for _, pointEpoch := range epochs {
+				formatted := strconv.FormatFloat(
+					varianceFinalValue(group.states[pointEpoch], spec.Operator), 'f', -1, 64,
+				)
+				points = append(points, dataset.Point{
+					Epoch:  pointEpoch,
+					Size:   len(formatted) + 32,
+					Values: []any{formatted},
+				})
+			}
+			if len(points) == 0 {
+				continue
+			}
+			output = append(output, &dataset.Series{
+				Header:    group.header,
+				Points:    points,
+				PointSize: points.Size(),
+			})
+		}
+		result.SeriesList = output
+	}
+}
+
+func varianceGroupingTags(tags dataset.Tags, grouping promql.AggregationGrouping) dataset.Tags {
+	if grouping.Without {
+		output := tags.Clone()
+		delete(output, "__name__")
+		for _, label := range grouping.Labels {
+			delete(output, label)
+		}
+		return output
+	}
+	output := make(dataset.Tags, len(grouping.Labels))
+	for _, label := range grouping.Labels {
+		if value, found := tags[label]; found && value != "" {
+			output[label] = value
+		}
+	}
+	return output
+}
+
+func variancePointFloat(point dataset.Point) (float64, bool) {
+	if len(point.Values) == 0 {
+		return 0, false
+	}
+	switch value := point.Values[0].(type) {
+	case string:
+		parsed, err := strconv.ParseFloat(value, 64)
+		return parsed, err == nil
+	case float64:
+		return value, true
+	case float32:
+		return float64(value), true
+	default:
+		return 0, false
+	}
+}
+
+func varianceFinalValue(state dataset.PooledVarianceState, operator string) float64 {
+	variance := state.PopulationVariance()
+	if operator == aggregation.StdDev {
+		return math.Sqrt(variance)
+	}
+	return variance
+}

--- a/pkg/backends/prometheus/tsm_variance_finalize_test.go
+++ b/pkg/backends/prometheus/tsm_variance_finalize_test.go
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus
+
+import (
+	"math"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/epoch"
+)
+
+func varianceFinalizeSeries(tags dataset.Tags, query string, valuesAndEpochs ...any) *dataset.Series {
+	points := make(dataset.Points, 0, len(valuesAndEpochs)/2)
+	for i := 0; i+1 < len(valuesAndEpochs); i += 2 {
+		value := valuesAndEpochs[i]
+		points = append(points, dataset.Point{
+			Epoch:  epoch.Epoch(valuesAndEpochs[i+1].(int64)),
+			Size:   32,
+			Values: []any{value},
+		})
+	}
+	return &dataset.Series{
+		Header: dataset.SeriesHeader{
+			Name:            tags["__name__"],
+			Tags:            tags,
+			QueryStatement:  query,
+			ValueFieldsList: timeseries.FieldDefinitions{{Name: "value", DataType: timeseries.String}},
+		},
+		Points: points,
+	}
+}
+
+func varianceFinalizeDataSet(query string, series ...*dataset.Series) *dataset.DataSet {
+	return &dataset.DataSet{
+		TimeRangeQuery: &timeseries.TimeRangeQuery{Statement: query},
+		Results: dataset.Results{{
+			SeriesList: series,
+		}},
+	}
+}
+
+func TestFinalizeTSMMergePooledVariance(t *testing.T) {
+	makeDataSet := func(state dataset.PooledVarianceState) *dataset.DataSet {
+		return varianceFinalizeDataSet("stdvar by (job) (up)",
+			varianceFinalizeSeries(dataset.Tags{"job": "api"}, "stdvar by (job) (up)",
+				state, int64(100)),
+		)
+	}
+
+	t.Run("stdvar", func(t *testing.T) {
+		ds := makeDataSet(dataset.PooledVarianceState{Count: 5, Mean: 5, M2: 40})
+		(&Client{}).FinalizeTSMMerge("stdvar by (job) (up)", ds)
+		if got := ds.Results[0].SeriesList[0].Points[0].Values[0]; got != "8" {
+			t.Fatalf("value got %v", got)
+		}
+	})
+
+	t.Run("stddev", func(t *testing.T) {
+		ds := makeDataSet(dataset.PooledVarianceState{Count: 5, Mean: 5, M2: 40})
+		(&Client{}).FinalizeTSMMerge("stddev by (job) (up)", ds)
+		got, _ := strconv.ParseFloat(ds.Results[0].SeriesList[0].Points[0].Values[0].(string), 64)
+		if math.Abs(got-math.Sqrt(8)) > 1e-15 {
+			t.Fatalf("value got %.17g", got)
+		}
+	})
+
+	t.Run("singleton and special values", func(t *testing.T) {
+		series := varianceFinalizeSeries(dataset.Tags{"job": "api"}, "stdvar(up)",
+			dataset.PooledVarianceState{Count: 1, Mean: -3, M2: 0}, int64(100),
+			dataset.PooledVarianceState{Count: 2, Mean: math.NaN(), M2: math.NaN()}, int64(200),
+			dataset.PooledVarianceState{Count: 2, Mean: 0, M2: math.Inf(1)}, int64(300),
+		)
+		ds := varianceFinalizeDataSet("stdvar(up)", series)
+		(&Client{}).FinalizeTSMMerge("stdvar(up)", ds)
+		got := ds.Results[0].SeriesList[0].Points
+		if got[0].Values[0] != "0" || got[1].Values[0] != "NaN" || got[2].Values[0] != "+Inf" {
+			t.Fatalf("values: %#v", got)
+		}
+	})
+
+	t.Run("sort wrapper orders finalized states", func(t *testing.T) {
+		ds := varianceFinalizeDataSet("stdvar by (job) (up)",
+			varianceFinalizeSeries(dataset.Tags{"job": "small"}, "stdvar by (job) (up)",
+				dataset.PooledVarianceState{Count: 2, Mean: 0, M2: 2}, int64(100)),
+			varianceFinalizeSeries(dataset.Tags{"job": "large"}, "stdvar by (job) (up)",
+				dataset.PooledVarianceState{Count: 2, Mean: 0, M2: 18}, int64(100)),
+		)
+		(&Client{}).FinalizeTSMMerge("sort_desc(stdvar by (job) (up))", ds)
+		if got := ds.Results[0].SeriesList; len(got) != 2 ||
+			got[0].Header.Tags["job"] != "large" || got[1].Header.Tags["job"] != "small" {
+			t.Fatalf("sort order: %#v", got)
+		}
+	})
+}
+
+func TestFinalizeTSMMergeCentralVariance(t *testing.T) {
+	const inner = "count by (instance, region) (requests)"
+	floatA := varianceFinalizeSeries(dataset.Tags{
+		"__name__": "requests", "instance": "a", "region": "east",
+	}, inner, "1", int64(100), "2", int64(200))
+	floatB := varianceFinalizeSeries(dataset.Tags{
+		"__name__": "requests", "instance": "b", "region": "east",
+	}, inner, "3", int64(100), "4", int64(200))
+	floatC := varianceFinalizeSeries(dataset.Tags{
+		"__name__": "requests", "instance": "c", "region": "east",
+	}, inner, "5", int64(100))
+	histogram := varianceFinalizeSeries(dataset.Tags{
+		"__name__": "requests", "instance": "hist", "region": "east",
+	}, inner, `{"count":"100","sum":"1000"}`, int64(100))
+	histogram.Header.ValueFieldsList[0].Name = histogramFieldName
+	ds := varianceFinalizeDataSet(inner, floatA, histogram, floatB, floatC)
+
+	(&Client{}).FinalizeTSMMerge("stdvar by (region) ("+inner+")", ds)
+	if len(ds.Results[0].SeriesList) != 1 {
+		t.Fatalf("series: %#v", ds.Results[0].SeriesList)
+	}
+	series := ds.Results[0].SeriesList[0]
+	if got := series.Header.Tags.JSON(); got != `{"region":"east"}` {
+		t.Fatalf("tags: %s", got)
+	}
+	if len(series.Points) != 2 || series.Points[0].Epoch != 100 || series.Points[1].Epoch != 200 {
+		t.Fatalf("points: %#v", series.Points)
+	}
+	first, _ := strconv.ParseFloat(series.Points[0].Values[0].(string), 64)
+	second, _ := strconv.ParseFloat(series.Points[1].Values[0].(string), 64)
+	if math.Abs(first-8.0/3.0) > 1e-15 || second != 1 {
+		t.Fatalf("values got %.17g and %.17g", first, second)
+	}
+}
+
+func TestFinalizeTSMMergeVarianceGroupingAndSort(t *testing.T) {
+	const inner = "count without (shard) (requests)"
+	series := []*dataset.Series{
+		varianceFinalizeSeries(dataset.Tags{"instance": "a", "region": "east", "job": "api",
+			"__type__": "gauge", "__unit__": "requests"}, inner,
+			"1", int64(100)),
+		varianceFinalizeSeries(dataset.Tags{"instance": "b", "region": "east", "job": "api",
+			"__type__": "gauge", "__unit__": "requests"}, inner,
+			"3", int64(100)),
+		varianceFinalizeSeries(dataset.Tags{"instance": "a", "region": "west", "job": "api",
+			"__type__": "gauge", "__unit__": "requests"}, inner,
+			"1", int64(100)),
+		varianceFinalizeSeries(dataset.Tags{"instance": "b", "region": "west", "job": "api",
+			"__type__": "gauge", "__unit__": "requests"}, inner,
+			"7", int64(100)),
+	}
+	ds := varianceFinalizeDataSet(inner, series...)
+	(&Client{}).FinalizeTSMMerge("sort_desc(stdvar without (instance) ("+inner+"))", ds)
+
+	got := ds.Results[0].SeriesList
+	if len(got) != 2 || got[0].Header.Tags["region"] != "west" ||
+		got[1].Header.Tags["region"] != "east" {
+		t.Fatalf("sort order: %#v", got)
+	}
+	if got[0].Header.Tags.JSON() !=
+		`{"__type__":"gauge","__unit__":"requests","job":"api","region":"west"}` {
+		t.Fatalf("without tags: %s", got[0].Header.Tags.JSON())
+	}
+	if got[0].Points[0].Values[0] != "9" || got[1].Points[0].Values[0] != "1" {
+		t.Fatalf("values: %v %v", got[0].Points[0].Values, got[1].Points[0].Values)
+	}
+}
+
+func TestFinalizeTSMMergeVarianceRangeSortWarning(t *testing.T) {
+	const inner = "count by (instance) (requests)"
+	ds := varianceFinalizeDataSet(inner,
+		varianceFinalizeSeries(dataset.Tags{"instance": "a"}, inner, "1", int64(100), "3", int64(200)),
+		varianceFinalizeSeries(dataset.Tags{"instance": "b"}, inner, "5", int64(100)),
+	)
+	ds.TimeRangeQuery.Step = time.Minute
+	(&Client{}).FinalizeTSMMerge("sort(stddev("+inner+"))", ds)
+	if len(ds.Warnings) != 1 || ds.Warnings[0] != sortInRangeQueryWarning {
+		t.Fatalf("warnings: %v", ds.Warnings)
+	}
+}
+
+func TestFinalizeTSMMergeVarianceFallbackOnlySorts(t *testing.T) {
+	const fallback = "stddev(up + down)"
+	ds := varianceFinalizeDataSet(fallback,
+		varianceFinalizeSeries(dataset.Tags{"instance": "a"}, fallback, "1", int64(100)),
+		varianceFinalizeSeries(dataset.Tags{"instance": "b"}, fallback, "3", int64(100)),
+	)
+	(&Client{}).FinalizeTSMMerge("sort_desc("+fallback+")", ds)
+	if len(ds.Results[0].SeriesList) != 2 ||
+		ds.Results[0].SeriesList[0].Header.Tags["instance"] != "b" {
+		t.Fatalf("fallback was regrouped or unsorted: %#v", ds.Results[0].SeriesList)
+	}
+}

--- a/pkg/timeseries/dataset/pooled_variance.go
+++ b/pkg/timeseries/dataset/pooled_variance.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataset
+
+import (
+	"errors"
+	"math"
+)
+
+// PooledVarianceState is an intermediate population-variance state. It is
+// stored in a point only between TSM reduction and provider finalization.
+type PooledVarianceState struct {
+	Count float64
+	Mean  float64
+	M2    float64
+}
+
+// Add incorporates one raw float sample using Welford's online update.
+func (s PooledVarianceState) Add(value float64) PooledVarianceState {
+	if s.Count == 0 {
+		s.Count = 1
+		s.Mean = value
+		if math.IsNaN(value) || math.IsInf(value, 0) {
+			s.M2 = math.NaN()
+		}
+		return s
+	}
+	s.Count++
+	delta := value - s.Mean
+	s.Mean += delta / s.Count
+	s.M2 += delta * (value - s.Mean)
+	return s
+}
+
+// NewPooledVarianceState converts a population variance into a mergeable
+// count/mean/M2 state.
+func NewPooledVarianceState(count, mean, variance float64) (PooledVarianceState, error) {
+	if math.IsNaN(count) || math.IsInf(count, 0) || count <= 0 || math.Trunc(count) != count {
+		return PooledVarianceState{}, errors.New("pooled variance requires a positive integral count")
+	}
+	if math.IsInf(variance, -1) || variance < 0 {
+		return PooledVarianceState{}, errors.New("pooled variance requires a non-negative variance")
+	}
+	state := PooledVarianceState{Count: count, Mean: mean, M2: count * variance}
+	if math.IsNaN(variance) || math.IsNaN(mean) || math.IsInf(mean, 0) {
+		state.M2 = math.NaN()
+	}
+	return state, nil
+}
+
+// Merge combines another state using the Chan parallel-variance formula.
+func (s PooledVarianceState) Merge(other PooledVarianceState) PooledVarianceState {
+	if s.Count == 0 {
+		return other
+	}
+	if other.Count == 0 {
+		return s
+	}
+	count := s.Count + other.Count
+	if math.IsNaN(s.M2) || math.IsNaN(other.M2) ||
+		math.IsNaN(s.Mean) || math.IsNaN(other.Mean) ||
+		math.IsInf(s.Mean, 0) || math.IsInf(other.Mean, 0) {
+		return PooledVarianceState{Count: count, Mean: math.NaN(), M2: math.NaN()}
+	}
+	delta := other.Mean - s.Mean
+	return PooledVarianceState{
+		Count: count,
+		Mean:  s.Mean + delta*other.Count/count,
+		M2: s.M2 + other.M2 +
+			delta*delta*s.Count*other.Count/count,
+	}
+}
+
+// PopulationVariance returns M2/n.
+func (s PooledVarianceState) PopulationVariance() float64 {
+	if s.Count <= 0 {
+		return math.NaN()
+	}
+	return s.M2 / s.Count
+}

--- a/pkg/timeseries/dataset/pooled_variance_test.go
+++ b/pkg/timeseries/dataset/pooled_variance_test.go
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dataset
+
+import (
+	"math"
+	"testing"
+)
+
+// Pooling changes floating-point operation order; require 1e-12 relative
+// agreement with a direct Welford pass rather than bit-for-bit identity.
+const pooledVarianceRelativeTolerance = 1e-12
+
+func TestPooledVarianceStateMatchesDirectWelford(t *testing.T) {
+	tests := []struct {
+		name   string
+		shards [][]float64
+	}{
+		{"unequal shards", [][]float64{{-5, 1}, {4, 8, 10, 13, 19}}},
+		{"large offset", [][]float64{{1e12 + 1, 1e12 + 2}, {1e12 + 3, 1e12 + 4, 1e12 + 5}}},
+		{"zero variance", [][]float64{{7, 7, 7}, {7, 7}}},
+		{"singleton", [][]float64{{-12}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var direct, pooled PooledVarianceState
+			for _, shard := range tt.shards {
+				var shardState PooledVarianceState
+				for _, value := range shard {
+					direct = direct.Add(value)
+					shardState = shardState.Add(value)
+				}
+				state, err := NewPooledVarianceState(
+					shardState.Count, shardState.Mean, shardState.PopulationVariance(),
+				)
+				if err != nil {
+					t.Fatalf("state: %v", err)
+				}
+				pooled = pooled.Merge(state)
+			}
+			got, want := pooled.PopulationVariance(), direct.PopulationVariance()
+			tolerance := pooledVarianceRelativeTolerance * math.Max(1, math.Abs(want))
+			if math.Abs(got-want) > tolerance {
+				t.Fatalf("variance got %.17g want %.17g tolerance %.17g", got, want, tolerance)
+			}
+		})
+	}
+}
+
+func TestPooledVarianceStateSpecialValues(t *testing.T) {
+	for _, value := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
+		state := PooledVarianceState{}.Add(value).Add(1)
+		if !math.IsNaN(state.PopulationVariance()) {
+			t.Fatalf("value %v produced variance %v", value, state.PopulationVariance())
+		}
+	}
+
+	finite, err := NewPooledVarianceState(2, 3, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalid, err := NewPooledVarianceState(1, math.Inf(1), math.NaN())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := finite.Merge(invalid).PopulationVariance(); !math.IsNaN(got) {
+		t.Fatalf("poisoned merge variance got %v", got)
+	}
+}
+
+func TestNewPooledVarianceStateRejectsInvalidInputs(t *testing.T) {
+	for _, input := range []struct {
+		count    float64
+		variance float64
+	}{
+		{0, 0},
+		{-1, 0},
+		{1.5, 0},
+		{math.Inf(1), 0},
+		{1, -1},
+		{1, math.Inf(-1)},
+	} {
+		if _, err := NewPooledVarianceState(input.count, 0, input.variance); err == nil {
+			t.Fatalf("input %#v unexpectedly accepted", input)
+		}
+	}
+}

--- a/pkg/timeseries/merge/merge.go
+++ b/pkg/timeseries/merge/merge.go
@@ -32,6 +32,9 @@ const (
 	// TSMReductionWeightedAverage divides an accumulated sum variant by its
 	// paired count variant.
 	TSMReductionWeightedAverage
+	// TSMReductionPooledVariance combines per-member count, mean, and variance
+	// states before provider finalization.
+	TSMReductionPooledVariance
 )
 
 const (
@@ -41,6 +44,12 @@ const (
 	TSMVariantWeightedAverageSum = "avg-sum"
 	// TSMVariantWeightedAverageCount is the summed-count input to weighted average.
 	TSMVariantWeightedAverageCount = "avg-count"
+	// TSMVariantPooledVarianceCount is the sample-count input to pooled variance.
+	TSMVariantPooledVarianceCount = "variance-count"
+	// TSMVariantPooledVarianceMean is the arithmetic-mean input to pooled variance.
+	TSMVariantPooledVarianceMean = "variance-mean"
+	// TSMVariantPooledVarianceValue is the population-variance input to pooled variance.
+	TSMVariantPooledVarianceValue = "variance-value"
 )
 
 // TSMReductionPrimaryVariant returns default primary variant as a single-element slice
@@ -52,6 +61,16 @@ func TSMReductionPrimaryVariant() []string {
 // the positional order required by the reducer: sum, then count.
 func TSMReductionWeightedAverageVariants() []string {
 	return []string{TSMVariantWeightedAverageSum, TSMVariantWeightedAverageCount}
+}
+
+// TSMReductionPooledVarianceVariants returns pooled-variance input names in
+// the positional order required by the reducer: count, mean, then variance.
+func TSMReductionPooledVarianceVariants() []string {
+	return []string{
+		TSMVariantPooledVarianceCount,
+		TSMVariantPooledVarianceMean,
+		TSMVariantPooledVarianceValue,
+	}
 }
 
 // TSMCompletenessPolicy determines which per-member contributions may enter
@@ -195,6 +214,35 @@ func (p *TSMMergePlan) Validate() error {
 		authority, _ := p.ResponseAuthority()
 		if p.Reduction.InputVariants[0] != p.Variants[authority].Name {
 			return errors.New("weighted-average tsm reduction must use response authority as its first input")
+		}
+	case TSMReductionPooledVariance:
+		if len(p.Variants) != 3 {
+			return errors.New("pooled-variance tsm reduction requires exactly three variants")
+		}
+		if p.OriginalQuery == "" {
+			return errors.New("pooled-variance tsm reduction requires the original query")
+		}
+		expectedInputs := TSMReductionPooledVarianceVariants()
+		if len(p.Reduction.InputVariants) != len(expectedInputs) {
+			return errors.New("pooled-variance tsm reduction requires three named inputs")
+		}
+		for i, expected := range expectedInputs {
+			if p.Reduction.InputVariants[i] != expected {
+				return fmt.Errorf("pooled-variance tsm reduction input %d must be %q", i, expected)
+			}
+			if variantsByName[expected].MergeStrategy != int(StrategyDedup) {
+				return fmt.Errorf("pooled-variance tsm variant %q must use dedup merge strategy", expected)
+			}
+		}
+		if p.Completeness != TSMCompletenessAllVariants {
+			return errors.New("pooled-variance tsm reduction requires all-variant completeness")
+		}
+		authority, _ := p.ResponseAuthority()
+		if p.Reduction.InputVariants[0] != p.Variants[authority].Name {
+			return errors.New("pooled-variance tsm reduction must use response authority as its first input")
+		}
+		if !p.Finalizer.Enabled {
+			return errors.New("pooled-variance tsm reduction requires provider finalization")
 		}
 	default:
 		return fmt.Errorf("tsm merge plan has invalid reduction kind %d", p.Reduction.Kind)

--- a/pkg/timeseries/merge/merge_test.go
+++ b/pkg/timeseries/merge/merge_test.go
@@ -68,12 +68,46 @@ func validWeightedAverageTSMPlan() *TSMMergePlan {
 	}
 }
 
+func validPooledVarianceTSMPlan() *TSMMergePlan {
+	variants := TSMReductionPooledVarianceVariants()
+	return &TSMMergePlan{
+		OriginalQuery: "stddev(up)",
+		Variants: []TSMQueryVariant{
+			{
+				Name:              variants[0],
+				Request:           testTSMRequest(variants[0]),
+				MergeStrategy:     int(StrategyDedup),
+				ResponseAuthority: true,
+			},
+			{
+				Name:          variants[1],
+				Request:       testTSMRequest(variants[1]),
+				MergeStrategy: int(StrategyDedup),
+			},
+			{
+				Name:          variants[2],
+				Request:       testTSMRequest(variants[2]),
+				MergeStrategy: int(StrategyDedup),
+			},
+		},
+		Reduction: TSMReductionSpec{
+			Kind:          TSMReductionPooledVariance,
+			InputVariants: variants,
+		},
+		Finalizer:    TSMFinalizerSpec{Enabled: true, Query: "stddev(up)"},
+		Completeness: TSMCompletenessAllVariants,
+	}
+}
+
 func TestTSMMergePlanValidate(t *testing.T) {
 	if err := validStandardTSMPlan().Validate(); err != nil {
 		t.Fatalf("valid standard plan: %v", err)
 	}
 	if err := validWeightedAverageTSMPlan().Validate(); err != nil {
 		t.Fatalf("valid weighted-average plan: %v", err)
+	}
+	if err := validPooledVarianceTSMPlan().Validate(); err != nil {
+		t.Fatalf("valid pooled-variance plan: %v", err)
 	}
 	maxStrategyPlan := validStandardTSMPlan()
 	maxStrategyPlan.Variants[0].MergeStrategy = int(MaxStrategyValue)
@@ -133,6 +167,35 @@ func TestTSMMergePlanValidate(t *testing.T) {
 			p.Variants[1].ResponseAuthority = true
 		}},
 		{"multi variant bypass", validWeightedAverageTSMPlan, func(p *TSMMergePlan) { p.AllowSingleMemberBypass = true }},
+		{"pooled missing variant", validPooledVarianceTSMPlan, func(p *TSMMergePlan) {
+			p.Variants = p.Variants[:2]
+		}},
+		{"pooled missing input", validPooledVarianceTSMPlan, func(p *TSMMergePlan) {
+			p.Reduction.InputVariants = p.Reduction.InputVariants[:2]
+		}},
+		{"pooled missing original query", validPooledVarianceTSMPlan, func(p *TSMMergePlan) {
+			p.OriginalQuery = ""
+		}},
+		{"pooled reversed inputs", validPooledVarianceTSMPlan, func(p *TSMMergePlan) {
+			p.Reduction.InputVariants[0], p.Reduction.InputVariants[1] =
+				p.Reduction.InputVariants[1], p.Reduction.InputVariants[0]
+		}},
+		{"pooled wrong merge strategy", validPooledVarianceTSMPlan, func(p *TSMMergePlan) {
+			p.Variants[2].MergeStrategy = int(StrategySum)
+		}},
+		{"pooled wrong completeness", validPooledVarianceTSMPlan, func(p *TSMMergePlan) {
+			p.Completeness = TSMCompletenessResponseAuthority
+		}},
+		{"pooled authority not first input", validPooledVarianceTSMPlan, func(p *TSMMergePlan) {
+			p.Variants[0].ResponseAuthority = false
+			p.Variants[1].ResponseAuthority = true
+		}},
+		{"pooled missing finalizer", validPooledVarianceTSMPlan, func(p *TSMMergePlan) {
+			p.Finalizer = TSMFinalizerSpec{}
+		}},
+		{"pooled bypass", validPooledVarianceTSMPlan, func(p *TSMMergePlan) {
+			p.AllowSingleMemberBypass = true
+		}},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description

Closes #1070.

Adds exact ALB TSM planning for outer `stdvar` and `stddev`. Each pool member returns float-only `count`, `avg`, and `stdvar` variants; TSM pairs them by member, result, labels, and timestamp, then combines `(n, mean, M2)` states in deterministic pool order with the Chan/Welford formula. Incomplete triples are excluded with partial-result warnings, injected labels are stripped before pairing, and response extents are merged only from included members.

With the replica-group support from #1088 now on `main`, pooled variance first coalesces replicas within each group and then combines the independent group contributions. This preserves HA deduplication without dropping distinct shards.

The PromQL rewrite supports `by` and `without` in both syntax positions, preserves metric metadata labels, handles instant/range queries and outer `sort` wrappers, and ignores native histograms through a float-only input filter. Compatible nested aggregations are finalized globally. Nested `sum` and `avg` now reuse the exact histogram-aware sum and weighted-average plans before the outer variance finalizer runs.

Coverage includes unequal shard sizes, a documented `1e-12` relative tolerance against direct Welford calculation, large offsets, singleton and special values, sparse timestamps, partial variants, replica groups, metadata grouping, GET/POST rewrites, request cancellation, extents, and multi-shard serving benchmarks.

Validation after rebasing onto current `main`:

- `go test ./pkg/backends/prometheus/... ./pkg/backends/alb/mech/tsm ./pkg/timeseries/dataset ./pkg/timeseries/merge -count=20`
- `go test -race ./pkg/backends/prometheus/... ./pkg/backends/alb/mech/tsm ./pkg/timeseries/dataset ./pkg/timeseries/merge -count=5`
- `go test ./pkg/backends/alb/... ./pkg/backends/prometheus/... ./pkg/timeseries/... -count=1`
- `go test -run '^$' ./...`
- `go vet ./pkg/backends/prometheus/... ./pkg/backends/alb/mech/tsm ./pkg/timeseries/dataset ./pkg/timeseries/merge`
- `go tool golangci-lint run --new-from-rev origin/main -c .golangci.yml`

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Optimization
- [x] Test coverage
- [ ] Documentation
- [ ] Infrastructure

## AI Disclosure

- [ ] This contribution DOES NOT include AI-generated changes
- [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.