### PR TITLE
test: update Prometheus SDK integration calls

### DIFF
--- a/integration/prometheus_sdk_test.go
+++ b/integration/prometheus_sdk_test.go
@@ -73,9 +73,9 @@ func TestPrometheusSDK(t *testing.T) {
 		labels, warnings, err := sdk.LabelNames(ctx, nil, time.Now().Add(-5*time.Minute), time.Now())
 		require.NoError(t, err)
 		t.Logf("warnings: %v", warnings)
-		require.Contains(t, labels, "__name__")
-		require.Contains(t, labels, "job")
-		require.Contains(t, labels, "instance")
+		require.Contains(t, labels, model.LabelName("__name__"))
+		require.Contains(t, labels, model.LabelName("job"))
+		require.Contains(t, labels, model.LabelName("instance"))
 	})
 
 	t.Run("label_values", func(t *testing.T) {

--- a/integration/prometheus_sdk_test.go
+++ b/integration/prometheus_sdk_test.go
@@ -116,7 +116,7 @@ func TestPrometheusSDK(t *testing.T) {
 	})
 
 	t.Run("rules", func(t *testing.T) {
-		rules, err := sdk.Rules(ctx)
+		rules, err := sdk.Rules(ctx, nil)
 		require.NoError(t, err)
 		t.Logf("rule groups: %d", len(rules.Groups))
 	})


### PR DESCRIPTION
## Description

Updates the Prometheus SDK integration test for `client_golang` v1.24.0. `Rules` now accepts a matcher slice, and `LabelNames` now returns `model.LabelNames`; passing `nil` preserves the previous unfiltered rules request, while typed label expectations preserve the existing assertions.

Validation:
- Linux integration test binary compilation
- Linux `go vet ./...` in the integration module

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Optimization
- [x] Test coverage
- [ ] Documentation
- [ ] Infrastructure

## AI Disclosure

- [ ] This contribution DOES NOT include AI-generated changes
- [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
