### PR TITLE
fix: set Fast Forward evaluation time from range end

### DIFF
--- a/integration/alb_tsm_fast_forward_test.go
+++ b/integration/alb_tsm_fast_forward_test.go
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/integration/internal/portutil"
+	"github.com/trickstercache/trickster/v2/integration/promstub"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestALBTSMFastForwardUsesRangeEnd(t *testing.T) {
+	type observedTimes struct {
+		sync.Mutex
+		values []string
+	}
+	snapshot := func(observed *observedTimes) []string {
+		observed.Lock()
+		defer observed.Unlock()
+		return append([]string(nil), observed.values...)
+	}
+
+	newOrigin := func(value string, implicitTime int64) (*httptest.Server, *observedTimes) {
+		observed := &observedTimes{}
+		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == promstub.BuildInfoPath {
+				promstub.WriteBuildInfo(w)
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+			if err := r.ParseForm(); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			switch {
+			case strings.HasSuffix(r.URL.Path, "/query_range"):
+				start, err := strconv.ParseInt(r.Form.Get("start"), 10, 64)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				end, err := strconv.ParseInt(r.Form.Get("end"), 10, 64)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				step, err := strconv.ParseInt(r.Form.Get("step"), 10, 64)
+				if err != nil || step <= 0 {
+					http.Error(w, "invalid step", http.StatusBadRequest)
+					return
+				}
+
+				var points strings.Builder
+				for ts := start; ts <= end; ts += step {
+					if points.Len() > 0 {
+						points.WriteByte(',')
+					}
+					fmt.Fprintf(&points, `[%d,%q]`, ts, value)
+				}
+				fmt.Fprintf(w, `{"status":"success","data":{"resultType":"matrix","result":[`+
+					`{"metric":{"__name__":"example_counter"},"values":[%s]}]}}`, points.String())
+
+			case strings.HasSuffix(r.URL.Path, "/query"):
+				evaluationTime := r.Form.Get("time")
+				observed.Lock()
+				observed.values = append(observed.values, evaluationTime)
+				observed.Unlock()
+
+				sampleTime := evaluationTime
+				if sampleTime == "" {
+					sampleTime = strconv.FormatInt(implicitTime, 10)
+				}
+				fmt.Fprintf(w, `{"status":"success","data":{"resultType":"vector","result":[`+
+					`{"metric":{"__name__":"example_counter"},"value":[%s,%q]}]}}`, sampleTime, value)
+
+			default:
+				http.NotFound(w, r)
+			}
+		})
+		srv := httptest.NewServer(h)
+		t.Cleanup(srv.Close)
+		return srv, observed
+	}
+
+	step := time.Hour
+	requestedEnd := time.Now().UTC().Add(5 * time.Minute).Truncate(time.Second)
+	requestedEndUnix := requestedEnd.Unix()
+	originA, timesA := newOrigin("10", requestedEndUnix+10)
+	originB, timesB := newOrigin("8", requestedEndUnix+20)
+
+	ports, releasePorts := portutil.Reserve(t, 3)
+	frontPort, metricsPort, mgmtPort := ports[0], ports[1], ports[2]
+	var cfg strings.Builder
+	cfg.WriteString(promstub.Preamble(frontPort, metricsPort, mgmtPort))
+	cfg.WriteString("backends:\n")
+	cfg.WriteString(promstub.BackendStanza("prom-a", originA.URL))
+	cfg.WriteString(promstub.BackendStanza("prom-b", originB.URL))
+	cfg.WriteString("  alb-tsm:\n")
+	cfg.WriteString("    provider: alb\n")
+	cfg.WriteString("    alb:\n")
+	cfg.WriteString("      mechanism: tsm\n")
+	cfg.WriteString("      output_format: prometheus\n")
+	cfg.WriteString("      pool:\n")
+	cfg.WriteString("        - prom-a\n")
+	cfg.WriteString("        - prom-b\n")
+
+	cfgPath := filepath.Join(t.TempDir(), "trickster.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfg.String()), 0644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	releasePorts()
+	go startTrickster(t, ctx, expectedStartError{}, "-config", cfgPath)
+	waitForTrickster(t, fmt.Sprintf("127.0.0.1:%d", metricsPort))
+	healthURL := fmt.Sprintf("http://127.0.0.1:%d/trickster/health", metricsPort)
+	requireHealthState(t, healthURL, "prom-a", "available", 10*time.Second)
+	requireHealthState(t, healthURL, "prom-b", "available", 10*time.Second)
+
+	params := url.Values{
+		"query": {"sum(example_counter)"},
+		"start": {strconv.FormatInt(requestedEnd.Add(-2*step).Unix(), 10)},
+		"end":   {strconv.FormatInt(requestedEndUnix, 10)},
+		"step":  {strconv.FormatInt(int64(step.Seconds()), 10)},
+	}
+	response, _ := queryTricksterProm(t,
+		fmt.Sprintf("127.0.0.1:%d", frontPort), "alb-tsm", "/api/v1/query_range", params)
+
+	var data promQueryData
+	require.NoError(t, json.Unmarshal(response.Data, &data))
+	require.Equal(t, "matrix", data.ResultType)
+	var series []struct {
+		Values [][]json.RawMessage `json:"values"`
+	}
+	require.NoError(t, json.Unmarshal(data.Result, &series))
+	require.Len(t, series, 1)
+
+	var fastForwardPoints [][]json.RawMessage
+	for _, point := range series[0].Values {
+		var epoch float64
+		require.NoError(t, json.Unmarshal(point[0], &epoch))
+		require.LessOrEqual(t, int64(epoch), requestedEndUnix)
+		if int64(epoch) == requestedEndUnix {
+			fastForwardPoints = append(fastForwardPoints, point)
+		}
+	}
+	require.Len(t, fastForwardPoints, 1)
+
+	var epoch float64
+	var value string
+	require.NoError(t, json.Unmarshal(fastForwardPoints[0][0], &epoch))
+	require.NoError(t, json.Unmarshal(fastForwardPoints[0][1], &value))
+	require.Equal(t, requestedEndUnix, int64(epoch))
+	require.Equal(t, "18", value)
+
+	wantTime := strconv.FormatInt(requestedEndUnix, 10)
+	require.Equal(t, []string{wantTime}, snapshot(timesA))
+	require.Equal(t, []string{wantTime}, snapshot(timesB))
+}

