### PR TITLE
fix: preserve duration parsing compatibility

### DIFF
--- a/pkg/parsing/timeconv/timeconv.go
+++ b/pkg/parsing/timeconv/timeconv.go
@@ -19,6 +19,7 @@ package timeconv
 
 import (
 	"crypto/rand"
+	"math"
 	"math/big"
 	"strconv"
 	"time"
@@ -133,8 +134,34 @@ func isIntAtPos(s string, i int) (v int64, is bool, inc int) {
 		return 0, false, 1
 	}
 	token := s[i:j]
-	v, _ = strconv.ParseInt(token, 10, 64)
+	v, err := strconv.ParseInt(token, 10, 64)
+	if err != nil {
+		return 0, false, j - i
+	}
 	return v, true, j - i
+}
+
+func addDurationComponent(d time.Duration, multiplier int64, unit DurationUnit) (time.Duration, bool) {
+	unitDuration := int64(Durations[unit])
+	if unitDuration <= 0 {
+		return 0, false
+	}
+	if multiplier > 0 && multiplier > math.MaxInt64/unitDuration {
+		return 0, false
+	}
+	if multiplier < 0 && multiplier < math.MinInt64/unitDuration {
+		return 0, false
+	}
+
+	component := multiplier * unitDuration
+	total := int64(d)
+	if component > 0 && total > math.MaxInt64-component {
+		return 0, false
+	}
+	if component < 0 && total < math.MinInt64-component {
+		return 0, false
+	}
+	return time.Duration(total + component), true
 }
 
 // ParseDuration returns a duration from a string. Slightly improved over the builtin,
@@ -142,8 +169,10 @@ func isIntAtPos(s string, i int) (v int64, is bool, inc int) {
 // Parse a literal duration.
 // Durations are formatted as [signed int][unit]..., with each int-unit pair representing a number of those units of duration.
 func ParseDuration(s string) (time.Duration, error) {
-	if s == "0" {
-		return 0, nil
+	// Preserve the complete standard-library grammar, including fractional
+	// values, before trying Trickster's larger duration units.
+	if d, err := time.ParseDuration(s); err == nil {
+		return d, nil
 	}
 	if len(s) <= 1 {
 		return 0, ErrInvalidDurationFormat(0, "value of at least length 2", s)
@@ -166,7 +195,11 @@ func ParseDuration(s string) (time.Duration, error) {
 			if !is {
 				return 0, ErrInvalidDurationFormat(i, "valid duration unit", s)
 			}
-			d += time.Duration(currentMult) * Durations[u]
+			var ok bool
+			d, ok = addDurationComponent(d, currentMult, u)
+			if !ok {
+				return 0, ErrInvalidDurationFormat(i, "duration within int64 range", s)
+			}
 			currentMult = 0
 			hasMult = false
 			hasUnits = true
@@ -215,4 +248,3 @@ func (d *Duration) UnmarshalYAML(unmarshal func(any) error) error {
 func (d Duration) MarshalYAML() (any, error) {
 	return time.Duration(d).String(), nil
 }
-

--- a/pkg/parsing/timeconv/timeconv_test.go
+++ b/pkg/parsing/timeconv/timeconv_test.go
@@ -19,6 +19,8 @@ package timeconv
 import (
 	"testing"
 	"time"
+
+	"gopkg.in/yaml.v2"
 )
 
 func TestIsIntAtPost(t *testing.T) {
@@ -40,13 +42,40 @@ func TestIsIntAtPost(t *testing.T) {
 }
 
 func TestParseDuration(t *testing.T) {
-	expected := time.Duration(1) * time.Hour
-	d, err := ParseDuration("1h")
-	if err != nil {
-		t.Error(err)
+	tests := map[string]time.Duration{
+		"0":      0,
+		"1.5s":   1500 * time.Millisecond,
+		"-1h30m": -90 * time.Minute,
+		"1d2h":   26 * time.Hour,
+		"2w3d":   17 * 24 * time.Hour,
 	}
-	if d != expected {
-		t.Errorf("expected %d got %d", expected, d)
+	for input, expected := range tests {
+		t.Run(input, func(t *testing.T) {
+			d, err := ParseDuration(input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if d != expected {
+				t.Errorf("expected %s got %s", expected, d)
+			}
+		})
+	}
+}
+
+func TestParseDurationOverflow(t *testing.T) {
+	tests := []string{
+		"9223372036854775808ns",
+		"9223372036854775807ns1ns",
+		"9223372036854775807d",
+		"-9223372036854775808d",
+		"-9223372036854775808ns-1ns",
+	}
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			if d, err := ParseDuration(input); err == nil {
+				t.Errorf("expected overflow error, got %s", d)
+			}
+		})
 	}
 }
 
@@ -97,24 +126,33 @@ func TestParseDurationFailed(t *testing.T) {
 }
 
 func TestDurationYAML(t *testing.T) {
-	d := Duration(0)
-	unmarshal := func(v any) error {
-		*v.(*string) = "14d"
-		return nil
+	tests := []struct {
+		input    string
+		expected time.Duration
+		output   string
+	}{
+		{input: "1.5s", expected: 1500 * time.Millisecond, output: "1.5s"},
+		{input: "14d", expected: 14 * 24 * time.Hour, output: "336h0m0s"},
 	}
-	err := d.UnmarshalYAML(unmarshal)
-	if err != nil {
-		t.Error(err)
-	}
-	if time.Duration(d) != 14*24*time.Hour {
-		t.Errorf("expected 14 days, got %s", time.Duration(d))
-	}
-
-	val, err := d.MarshalYAML()
-	if err != nil {
-		t.Error(err)
-	}
-	if val.(string) != "336h0m0s" {
-		t.Errorf("expected 336h0m0s, got %s", val)
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			value := struct {
+				Timeout Duration `yaml:"timeout"`
+			}{}
+			if err := yaml.Unmarshal([]byte("timeout: "+test.input+"\n"), &value); err != nil {
+				t.Fatal(err)
+			}
+			if time.Duration(value.Timeout) != test.expected {
+				t.Errorf("expected %s, got %s", test.expected, time.Duration(value.Timeout))
+			}
+			out, err := yaml.Marshal(value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expectedOutput := "timeout: " + test.output + "\n"
+			if string(out) != expectedOutput {
+				t.Errorf("expected %q, got %q", expectedOutput, out)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Description

Fixes #1091.

#1090 changed YAML-backed duration fields from `time.Duration` to `timeconv.Duration`, which made standard fractional values such as `1.5s` fail configuration loading. The extended parser could also silently wrap values that overflow `time.Duration`.

This keeps Go's standard duration grammar as the first parsing path, then falls back to Trickster's existing `d`, `w`, `mo`, and `y` extensions. The extended path now rejects integer, multiplication, and accumulation overflow instead of returning a wrapped duration.

Validation:

- `go test ./pkg/parsing/timeconv -count=100`
- `go test -race ./pkg/parsing/timeconv -count=20`
- focused configuration loading tests with `-count=20`
- `go test -run '^$' ./...`
- `go tool golangci-lint run --new-from-rev origin/main -c .golangci.yml`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Optimization
- [x] Test coverage
- [ ] Documentation
- [ ] Infrastructure

## AI Disclosure

- [ ] This contribution DOES NOT include AI-generated changes
- [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