--- a/pkg/backends/prometheus/url.go
+++ b/pkg/backends/prometheus/url.go
@@ -48,9 +48,13 @@ func (c *Client) FastForwardRequest(r *http.Request) (*http.Request, error) {
 		nr.URL.Path = nr.URL.Path[0 : len(nr.URL.Path)-6]
 	}
 	v, _, _ := params.GetRequestValues(nr)
+	evaluationTime := v.Get(upEnd)
 	v.Del(upStart)
 	v.Del(upEnd)
 	v.Del(upStep)
+	if evaluationTime != "" {
+		v.Set(upTime, evaluationTime)
+	}
 	params.SetRequestValues(nr, v)
 	return nr, nil
 }

--- a/pkg/backends/prometheus/url_test.go
+++ b/pkg/backends/prometheus/url_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -81,7 +82,7 @@ func TestSetExtent(t *testing.T) {
 }
 
 func TestFastForwardURL(t *testing.T) {
-	expected := "q=up"
+	expected := "q=up&time=1"
 
 	conf, err := config.Load([]string{
 		"-origin-url", "none:9090", "-provider",
@@ -120,6 +121,111 @@ func TestFastForwardURL(t *testing.T) {
 	_, err = pc.FastForwardRequest(r)
 	if err != nil {
 		t.Error(err)
+	}
+}
+
+func TestFastForwardRequestPromotesEndToTime(t *testing.T) {
+	conf, err := config.Load([]string{
+		"-origin-url", "none:9090", "-provider",
+		providers.Prometheus, "-log-level", "debug",
+	})
+	if err != nil {
+		t.Fatalf("Could not load configuration: %s", err.Error())
+	}
+
+	client, err := NewClient("default", conf.Backends["default"], nil, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pc := client.(*Client)
+
+	tests := []struct {
+		name        string
+		method      string
+		target      string
+		body        string
+		contentType string
+		wantTime    string
+	}{
+		{
+			name:     "GET Unix timestamp",
+			method:   http.MethodGet,
+			target:   "/api/v1/query_range?query=up&start=1&end=1785801280&step=60",
+			wantTime: "1785801280",
+		},
+		{
+			name:     "GET fractional Unix timestamp",
+			method:   http.MethodGet,
+			target:   "/api/v1/query_range?query=up&start=1&end=1785801280.25&step=60",
+			wantTime: "1785801280.25",
+		},
+		{
+			name:     "GET RFC3339 timestamp",
+			method:   http.MethodGet,
+			target:   "/api/v1/query_range?query=up&start=1&end=2026-08-03T23%3A54%3A40Z&step=60",
+			wantTime: "2026-08-03T23:54:40Z",
+		},
+		{
+			name:        "POST form timestamp",
+			method:      http.MethodPost,
+			target:      "/api/v1/query_range?stats=all",
+			body:        "query=up&start=1&end=1785801280.5&step=60",
+			contentType: "application/x-www-form-urlencoded",
+			wantTime:    "1785801280.5",
+		},
+		{
+			name:     "range end replaces irrelevant time",
+			method:   http.MethodGet,
+			target:   "/api/v1/query_range?query=up&start=1&end=1785801280&step=60&time=old",
+			wantTime: "1785801280",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var body io.Reader
+			if test.body != "" {
+				body = strings.NewReader(test.body)
+			}
+			r, err := http.NewRequest(test.method, test.target, body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.contentType != "" {
+				r.Header.Set("Content-Type", test.contentType)
+			}
+			r = request.SetResources(r, &request.Resources{})
+
+			got, err := pc.FastForwardRequest(r)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.URL.Path != "/api/v1/query" {
+				t.Fatalf("path got %q want %q", got.URL.Path, "/api/v1/query")
+			}
+			values := got.URL.Query()
+			if gotTime := values.Get(upTime); gotTime != test.wantTime {
+				t.Errorf("time got %q want %q", gotTime, test.wantTime)
+			}
+			for _, name := range []string{upStart, upEnd, upStep} {
+				if values.Has(name) {
+					t.Errorf("unexpected range parameter %q=%q", name, values.Get(name))
+				}
+			}
+			if got.Method == http.MethodPost {
+				b, err := io.ReadAll(got.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+				form, err := url.ParseQuery(string(b))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if gotTime := form.Get(upTime); gotTime != test.wantTime {
+					t.Errorf("POST body time got %q want %q", gotTime, test.wantTime)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Description
Prometheus Fast Forward removed the range parameters without setting the instant query's `time`. In a TSM pool, terminal origins could therefore evaluate one request at different epochs and leave aggregate contributions split across several points.

This promotes the original range `end` to `time` unchanged before removing `start`, `end`, and `step`. It also covers GET and POST forms plus a two-member TSM request that must produce one summed Fast Forward point at the requested epoch.

Fixes #1100

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [x] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.